### PR TITLE
Fix getDialogMedia parameters in chat detail

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
@@ -45,10 +45,42 @@ class ChatDialogDetailViewModel @Inject constructor(
                 .subscribe({
                     currentUser = it
                     viewModelScope.launch {
-                        val media = chatInteractor.getDialogMedia(dialogInfo.id, category = 1)
-                        val files = chatInteractor.getDialogMedia(dialogInfo.id, category = 3)
-                        val voices = chatInteractor.getDialogMedia(dialogInfo.id, category = 6)
-                        val notes = chatInteractor.getDialogMedia(dialogInfo.id, category = 7)
+                        val media = chatInteractor.getDialogMedia(
+                            dialogInfo.id,
+                            category = 1,
+                            limit = 50,
+                            page = 1,
+                            query = null,
+                            sd = null,
+                            ed = null,
+                        )
+                        val files = chatInteractor.getDialogMedia(
+                            dialogInfo.id,
+                            category = 3,
+                            limit = 50,
+                            page = 1,
+                            query = null,
+                            sd = null,
+                            ed = null,
+                        )
+                        val voices = chatInteractor.getDialogMedia(
+                            dialogInfo.id,
+                            category = 6,
+                            limit = 50,
+                            page = 1,
+                            query = null,
+                            sd = null,
+                            ed = null,
+                        )
+                        val notes = chatInteractor.getDialogMedia(
+                            dialogInfo.id,
+                            category = 7,
+                            limit = 50,
+                            page = 1,
+                            query = null,
+                            sd = null,
+                            ed = null,
+                        )
                         _uiState.value = ChatDetailUiState.Success(
                             profile = User(
                                 image = dialogInfo.interlocutor?.image.orEmpty(),

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -75,7 +75,15 @@ class ChatRepositoryImpl @Inject constructor(
         ed: String?,
     ): List<MediaMessage> {
         return try {
-            apiService.getDialogMedia(dialogId, category = 1)
+            apiService.getDialogMedia(
+                dialogId,
+                category = category,
+                limit = limit,
+                page = page,
+                query = query,
+                sd = sd,
+                ed = ed,
+            )
         } catch (e: Exception) {
             println("Error getting dialog media: ${e.message}")
             throw e


### PR DESCRIPTION
## Summary
- add missing parameters when loading dialog media in chat detail view model
- forward full parameter set from repository to API service

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ef4399d483278e39b8d3321803ef