### PR TITLE
feat(chat): add compose bottom sheet for chat functions

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -1,7 +1,8 @@
 import android.text.format.DateUtils
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.*
@@ -25,6 +26,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ChatCard(
     dialogId: Long,
@@ -37,7 +39,8 @@ fun ChatCard(
     isRepost: Boolean = false,
     isMedia: Boolean = false,
     isFromMe: Boolean = false,
-    onChatClick: (Long) -> Unit
+    onChatClick: (Long) -> Unit,
+    onChatLongClick: (Long) -> Unit
 ) {
     // Определяем форматирование даты
     val formattedTime = formatMessageTime(time)
@@ -46,9 +49,10 @@ fun ChatCard(
         modifier = Modifier
             .fillMaxWidth()
             .padding(0.dp)
-            .clickable {
-                onChatClick(dialogId)
-            },  // Убираем отступы
+            .combinedClickable(
+                onClick = { onChatClick(dialogId) },
+                onLongClick = { onChatLongClick(dialogId) }
+            ),  // Убираем отступы
         colors = CardDefaults.cardColors(containerColor = Color.White)  // Белый фон
     ) {
         Column {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -1,0 +1,74 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import uddug.com.naukoteka.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatFunctionsBottomSheetDialog(
+    onDismissRequest: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_settings),
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(14.dp))
+                Text(
+                    text = stringResource(R.string.chat_functions_title),
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            val items = listOf(
+                R.string.chat_mark_unread,
+                R.string.chat_show_attachments,
+                R.string.chat_pin,
+                R.string.chat_disable_notifications,
+                R.string.chat_select_messages,
+                R.string.chat_block_chat,
+                R.string.chat_delete_chat
+            )
+            items.forEach { itemRes ->
+                Text(
+                    text = stringResource(id = itemRes),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { }
+                        .padding(vertical = 12.dp),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -23,18 +23,21 @@ fun ChatTabBar(
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
 
+    var showOptions by remember { mutableStateOf(false) }
+
     val tabTitles = listOf("Все", "Люди", "Работа", "Наука", "Учеба")
 
     val uiState by viewModel.uiState.collectAsState()
 
     val selectedTabContent = TabContent.values()[selectedTabIndex]
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(Color.White),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    Box {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
         TabRow(
             modifier = Modifier
                 .fillMaxWidth()
@@ -118,6 +121,9 @@ fun ChatTabBar(
                                         isFromMe = chat.lastMessage.ownerId == "",
                                         onChatClick = {
                                             viewModel.onChatClick(it)
+                                        },
+                                        onChatLongClick = {
+                                            showOptions = true
                                         }
                                     )
                                 }
@@ -143,7 +149,11 @@ fun ChatTabBar(
                 }
             }
         }
-
+        if (showOptions) {
+            ChatFunctionsBottomSheetDialog(
+                onDismissRequest = { showOptions = false }
+            )
+        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -372,7 +372,15 @@
     <string name="profile_shasre">Поделиться</string>
     <string name="profile_more">Еще</string>
     <string name="find_chat_message">Поиск чатов и сообщений</string>
-   <string name="create_group_chat">Создать групповой чат</string>
+    <string name="chat_functions_title">Функции чата</string>
+    <string name="chat_mark_unread">Отметить непрочитанным</string>
+    <string name="chat_show_attachments">Показать вложения</string>
+    <string name="chat_pin">Закрепить в списке</string>
+    <string name="chat_disable_notifications">Отключить уведомления</string>
+    <string name="chat_select_messages">Выделить сообщения</string>
+    <string name="chat_block_chat">Заблокировать чат</string>
+    <string name="chat_delete_chat">Удалить чат</string>
+    <string name="create_group_chat">Создать групповой чат</string>
     <string name="subs">Подписки</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- show new chat options bottom sheet on long press in chat list
- extract chat option labels to resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db730c088832784e0cfa942f41004