### PR TITLE
feat: add multi chat creation screen

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateMultiViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateMultiViewModel.kt
@@ -1,0 +1,85 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import uddug.com.data.repositories.chat.ChatRepository
+import uddug.com.domain.entities.chat.User
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatCreateMultiViewModel @Inject constructor(
+    private val chatRepository: ChatRepository,
+) : ViewModel() {
+
+    private val _uiState =
+        MutableStateFlow<ChatCreateMultiUiState>(ChatCreateMultiUiState.Loading)
+    val uiState: StateFlow<ChatCreateMultiUiState> = _uiState
+
+    private val _events = MutableSharedFlow<ChatCreateMultiEvent>()
+    val events: SharedFlow<ChatCreateMultiEvent> = _events.asSharedFlow()
+
+    init {
+        _uiState.value = ChatCreateMultiUiState.Success(query = "", users = emptyList(), selectedIds = emptySet())
+    }
+
+    fun onCurrentSearchChange(query: String) {
+        viewModelScope.launch {
+            val selected = (uiState.value as? ChatCreateMultiUiState.Success)?.selectedIds ?: emptySet()
+            _uiState.value = when (val currentState = _uiState.value) {
+                is ChatCreateMultiUiState.Success -> currentState.copy(query = query)
+                else -> ChatCreateMultiUiState.Success(query = query, users = emptyList(), selectedIds = selected)
+            }
+            if (query.isNotBlank()) {
+                val users = chatRepository.searchUsers(query)
+                _uiState.value = ChatCreateMultiUiState.Success(query = query, users = users, selectedIds = selected)
+            } else {
+                _uiState.value = ChatCreateMultiUiState.Success(query = query, users = emptyList(), selectedIds = selected)
+            }
+        }
+    }
+
+    fun onUserChecked(user: User, checked: Boolean) {
+        viewModelScope.launch {
+            val currentState = _uiState.value
+            if (currentState is ChatCreateMultiUiState.Success) {
+                val newSelected = currentState.selectedIds.toMutableSet()
+                user.userId?.toLongOrNull()?.let { id ->
+                    if (checked) newSelected.add(id) else newSelected.remove(id)
+                }
+                _uiState.value = currentState.copy(selectedIds = newSelected)
+            }
+        }
+    }
+
+    fun onCreateGroupClick() {
+        viewModelScope.launch {
+            val current = _uiState.value
+            if (current is ChatCreateMultiUiState.Success) {
+                chatRepository.createGroupDialog(current.selectedIds.toList())
+                _events.emit(ChatCreateMultiEvent.CloseAndRefresh)
+            }
+        }
+    }
+}
+
+sealed class ChatCreateMultiEvent {
+    data object CloseAndRefresh : ChatCreateMultiEvent()
+}
+
+sealed class ChatCreateMultiUiState {
+    object Loading : ChatCreateMultiUiState()
+    data class Success(
+        val query: String,
+        val users: List<User>,
+        val selectedIds: Set<Long>,
+    ) : ChatCreateMultiUiState()
+
+    data class Error(val message: String) : ChatCreateMultiUiState()
+}

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
@@ -33,7 +33,9 @@ class ChatCreateSingleViewModel @Inject constructor(
     }
 
     fun onGroupCreateClick() {
-
+        viewModelScope.launch {
+            _events.emit(ChatCreateSingleEvent.OpenGroupCreate)
+        }
     }
 
     fun onCurrentSearchChange(query: String) {
@@ -64,6 +66,7 @@ class ChatCreateSingleViewModel @Inject constructor(
 sealed class ChatCreateSingleEvent {
     data class OpenDialogDetail(val dialogId: Long) : ChatCreateSingleEvent()
     data object CloseAndRefresh : ChatCreateSingleEvent()
+    data object OpenGroupCreate : ChatCreateSingleEvent()
 }
 
 sealed class ChatCreateSingleUiState {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
@@ -1,0 +1,53 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import uddug.com.naukoteka.mvvm.chat.ChatCreateMultiEvent
+import uddug.com.naukoteka.mvvm.chat.ChatCreateMultiViewModel
+import uddug.com.naukoteka.ui.chat.compose.ChatCreateMultiScreen
+
+@AndroidEntryPoint
+class ChatCreateMultiFragment : Fragment() {
+
+    private val viewModel: ChatCreateMultiViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        setupObservers()
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatCreateMultiScreen(
+                        viewModel = viewModel,
+                        onCreateClick = { viewModel.onCreateGroupClick() },
+                        onBackPressed = { findNavController().popBackStack() },
+                    )
+                }
+            }
+        }
+    }
+
+    private fun setupObservers() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.events.collectLatest { event ->
+                when (event) {
+                    ChatCreateMultiEvent.CloseAndRefresh -> findNavController().popBackStack()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
@@ -72,6 +72,9 @@ class ChatCreateSingleFragment : Fragment() {
                     ChatCreateSingleEvent.CloseAndRefresh -> {
                         findNavController().popBackStack()
                     }
+                    ChatCreateSingleEvent.OpenGroupCreate -> {
+                        // Navigation to group chat creation will be added later
+                    }
                 }
             }
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
@@ -1,0 +1,69 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatCreateMultiUiState
+import uddug.com.naukoteka.mvvm.chat.ChatCreateMultiViewModel
+import uddug.com.naukoteka.ui.chat.compose.components.ChatToolbarCreateMultiComponent
+import uddug.com.naukoteka.ui.chat.compose.components.SearchField
+import uddug.com.naukoteka.ui.chat.compose.components.UserSelectableItem
+
+@Composable
+fun ChatCreateMultiScreen(
+    modifier: Modifier = Modifier,
+    viewModel: ChatCreateMultiViewModel,
+    onCreateClick: () -> Unit,
+    onBackPressed: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = Color.White)
+    ) {
+        ChatToolbarCreateMultiComponent(
+            onApplyClick = onCreateClick,
+            onBackPressed = onBackPressed,
+        )
+
+        when (uiState) {
+            is ChatCreateMultiUiState.Error -> Unit
+            ChatCreateMultiUiState.Loading -> Unit
+            is ChatCreateMultiUiState.Success -> {
+                val state = uiState as ChatCreateMultiUiState.Success
+                SearchField(
+                    title = stringResource(R.string.find_chat_message),
+                    query = state.query,
+                    onSearchChanged = { viewModel.onCurrentSearchChange(it) }
+                )
+                val users = state.users
+                if (users.isNotEmpty()) {
+                    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                        items(users) { user ->
+                            val selected = state.selectedIds.contains(user.userId?.toLongOrNull())
+                            UserSelectableItem(
+                                user = user,
+                                selected = selected,
+                                onCheckedChange = { checked ->
+                                    viewModel.onUserChecked(user, checked)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateMultiComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateMultiComponent.kt
@@ -1,0 +1,50 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.naukoteka.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatToolbarCreateMultiComponent(
+    modifier: Modifier = Modifier,
+    onApplyClick: () -> Unit,
+    onBackPressed: () -> Unit,
+) {
+    TopAppBar(
+        title = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Создать чат", fontSize = 20.sp, color = Color.Black)
+            }
+        },
+        actions = {
+            IconButton(onClick = { onApplyClick() }) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_chat_create_apply),
+                    contentDescription = "Apply Icon",
+                )
+            }
+        },
+        navigationIcon = {
+            IconButton(onClick = { onBackPressed() }) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_chat_back),
+                    contentDescription = "Back Icon",
+                )
+            }
+        },
+        backgroundColor = Color.White,
+        elevation = 0.dp,
+    )
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/UserSelectableItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/UserSelectableItem.kt
@@ -1,0 +1,42 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.domain.entities.chat.User
+
+@Composable
+fun UserSelectableItem(
+    user: User,
+    selected: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!selected) }
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Avatar(url = user.image)
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            text = user.fullName ?: user.nickname.orEmpty(),
+            fontSize = 16.sp,
+            color = Color.Black,
+            modifier = Modifier.weight(1f)
+        )
+        RadioButton(selected = selected, onClick = { onCheckedChange(!selected) })
+    }
+}

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
@@ -6,6 +6,7 @@ import uddug.com.data.mapper.mapUserSearchDtoToDomain
 
 import uddug.com.data.services.chat.ChatApiService
 import uddug.com.data.services.models.request.chat.CreateDialogRequest
+import uddug.com.data.services.models.request.chat.CreateGroupDialogRequest
 import uddug.com.data.services.models.response.chat.DialogInfoDto
 import uddug.com.data.services.models.response.chat.mapDialogInfoDtoToDomain
 import uddug.com.domain.entities.chat.Chat
@@ -39,6 +40,8 @@ interface ChatRepository {
     suspend fun searchUsers(searchField: String): List<User>
 
     suspend fun createDialog(id: Long)
+
+    suspend fun createGroupDialog(ids: List<Long>)
 }
 
 
@@ -121,6 +124,14 @@ class ChatRepositoryImpl @Inject constructor(
             apiService.createDialog(CreateDialogRequest(id))
         } catch (e: Exception) {
             println("Error creating dialog: ${e.message}")
+        }
+    }
+
+    override suspend fun createGroupDialog(ids: List<Long>) {
+        try {
+            apiService.createGroupDialog(CreateGroupDialogRequest(ids))
+        } catch (e: Exception) {
+            println("Error creating group dialog: ${e.message}")
         }
     }
 

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -10,6 +10,7 @@ import uddug.com.data.services.models.response.chat.DialogInfoDto
 import uddug.com.data.services.models.response.chat.MessageDto
 import uddug.com.data.services.models.response.chat.SearchUsersDto
 import uddug.com.data.services.models.request.chat.CreateDialogRequest
+import uddug.com.data.services.models.request.chat.CreateGroupDialogRequest
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
@@ -44,5 +45,10 @@ interface ChatApiService {
     @POST("chat/v1/dialogs/create")
     suspend fun createDialog(
         @Body body: CreateDialogRequest,
+    )
+
+    @POST("chat/v1/dialogs/group/create")
+    suspend fun createGroupDialog(
+        @Body body: CreateGroupDialogRequest,
     )
 }

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/CreateGroupDialogRequest.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/CreateGroupDialogRequest.kt
@@ -1,0 +1,11 @@
+package uddug.com.data.services.models.request.chat
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Request body for creating group dialog containing list of participant ids.
+ */
+data class CreateGroupDialogRequest(
+    @SerializedName("ids")
+    val ids: List<Long>
+)


### PR DESCRIPTION
## Summary
- add ChatCreateMultiScreen with selectable users list
- implement ChatCreateMultiViewModel and supporting UI components
- extend chat repository and API to create group dialogs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9e3a0ff08327bd59de92c8548011