### PR TITLE
feat: load chat dialog media categories

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
@@ -8,9 +8,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import uddug.com.data.repositories.chat.ChatRepository
-import uddug.com.domain.entities.chat.ChatSocketMessage
 import uddug.com.domain.entities.chat.DialogInfo
-import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.User
 import uddug.com.domain.entities.profile.UserProfileFullInfo
@@ -32,8 +30,6 @@ class ChatDialogDetailViewModel @Inject constructor(
     val selectedTabIndex: StateFlow<Int> = _selectedTabIndex
 
     private var currentDialogInfo: DialogInfo? = null
-    private var attachedFiles: MutableList<FileDescriptor> = mutableListOf()
-
     private var currentUser: UserProfileFullInfo? = null
 
     fun selectTab(index: Int) {
@@ -48,14 +44,20 @@ class ChatDialogDetailViewModel @Inject constructor(
                 .subscribe({
                     currentUser = it
                     viewModelScope.launch {
-                        val currentMedia = chatRepository.getDialogMedia(dialogId = dialogInfo.id)
+                        val media = chatRepository.getDialogMedia(dialogInfo.id, category = 1)
+                        val files = chatRepository.getDialogMedia(dialogInfo.id, category = 3)
+                        val voices = chatRepository.getDialogMedia(dialogInfo.id, category = 6)
+                        val notes = chatRepository.getDialogMedia(dialogInfo.id, category = 7)
                         _uiState.value = ChatDetailUiState.Success(
                             profile = User(
                                 image = dialogInfo.interlocutor?.image.orEmpty(),
                                 fullName = dialogInfo.interlocutor?.fullName.orEmpty(),
                                 nickname = dialogInfo.interlocutor?.nickname.orEmpty()
                             ),
-                            currentMedia = currentMedia
+                            media = media,
+                            files = files,
+                            voices = voices,
+                            notes = notes
                         )
                     }
 
@@ -70,7 +72,10 @@ sealed class ChatDetailUiState {
     object Loading : ChatDetailUiState()
     data class Success(
         val profile: User,
-        val currentMedia: List<MediaMessage>,
+        val media: List<MediaMessage>,
+        val files: List<MediaMessage>,
+        val voices: List<MediaMessage>,
+        val notes: List<MediaMessage>,
     ) : ChatDetailUiState()
 
     data class Error(val message: String) : ChatDetailUiState()

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -21,9 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import uddug.com.naukoteka.mvvm.chat.ChatDialogDetailViewModel
 import androidx.compose.foundation.border
@@ -321,10 +320,10 @@ fun ChatDetailDialogComponent(viewModel: ChatDialogDetailViewModel, onBackPresse
 
                     // Контент табов
                     when (selectedTabIndex) {
-                        0 -> MediaContent(state.currentMedia)
-                        1 -> FilesContent()
-                        2 -> VoiceContent()
-                        3 -> NotesContent()
+                        0 -> MediaContent(state.media)
+                        1 -> FilesContent(state.files)
+                        2 -> VoiceContent(state.voices)
+                        3 -> NotesContent(state.notes)
                     }
                 }
             }
@@ -364,31 +363,49 @@ fun MediaContent(items: List<MediaMessage>) {
 }
 
 @Composable
-fun FilesContent() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+fun FilesContent(items: List<MediaMessage>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(8.dp)
     ) {
-
+        items(items) { item ->
+            Text(
+                text = item.file.fileName,
+                modifier = Modifier.padding(4.dp)
+            )
+        }
     }
 }
 
 @Composable
-fun VoiceContent() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+fun VoiceContent(items: List<MediaMessage>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(8.dp)
     ) {
-        Text("Голосовые сообщения")
+        items(items) { item ->
+            Text(
+                text = item.file.fileName,
+                modifier = Modifier.padding(4.dp)
+            )
+        }
     }
 }
 
 @Composable
-fun NotesContent() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+fun NotesContent(items: List<MediaMessage>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(8.dp)
     ) {
-        Text("Записи")
+        items(items) { item ->
+            Text(
+                text = item.file.fileName,
+                modifier = Modifier.padding(4.dp)
+            )
+        }
     }
 }

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
@@ -31,6 +31,12 @@ interface ChatRepository {
 
     suspend fun getDialogMedia(
         dialogId: Long,
+        category: Int,
+        limit: Int = 10,
+        page: Int = 1,
+        query: String? = null,
+        sd: String? = null,
+        ed: String? = null,
     ): List<MediaMessage>
 
     suspend fun createDialog(userId: Long): Long
@@ -91,10 +97,25 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getDialogMedia(dialogId: Long): List<MediaMessage> {
+    override suspend fun getDialogMedia(
+        dialogId: Long,
+        category: Int,
+        limit: Int,
+        page: Int,
+        query: String?,
+        sd: String?,
+        ed: String?,
+    ): List<MediaMessage> {
         return try {
-            val dialogInfoDto = apiService.getDialogMedia(dialogId, category = 1)
-            return dialogInfoDto
+            apiService.getDialogMedia(
+                dialogId = dialogId,
+                category = category,
+                limit = limit,
+                page = page,
+                query = query,
+                sd = sd,
+                ed = ed
+            )
         } catch (e: Exception) {
             println("Error getting dialog info: ${e.message}")
             throw e // or return default DialogInfo

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -31,6 +31,11 @@ interface ChatApiService {
     suspend fun getDialogMedia(
         @Path("dialogId") dialogId: Long,
         @Query("category") category: Int,
+        @Query("limit") limit: Int? = null,
+        @Query("page") page: Int? = null,
+        @Query("q") query: String? = null,
+        @Query("sd") sd: String? = null,
+        @Query("ed") ed: String? = null,
     ): List<MediaMessage>
 
     @POST("chat/v1/dialogs/{userId}")


### PR DESCRIPTION
## Summary
- extend chat API service to request dialog media with pagination and filtering params
- fetch media, files, voice messages and call records for chat details
- render separate lists for each media category in chat details

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2de0476d883278a54e4a54d07e898