### PR TITLE
Fix navigation for group chat creation

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
@@ -73,7 +73,9 @@ class ChatCreateSingleFragment : Fragment() {
                         findNavController().popBackStack()
                     }
                     ChatCreateSingleEvent.OpenGroupCreate -> {
-                        // Navigation to group chat creation will be added later
+                        findNavController().navigate(
+                            R.id.chatCreateMultiFragment,
+                        )
                     }
                 }
             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
@@ -3,6 +3,7 @@ package uddug.com.naukoteka.ui.chat.compose
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,6 +16,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -46,9 +48,7 @@ fun ChatCreateSingleScreen(
     ) {
         ChatToolbarCreateSingleComponent(
             viewModel = viewModel,
-            onBackPressed = {
-
-            }
+            onBackPressed = onBackPressed,
         )
 
         when (uiState) {
@@ -65,7 +65,10 @@ fun ChatCreateSingleScreen(
                 Row(
                     modifier = Modifier
                         .padding(20.dp)
-                        .clickable {
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                        ) {
                             onGroupCreateClick()
                         },
                     verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -32,4 +32,10 @@
 
     </fragment>
 
+    <fragment
+        android:id="@+id/chatCreateMultiFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatCreateMultiFragment">
+
+    </fragment>
+
 </navigation>


### PR DESCRIPTION
## Summary
- wire back button and remove press ripple on single chat creation screen
- navigate to group chat creation and register fragment in navigation graph

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da36dcb848327a98c9e70aa91cbec