### PR TITLE
feat: support image attachments

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -158,12 +158,27 @@ class ChatDialogViewModel @Inject constructor(
                 Log.d("ChatViewModel", "Message is blank and no files attached — skipping")
                 return@launch
             }
+            val uploaded = if (attachedFiles.isNotEmpty()) {
+                try {
+                    chatInteractor.uploadFiles(attachedFiles)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    emptyList()
+                }
+            } else emptyList()
+
+            val fileDescriptors = uploaded.map {
+                ChatSocketMessage.FileDescriptor(
+                    id = it.id,
+                    fileType = (it.fileType ?: 1).toString()
+                )
+            }
 
             val message = ChatSocketMessage(
                 dialog = dialog.id,
                 text = text,
                 owner = currentUser?.id.orEmpty(),
-                // files = attachedFiles.toList()
+                files = fileDescriptors.ifEmpty { null }
             )
             val currentState = _uiState.value
             if (currentState is ChatDialogUiState.Success) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -150,6 +150,9 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                         },
                         onAttachClick = {
                             permissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+                        },
+                        onRemoveFile = { file ->
+                            viewModel.removeAttachedFile(file)
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -2,12 +2,15 @@ package uddug.com.naukoteka.ui.chat.compose.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -30,6 +33,7 @@ fun ChatInputBar(
     onMessageChange: (String) -> Unit,
     onSendClick: () -> Unit,
     onAttachClick: () -> Unit,
+    onRemoveFile: (File) -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -52,14 +56,33 @@ fun ChatInputBar(
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(attachedFiles) { file ->
-                    AsyncImage(
-                        model = file,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
+                    Box(
                         modifier = Modifier
                             .size(50.dp)
                             .clip(RoundedCornerShape(8.dp))
-                    )
+                            .clickable { onRemoveFile(file) }
+                    ) {
+                        AsyncImage(
+                            model = file,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.matchParentSize()
+                        )
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .size(16.dp)
+                                .background(Color.Red, CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = "Remove", 
+                                tint = Color.White,
+                                modifier = Modifier.size(10.dp)
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -1,11 +1,14 @@
 package uddug.com.data.services.chat
 
+import okhttp3.MultipartBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.HTTP
+import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
@@ -15,6 +18,7 @@ import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.response.chat.ChatDto
 import uddug.com.data.services.models.response.chat.DialogInfoDto
 import uddug.com.data.services.models.response.chat.MessageDto
+import uddug.com.data.services.models.response.chat.FileDto
 import uddug.com.data.services.models.response.user_profile.UserProfileFullInfoDto
 import uddug.com.domain.entities.chat.MediaMessage
 
@@ -80,4 +84,11 @@ interface ChatApiService {
         @Query("limit") limit: Int = 10,
         @Query("page") page: Int = 1,
     ): List<UserProfileFullInfoDto>
+
+    @Multipart
+    @POST("core/files")
+    suspend fun uploadFiles(
+        @Part files: List<MultipartBody.Part>,
+        @Query("raw") raw: Boolean = false,
+    ): List<FileDto>
 }

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -6,6 +6,8 @@ import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.repositories.chat.ChatRepository
+import uddug.com.domain.entities.chat.File as ChatFile
+import java.io.File as JavaFile
 import javax.inject.Inject
 
 class ChatInteractor @Inject constructor(
@@ -60,4 +62,7 @@ class ChatInteractor @Inject constructor(
 
     suspend fun deleteMessages(messages: List<Long>, forMe: Boolean = false) =
         chatRepository.deleteMessages(messages, forMe)
+
+    suspend fun uploadFiles(files: List<JavaFile>, raw: Boolean = false): List<ChatFile> =
+        chatRepository.uploadFiles(files, raw)
 }

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -5,6 +5,8 @@ import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.domain.entities.chat.File as ChatFile
+import java.io.File as JavaFile
 
 interface ChatRepository {
     suspend fun getChats(): List<Chat>
@@ -48,4 +50,6 @@ interface ChatRepository {
     suspend fun deleteMessage(messageId: Long, forMe: Boolean = false)
 
     suspend fun deleteMessages(messages: List<Long>, forMe: Boolean = false)
+
+    suspend fun uploadFiles(files: List<JavaFile>, raw: Boolean = false): List<ChatFile>
 }


### PR DESCRIPTION
## Summary
- overlay delete icon on attached images and allow removing them from ChatInputBar
- upload selected images and send their identifiers with messages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30f2e8bd48327b574ddfedc9215ba