### PR TITLE
Add message actions bottom sheet

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -27,6 +27,8 @@ import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,7 +41,9 @@ import uddug.com.naukoteka.mvvm.chat.ChatDialogUiState
 import uddug.com.naukoteka.mvvm.chat.ChatDialogViewModel
 import uddug.com.naukoteka.ui.chat.compose.components.ChatInputBar
 import uddug.com.naukoteka.ui.chat.compose.components.ChatMessageItem
+import uddug.com.naukoteka.ui.chat.compose.components.MessageFunctionsBottomSheetDialog
 import uddug.com.naukoteka.ui.chat.compose.components.ChatTopBar
+import uddug.com.domain.entities.chat.MessageChat
 import java.io.File
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -50,6 +54,7 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
     val context = LocalContext.current
+    var selectedMessage by remember { mutableStateOf<MessageChat?>(null) }
 
     val filePickerLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenMultipleDocuments()
@@ -120,7 +125,11 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                             reverseLayout = true,
                         ) {
                             items(messages) { message ->
-                                ChatMessageItem(message, isMine = message.isMine)
+                                ChatMessageItem(
+                                    message,
+                                    isMine = message.isMine,
+                                    onLongPress = { selectedMessage = it }
+                                )
                             }
                         }
                     }
@@ -144,6 +153,11 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                     )
                 }
             }
+        }
+        selectedMessage?.let {
+            MessageFunctionsBottomSheetDialog(
+                onDismissRequest = { selectedMessage = null }
+            )
         }
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -1,8 +1,19 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
@@ -28,14 +39,23 @@ import java.time.format.DateTimeFormatter
 import java.time.LocalTime // если toLocalTime() возвращает LocalTime
 
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun ChatMessageItem(message: MessageChat, isMine: Boolean) {
+fun ChatMessageItem(
+    message: MessageChat,
+    isMine: Boolean,
+    onLongPress: (MessageChat) -> Unit
+) {
     Row(
         modifier = Modifier
             .padding(horizontal = 10.dp)
             .fillMaxWidth()
             .defaultMinSize(minWidth = 150.dp)
-            .padding(vertical = 4.dp),
+            .padding(vertical = 4.dp)
+            .combinedClickable(
+                onClick = {},
+                onLongClick = { onLongPress(message) }
+            ),
         horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -1,0 +1,74 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import uddug.com.naukoteka.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MessageFunctionsBottomSheetDialog(
+    onDismissRequest: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_settings),
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(14.dp))
+                Text(
+                    text = stringResource(R.string.message_functions_title),
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            val items = listOf(
+                R.string.chat_message_reply,
+                R.string.chat_message_forward,
+                R.string.chat_message_copy,
+                R.string.chat_message_select,
+                R.string.chat_message_show_original,
+                R.string.chat_message_delete
+            )
+            items.forEach { itemRes ->
+                Text(
+                    text = stringResource(id = itemRes),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { }
+                        .padding(vertical = 12.dp),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -380,6 +380,13 @@
     <string name="chat_select_messages">Выделить сообщения</string>
     <string name="chat_block_chat">Заблокировать чат</string>
     <string name="chat_delete_chat">Удалить чат</string>
+    <string name="message_functions_title">Действия с сообщением</string>
+    <string name="chat_message_reply">Ответить</string>
+    <string name="chat_message_forward">Переслать</string>
+    <string name="chat_message_copy">Скопировать</string>
+    <string name="chat_message_select">Выбрать сообщение</string>
+    <string name="chat_message_show_original">Показать оригинал в чате</string>
+    <string name="chat_message_delete">Удалить сообщение</string>
     <string name="create_group_chat">Создать групповой чат</string>
     <string name="subs">Подписки</string>
 


### PR DESCRIPTION
## Summary
- show message options bottom sheet with reply, forward, copy and other actions
- trigger bottom sheet on long press of chat messages
- add string resources for message actions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a306889bd083279bb2c77bfd1ec716