### PR TITLE
Show previews for selected attachments in chat

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -129,10 +129,26 @@ class ChatDialogViewModel @Inject constructor(
 
     fun attachFiles(files: List<File>) {
         attachedFiles.addAll(files)
+        val currentState = _uiState.value
+        if (currentState is ChatDialogUiState.Success) {
+            _uiState.value = currentState.copy(attachedFiles = attachedFiles.toList())
+        }
     }
 
     fun clearAttachedFiles() {
         attachedFiles.clear()
+        val currentState = _uiState.value
+        if (currentState is ChatDialogUiState.Success) {
+            _uiState.value = currentState.copy(attachedFiles = emptyList())
+        }
+    }
+
+    fun removeAttachedFile(file: File) {
+        attachedFiles.remove(file)
+        val currentState = _uiState.value
+        if (currentState is ChatDialogUiState.Success) {
+            _uiState.value = currentState.copy(attachedFiles = attachedFiles.toList())
+        }
     }
 
     fun sendMessage(text: String) {
@@ -231,6 +247,7 @@ sealed class ChatDialogUiState {
         val chatImage: String,
         val isGroup: Boolean,
         val currentMessage: String = "",
+        val attachedFiles: List<File> = emptyList(),
     ) : ChatDialogUiState()
 
     data class Error(val message: String) : ChatDialogUiState()

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -128,6 +128,7 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                     // ChatInputBar остается внизу экрана
                     ChatInputBar(
                         currentMessage = state.currentMessage,
+                        attachedFiles = state.attachedFiles,
                         onMessageChange = { newMessage ->
                             viewModel.updateCurrentMessage(newMessage)
                         },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -3,6 +3,8 @@ package uddug.com.naukoteka.ui.chat.compose.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
@@ -10,16 +12,21 @@ import androidx.compose.material.icons.filled.Send
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import uddug.com.naukoteka.R
+import java.io.File
 
 
 @Composable
 fun ChatInputBar(
     modifier: Modifier = Modifier,
     currentMessage: String,
+    attachedFiles: List<File>,
     onMessageChange: (String) -> Unit,
     onSendClick: () -> Unit,
     onAttachClick: () -> Unit,
@@ -35,6 +42,27 @@ fun ChatInputBar(
                 .background(Color(0xFFEAEAF2))
                 .height(1.dp)
         )
+
+        if (attachedFiles.isNotEmpty()) {
+            LazyRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.White)
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(attachedFiles) { file ->
+                    AsyncImage(
+                        model = file,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(50.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                    )
+                }
+            }
+        }
 
         Row(
             modifier = Modifier


### PR DESCRIPTION
## Summary
- Display selected attachments as 50x50 thumbnails above the chat input field
- Track attached files in `ChatDialogViewModel`
- Provide files to `ChatInputBar` for preview

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a306cef2908327820ce5a8fd4155c8