### PR TITLE
Fix ChatDetail reopening on back navigation

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
@@ -62,7 +62,7 @@ class ChatListFragment : Fragment() {
     }
 
     private fun setupObservers() {
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             viewModel.uiState.collectLatest { state ->
                 when (state) {
                     is ChatListUiState.Loading -> showLoading()
@@ -72,7 +72,7 @@ class ChatListFragment : Fragment() {
                 }
             }
         }
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             viewModel.events.collectLatest { state ->
                 when (state) {
                     is ChatListEvents.OpenDialogDetail -> {


### PR DESCRIPTION
## Summary
- scope ChatList observers to view lifecycle to avoid re-triggered navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dacff298832786ed0f3602a73113