### PR TITLE
Add image upload with removable preview in chat

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -46,14 +46,25 @@ import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.material.Scaffold
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalContext
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Unit) {
     val uiState by viewModel.uiState.collectAsState()
+    val attachments by viewModel.attachedImages.collectAsState()
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
+    val context = LocalContext.current
+
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
+        if (uris.isNotEmpty()) {
+            viewModel.attachImages(context, uris)
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -125,9 +136,10 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                                 // keyboardController?.hide()
                             }
                         },
-
-
-                        )
+                        attachments = attachments,
+                        onAttachmentClick = { uri -> viewModel.removeAttachment(uri) },
+                        onAttachClick = { imagePicker.launch("image/*") }
+                    )
                 }
             }
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -1,40 +1,86 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import uddug.com.naukoteka.R
-
 
 @Composable
 fun ChatInputBar(
     modifier: Modifier = Modifier,
     currentMessage: String,
     onMessageChange: (String) -> Unit,
-    onSendClick: () -> Unit
+    onSendClick: () -> Unit,
+    attachments: List<Uri> = emptyList(),
+    onAttachmentClick: (Uri) -> Unit = {},
+    onAttachClick: () -> Unit = {}
 ) {
     Column(
         modifier = modifier
             .padding(bottom = 10.dp)
             .fillMaxWidth()
     ) {
+        if (attachments.isNotEmpty()) {
+            LazyRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.White)
+                    .padding(horizontal = 8.dp, vertical = 8.dp)
+            ) {
+                items(attachments) { uri ->
+                    Box(
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .size(80.dp)
+                            .clickable { onAttachmentClick(uri) }
+                    ) {
+                        AsyncImage(
+                            model = uri,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(RoundedCornerShape(8.dp)),
+                            contentScale = ContentScale.Crop
+                        )
+                        Box(
+                            modifier = Modifier
+                                .size(16.dp)
+                                .background(Color.Red, CircleShape)
+                                .align(Alignment.TopEnd)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier
+                                    .size(12.dp)
+                                    .align(Alignment.Center)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -47,9 +93,9 @@ fun ChatInputBar(
                 .fillMaxWidth()
                 .background(Color.White)
                 .padding(horizontal = 8.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            IconButton(onClick = { /* вложения */ }) {
+            IconButton(onClick = onAttachClick) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_attach),
                     contentDescription = "Attach",
@@ -75,7 +121,7 @@ fun ChatInputBar(
                     focusedIndicatorColor = Color.Transparent,
                     unfocusedIndicatorColor = Color.Transparent
                 ),
-                shape = RoundedCornerShape(12.dp)
+                shape = RoundedCornerShape(12.dp),
             )
 
             IconButton(onClick = onSendClick) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/di/ChatModule.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/di/ChatModule.kt
@@ -10,6 +10,7 @@ import uddug.com.data.cache.cookies.CookiesCache
 import uddug.com.data.repositories.chat.ChatRepository
 import uddug.com.data.repositories.chat.ChatRepositoryImpl
 import uddug.com.data.services.chat.ChatApiService
+import uddug.com.data.services.FileApiService
 
 @Module
 @InstallIn(ViewModelComponent::class)
@@ -22,8 +23,13 @@ object ChatModule {
 
 
     @Provides
-    fun provideChatRepository(apiService: ChatApiService): ChatRepository {
-        return ChatRepositoryImpl(apiService)
+    fun provideFileApiService(retrofit: Retrofit): FileApiService {
+        return retrofit.create(FileApiService::class.java)
+    }
+
+    @Provides
+    fun provideChatRepository(apiService: ChatApiService, fileApiService: FileApiService): ChatRepository {
+        return ChatRepositoryImpl(apiService, fileApiService)
     }
 
     @Provides

--- a/data/src/main/java/uddug/com/data/services/FileApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/FileApiService.kt
@@ -1,0 +1,17 @@
+package uddug.com.data.services
+
+import okhttp3.MultipartBody
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+import retrofit2.http.Query
+import uddug.com.data.services.models.response.file.UploadFileDto
+
+interface FileApiService {
+    @Multipart
+    @POST("core/files")
+    suspend fun uploadFiles(
+        @Part files: List<MultipartBody.Part>,
+        @Query("raw") raw: Boolean = false
+    ): List<UploadFileDto>
+}

--- a/data/src/main/java/uddug/com/data/services/models/response/file/UploadFileDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/file/UploadFileDto.kt
@@ -1,0 +1,11 @@
+package uddug.com.data.services.models.response.file
+
+data class UploadFileDto(
+    val id: String,
+    val path: String,
+    val fileName: String,
+    val contentType: String,
+    val fileSize: Long,
+    val fileKind: Int,
+    val fileType: Int?
+)


### PR DESCRIPTION
## Summary
- allow picking images and show them in a LazyRow with red remove badges
- upload selected images to server and include file ids when sending messages
- wire up File API service and DI for file uploads

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30bee9f808327ba2e2eb01768c985