### PR TITLE
Show chat options bottom sheet on long press

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -5,11 +5,16 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
+import uddug.com.naukoteka.ui.chat.compose.components.ChatFunctionsBottomSheetDialog
 import uddug.com.naukoteka.ui.chat.compose.components.ChatTabBar
 import uddug.com.naukoteka.ui.chat.compose.components.ChatToolbarComponent
 import uddug.com.naukoteka.ui.chat.compose.components.SearchField
@@ -22,6 +27,8 @@ fun ChatListComponent(
     onBackPressed: () -> Unit,
     onCreateChatClick: () -> Unit
 ) {
+    var showOptions by remember { mutableStateOf(false) }
+
     Column(
         modifier = Modifier.fillMaxSize().background(color = Color.White)
     ) {
@@ -41,6 +48,17 @@ fun ChatListComponent(
 
             }
         )
-        ChatTabBar(viewModel)
+        ChatTabBar(
+            viewModel = viewModel,
+            onChatLongClick = {
+                showOptions = true
+            }
+        )
+    }
+
+    if (showOptions) {
+        ChatFunctionsBottomSheetDialog(
+            onDismissRequest = { showOptions = false }
+        )
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -36,10 +36,9 @@ enum class TabContent(val content: String) {
 @Composable
 fun ChatTabBar(
     viewModel: ChatListViewModel,
+    onChatLongClick: (Long) -> Unit,
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
-
-    var showOptions by remember { mutableStateOf(false) }
 
     val tabTitles = listOf("Все", "Люди", "Работа", "Наука", "Учеба")
 
@@ -139,7 +138,7 @@ fun ChatTabBar(
                                                 viewModel.onChatClick(it)
                                             },
                                             onChatLongClick = {
-                                                showOptions = true
+                                                onChatLongClick(it)
                                             }
                                         )
                                     }
@@ -164,11 +163,6 @@ fun ChatTabBar(
                         }
                     }
                 }
-            }
-            if (showOptions) {
-                ChatFunctionsBottomSheetDialog(
-                    onDismissRequest = { showOptions = false }
-                )
             }
         }
 


### PR DESCRIPTION
## Summary
- Handle chat card long presses via ChatList and display options bottom sheet
- Delegate chat long press callback from tab bar to parent component

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3061ec254832797005cbc504af705