### PR TITLE
Enable chat search and round checkboxes

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
@@ -55,19 +55,17 @@ class ChatCreateSingleFragment : Fragment() {
             viewModel.events.collectLatest { state ->
                 when (state) {
                     is ChatCreateSingleEvent.OpenDialogDetail -> {
+                        findNavController().previousBackStackEntry?.savedStateHandle?.set(
+                            "refreshChats",
+                            true
+                        )
+                        findNavController().popBackStack()
                         findNavController().navigate(
                             R.id.chatDialogFragment,
                             args = Bundle().apply {
                                 putLong(DIALOG_ID, state.dialogId)
                             }
                         )
-                    }
-                    is ChatCreateSingleEvent.DialogCreated -> {
-                        findNavController().previousBackStackEntry?.savedStateHandle?.set(
-                            "refreshChats",
-                            true
-                        )
-                        findNavController().popBackStack()
                     }
                     ChatCreateSingleEvent.OpenMultiCreate -> {
                         findNavController().navigate(R.id.chatCreateMultiFragment)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
@@ -49,13 +49,34 @@ fun ChatCreateSingleScreen(
             is ChatCreateSingleUiState.Error -> Unit
             ChatCreateSingleUiState.Loading -> Unit
             is ChatCreateSingleUiState.Success -> {
+                val state = uiState as ChatCreateSingleUiState.Success
                 SearchField(
                     title = stringResource(R.string.find_chat_message),
-                    query = (uiState as ChatCreateSingleUiState.Success).query,
+                    query = state.query,
                     onSearchChanged = {
                         viewModel.onCurrentSearchChange(it)
                     }
                 )
+                if (state.searchResults.isNotEmpty()) {
+                    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
+                        Text(
+                            text = stringResource(R.string.search_country),
+                            fontSize = 18.sp,
+                            color = Color.Black
+                        )
+                        state.searchResults.forEach { user ->
+                            CreateChatMemberCard(
+                                name = user.fullName.orEmpty(),
+                                avatarUrl = user.image?.path.orEmpty(),
+                                time = "",
+                                onMemberClick = {
+                                    user.id?.toLongOrNull()?.let { viewModel.onUserClick(it) }
+                                },
+                                showCheckbox = false
+                            )
+                        }
+                    }
+                }
                 Row(
                     modifier = Modifier
                         .padding(20.dp)
@@ -81,7 +102,6 @@ fun ChatCreateSingleScreen(
                         fontSize = 18.sp,
                         color = Color.Black
                     )
-                    val state = uiState as ChatCreateSingleUiState.Success
                     state.users.forEach { user ->
                         CreateChatMemberCard(
                             name = user.fullName.orEmpty(),
@@ -94,7 +114,6 @@ fun ChatCreateSingleScreen(
                         )
                     }
                 }
-
             }
         }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/CreateChatMemberCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/CreateChatMemberCard.kt
@@ -4,7 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,20 +61,15 @@ fun CreateChatMemberCard(
                   verticalAlignment = Alignment.CenterVertically
               ) {
                   if (showCheckbox && checkboxOnLeft) {
-                      Checkbox(
-                          checked = isChecked,
-                          onCheckedChange = {
-                              isChecked = it
-                              onMemberClick()
-                          },
+                      Icon(
+                          painter = painterResource(id = if (isChecked) R.drawable.ic_checkbox_checked else R.drawable.ic_checkbox_unchecked),
+                          contentDescription = null,
                           modifier = Modifier
                               .size(24.dp)
-                              .clip(CircleShape),
-                          colors = CheckboxDefaults.colors(
-                              checkedColor = Color(0xFF2E83D9),
-                              uncheckedColor = Color(0xFFB0BEC5),
-                              checkmarkColor = Color.White
-                          )
+                              .clickable {
+                                  isChecked = !isChecked
+                                  onMemberClick()
+                              }
                       )
                       Spacer(modifier = Modifier.width(16.dp))
                   }
@@ -126,17 +124,15 @@ fun CreateChatMemberCard(
                 }
 
                   if (showCheckbox && !checkboxOnLeft) {
-                      Checkbox(
-                          checked = isChecked,
-                          onCheckedChange = {
-                              isChecked = it
-                              onMemberClick()
-                          },
-                          colors = CheckboxDefaults.colors(
-                              checkedColor = Color(0xFF2E83D9),
-                              uncheckedColor = Color(0xFFB0BEC5),
-                              checkmarkColor = Color.White
-                          )
+                      Icon(
+                          painter = painterResource(id = if (isChecked) R.drawable.ic_checkbox_checked else R.drawable.ic_checkbox_unchecked),
+                          contentDescription = null,
+                          modifier = Modifier
+                              .size(24.dp)
+                              .clickable {
+                                  isChecked = !isChecked
+                                  onMemberClick()
+                              }
                       )
                   }
             }


### PR DESCRIPTION
## Summary
- fetch user search results and navigate to dialog on click
- show search block above subscriptions in single chat
- replace square checkboxes with circular icons for group chat creation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3005366648327900cc3910f397004