### PR TITLE
Support media category for dialog media fetch

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
@@ -38,6 +38,18 @@ class ChatDialogDetailViewModel @Inject constructor(
 
     fun selectTab(index: Int) {
         _selectedTabIndex.value = index
+        currentDialogInfo?.let { dialogInfo ->
+            viewModelScope.launch {
+                val media = chatRepository.getDialogMedia(
+                    dialogId = dialogInfo.id,
+                    category = index + 1,
+                )
+                val state = _uiState.value
+                if (state is ChatDetailUiState.Success) {
+                    _uiState.value = state.copy(currentMedia = media)
+                }
+            }
+        }
     }
 
     fun setDialogInfo(dialogInfo: DialogInfo) {
@@ -48,7 +60,10 @@ class ChatDialogDetailViewModel @Inject constructor(
                 .subscribe({
                     currentUser = it
                     viewModelScope.launch {
-                        val currentMedia = chatRepository.getDialogMedia(dialogId = dialogInfo.id)
+                        val currentMedia = chatRepository.getDialogMedia(
+                            dialogId = dialogInfo.id,
+                            category = _selectedTabIndex.value + 1,
+                        )
                         _uiState.value = ChatDetailUiState.Success(
                             profile = User(
                                 image = dialogInfo.interlocutor?.image.orEmpty(),

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
@@ -31,6 +31,7 @@ interface ChatRepository {
 
     suspend fun getDialogMedia(
         dialogId: Long,
+        category: Int,
     ): List<MediaMessage>
 }
 
@@ -89,12 +90,11 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getDialogMedia(dialogId: Long): List<MediaMessage> {
+    override suspend fun getDialogMedia(dialogId: Long, category: Int): List<MediaMessage> {
         return try {
-            val dialogInfoDto = apiService.getDialogMedia(dialogId, category = 1)
-            return dialogInfoDto
+            apiService.getDialogMedia(dialogId, category)
         } catch (e: Exception) {
-            println("Error getting dialog info: ${e.message}")
+            println("Error getting dialog media: ${e.message}")
             throw e // or return default DialogInfo
         }
     }


### PR DESCRIPTION
## Summary
- allow ChatRepository.getDialogMedia to receive a category parameter
- fetch dialog media by selected category in ChatDialogDetailViewModel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ecc776a48327b38adbe0b1a34a9c