### PR TITLE
feat: add user search for chat creation

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -22,12 +25,9 @@ import androidx.compose.ui.unit.sp
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatCreateSingleUiState
 import uddug.com.naukoteka.mvvm.chat.ChatCreateSingleViewModel
-import uddug.com.naukoteka.mvvm.chat.ChatDialogUiState
-import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
-import uddug.com.naukoteka.ui.chat.compose.components.ChatTabBar
-import uddug.com.naukoteka.ui.chat.compose.components.ChatToolbarComponent
 import uddug.com.naukoteka.ui.chat.compose.components.ChatToolbarCreateSingleComponent
 import uddug.com.naukoteka.ui.chat.compose.components.SearchField
+import uddug.com.naukoteka.ui.chat.compose.components.UserSearchItem
 
 
 @Composable
@@ -81,14 +81,23 @@ fun ChatCreateSingleScreen(
                         color = Color.Black
                     )
                 }
-                Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
-                    Text(
-                        text = stringResource(R.string.subs),
-                        fontSize = 18.sp,
-                        color = Color.Black
-                    )
-                }
 
+                val users = (uiState as ChatCreateSingleUiState.Success).users
+                if (users.isNotEmpty()) {
+                    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                        items(users) { user ->
+                            UserSearchItem(user = user)
+                        }
+                    }
+                } else {
+                    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
+                        Text(
+                            text = stringResource(R.string.subs),
+                            fontSize = 18.sp,
+                            color = Color.Black
+                        )
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/UserSearchItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/UserSearchItem.kt
@@ -1,0 +1,38 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.material.Text
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.domain.entities.chat.User
+
+@Composable
+fun UserSearchItem(
+    user: User,
+    onClick: (User) -> Unit = {},
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick(user) }
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Avatar(url = user.image)
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            text = user.fullName ?: user.nickname.orEmpty(),
+            fontSize = 16.sp,
+            color = Color.Black,
+        )
+    }
+}

--- a/data/src/main/java/uddug/com/data/mapper/mapUserSearchDtoToDomain.kt
+++ b/data/src/main/java/uddug/com/data/mapper/mapUserSearchDtoToDomain.kt
@@ -1,0 +1,13 @@
+package uddug.com.data.mapper
+
+import uddug.com.data.services.models.response.chat.UserSearchDto
+import uddug.com.domain.entities.chat.User
+
+fun mapUserSearchDtoToDomain(dto: UserSearchDto): User {
+    return User(
+        image = dto.image?.path,
+        fullName = dto.fullName,
+        nickname = dto.nickname,
+        userId = dto.id,
+    )
+}

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
@@ -2,6 +2,7 @@ package uddug.com.data.repositories.chat
 
 import io.reactivex.Single
 import uddug.com.data.mapper.mapChatDtoToDomain
+import uddug.com.data.mapper.mapUserSearchDtoToDomain
 
 import uddug.com.data.services.chat.ChatApiService
 import uddug.com.data.services.models.response.chat.DialogInfoDto
@@ -10,6 +11,7 @@ import uddug.com.domain.entities.chat.Chat
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.domain.entities.chat.User
 import uddug.com.domain.entities.chat.updateOwnerInfoFromDialog
 import uddug.com.domain.entities.feed.PostComment
 import javax.inject.Inject
@@ -32,6 +34,8 @@ interface ChatRepository {
     suspend fun getDialogMedia(
         dialogId: Long,
     ): List<MediaMessage>
+
+    suspend fun searchUsers(searchField: String): List<User>
 }
 
 
@@ -96,6 +100,16 @@ class ChatRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             println("Error getting dialog info: ${e.message}")
             throw e // or return default DialogInfo
+        }
+    }
+
+    override suspend fun searchUsers(searchField: String): List<User> {
+        return try {
+            val dto = apiService.searchUsers(searchField)
+            dto.users.map { mapUserSearchDtoToDomain(it) }
+        } catch (e: Exception) {
+            println("Error searching users: ${e.message}")
+            emptyList()
         }
     }
 

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -6,6 +6,7 @@ import retrofit2.http.Query
 import uddug.com.data.services.models.response.chat.ChatDto
 import uddug.com.data.services.models.response.chat.DialogInfoDto
 import uddug.com.data.services.models.response.chat.MessageDto
+import uddug.com.data.services.models.response.chat.SearchUsersDto
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
@@ -31,4 +32,9 @@ interface ChatApiService {
         @Path("dialogId") dialogId: Long,
         @Query("category") category: Int,
     ): List<MediaMessage>
+
+    @GET("chat/v1/users/search")
+    suspend fun searchUsers(
+        @Query("searchField") searchField: String,
+    ): SearchUsersDto
 }

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/SearchUsersDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/SearchUsersDto.kt
@@ -1,0 +1,18 @@
+package uddug.com.data.services.models.response.chat
+
+import uddug.com.data.services.models.response.chat.ImageDto
+
+// DTO for users search endpoint
+
+data class SearchUsersDto(
+    val users: List<UserSearchDto>,
+    val count: Int,
+)
+
+data class UserSearchDto(
+    val id: String,
+    val fullName: String?,
+    val nickname: String?,
+    val permits: List<String>?,
+    val image: ImageDto?,
+)


### PR DESCRIPTION
## Summary
- add API and repository support for user search
- implement search logic in ChatCreateSingleViewModel
- render search results list with avatars and names

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :data:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d96fb044483278c9f9ef74d41b0ef