### PR TITLE
Fix chat creation screen back navigation and search input

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
@@ -1,6 +1,5 @@
 package uddug.com.naukoteka.mvvm.chat
 
-import android.annotation.SuppressLint
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,16 +9,14 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import uddug.com.domain.repositories.chat.ChatRepository
+import uddug.com.domain.entities.profile.Image
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.interactors.chat.ChatInteractor
-import uddug.com.domain.repositories.user_profile.UserProfileRepository
 import javax.inject.Inject
 
 @HiltViewModel
 class ChatCreateSingleViewModel @Inject constructor(
     private val chatInteractor: ChatInteractor,
-    private val userProfileRepository: UserProfileRepository,
 ) : ViewModel() {
 
     private val _uiState =
@@ -31,7 +28,20 @@ class ChatCreateSingleViewModel @Inject constructor(
     val events: SharedFlow<ChatCreateSingleEvent> = _events.asSharedFlow()
 
     init {
-        _uiState.value = ChatCreateSingleUiState.Success(query = "", users = emptyList())
+        viewModelScope.launch {
+            try {
+                val users = chatInteractor.getDialogs().map { chat ->
+                    UserProfileFullInfo(
+                        id = chat.interlocutor.userId,
+                        fullName = chat.interlocutor.fullName,
+                        image = Image(path = chat.interlocutor.image)
+                    )
+                }
+                _uiState.value = ChatCreateSingleUiState.Success(query = "", users = users)
+            } catch (e: Exception) {
+                _uiState.value = ChatCreateSingleUiState.Error(e.message ?: "Unknown error")
+            }
+        }
     }
 
     fun onGroupCreateClick() {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
@@ -42,10 +42,7 @@ fun ChatCreateSingleScreen(
             .background(color = Color.White)
     ) {
         ChatToolbarCreateSingleComponent(
-            viewModel = viewModel,
-            onBackPressed = {
-
-            }
+            onBackPressed = onBackPressed
         )
 
         when (uiState) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
@@ -2,9 +2,6 @@ package uddug.com.naukoteka.ui.chat.compose.components
 
 
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -18,15 +15,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import uddug.com.naukoteka.R
-import uddug.com.naukoteka.mvvm.chat.ChatCreateSingleViewModel
-import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatToolbarCreateSingleComponent(
     modifier: Modifier = Modifier,
-    viewModel: ChatCreateSingleViewModel,
     onBackPressed: () -> Unit,
 ) {
     TopAppBar(
@@ -44,12 +38,11 @@ fun ChatToolbarCreateSingleComponent(
             }
         },
         navigationIcon = {
-            IconButton(onClick = {
-                onBackPressed()
-            }) {
+            IconButton(onClick = { onBackPressed() }) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_chat_back),
                     contentDescription = "Edit Icon",
+                    tint = Color(0xFF2E83D9)
                 )
             }
         },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
@@ -2,27 +2,21 @@ package uddug.com.naukoteka.ui.chat.compose.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.Icon
 import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import uddug.com.naukoteka.R
-import java.lang.reflect.Modifier
 
 @Composable
 fun SearchField(
@@ -30,10 +24,8 @@ fun SearchField(
      query: String,
      onSearchChanged: (String) -> Unit
 ) {
-    var searchText = TextFieldValue(title)
-
     Row(
-        modifier = androidx.compose.ui.Modifier
+        modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp)
             .background(
@@ -42,29 +34,28 @@ fun SearchField(
             )
             .padding(start = 16.dp)
     ) {
-        // Иконка слева
         Icon(
             painter = painterResource(id = R.drawable.ic_search),
             contentDescription = "Search",
             tint = Color.Gray,
-            modifier = androidx.compose.ui.Modifier
+            modifier = Modifier
                 .size(18.dp)
                 .align(Alignment.CenterVertically)
         )
 
-        // BasicTextField
         BasicTextField(
             value = query,
             onValueChange = { onSearchChanged(it) },
-            textStyle = LocalTextStyle.current.copy(color = Color.Gray),
-            modifier = androidx.compose.ui.Modifier
+            textStyle = LocalTextStyle.current.copy(color = Color.Black),
+            modifier = Modifier
                 .fillMaxWidth()
-                .padding(10.dp)
-                .background(
-                    shape = RoundedCornerShape(16.dp),
-                    color = Color(0xFFEAEAF2),
-                )
-
+                .padding(10.dp),
+            decorationBox = { innerTextField ->
+                if (query.isEmpty()) {
+                    Text(text = title, color = Color.Gray)
+                }
+                innerTextField()
+            }
         )
     }
 }


### PR DESCRIPTION
## Summary
- Hook up and tint back button on single chat creation toolbar
- Show entered text and placeholder in chat user search field
- Load subscriptions from API when opening chat creation screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2eb3f30a08327bc0a34a126fda601