### PR TITLE
Add icons to chat bottom sheet items

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -38,36 +38,38 @@ fun ChatFunctionsBottomSheetDialog(
                 .fillMaxWidth()
                 .padding(20.dp)
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_settings),
-                    contentDescription = null,
-                )
-                Spacer(modifier = Modifier.width(14.dp))
-                Text(
-                    text = stringResource(R.string.chat_functions_title),
-                    style = MaterialTheme.typography.titleMedium
-                )
-            }
+            Text(
+                text = stringResource(R.string.chat_functions_title),
+                style = MaterialTheme.typography.titleMedium
+            )
             Spacer(modifier = Modifier.height(20.dp))
             val items = listOf(
-                R.string.chat_mark_unread,
-                R.string.chat_show_attachments,
-                R.string.chat_pin,
-                R.string.chat_disable_notifications,
-                R.string.chat_select_messages,
-                R.string.chat_block_chat,
-                R.string.chat_delete_chat
+                R.drawable.ic_mail to R.string.chat_mark_unread,
+                R.drawable.ic_attach to R.string.chat_show_attachments,
+                R.drawable.ic_save_post to R.string.chat_pin,
+                R.drawable.ic_mute to R.string.chat_disable_notifications,
+                R.drawable.ic_checkbox_unchecked to R.string.chat_select_messages,
+                R.drawable.ic_lock to R.string.chat_block_chat,
+                R.drawable.ic_trash to R.string.chat_delete_chat
             )
-            items.forEach { itemRes ->
-                Text(
-                    text = stringResource(id = itemRes),
+            items.forEach { (iconRes, textRes) ->
+                Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable { }
                         .padding(vertical = 12.dp),
-                    style = MaterialTheme.typography.bodyLarge
-                )
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        painter = painterResource(id = iconRes),
+                        contentDescription = null
+                    )
+                    Spacer(modifier = Modifier.width(14.dp))
+                    Text(
+                        text = stringResource(id = textRes),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -38,35 +38,37 @@ fun MessageFunctionsBottomSheetDialog(
                 .fillMaxWidth()
                 .padding(20.dp)
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_settings),
-                    contentDescription = null,
-                )
-                Spacer(modifier = Modifier.width(14.dp))
-                Text(
-                    text = stringResource(R.string.message_functions_title),
-                    style = MaterialTheme.typography.titleMedium
-                )
-            }
+            Text(
+                text = stringResource(R.string.message_functions_title),
+                style = MaterialTheme.typography.titleMedium
+            )
             Spacer(modifier = Modifier.height(20.dp))
             val items = listOf(
-                R.string.chat_message_reply,
-                R.string.chat_message_forward,
-                R.string.chat_message_copy,
-                R.string.chat_message_select,
-                R.string.chat_message_show_original,
-                R.string.chat_message_delete
+                R.drawable.ic_send to R.string.chat_message_reply,
+                R.drawable.ic_share to R.string.chat_message_forward,
+                R.drawable.ic_copy to R.string.chat_message_copy,
+                R.drawable.ic_checkbox_unchecked to R.string.chat_message_select,
+                R.drawable.ic_more_info to R.string.chat_message_show_original,
+                R.drawable.ic_trash to R.string.chat_message_delete
             )
-            items.forEach { itemRes ->
-                Text(
-                    text = stringResource(id = itemRes),
+            items.forEach { (iconRes, textRes) ->
+                Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable { }
                         .padding(vertical = 12.dp),
-                    style = MaterialTheme.typography.bodyLarge
-                )
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        painter = painterResource(id = iconRes),
+                        contentDescription = null
+                    )
+                    Spacer(modifier = Modifier.width(14.dp))
+                    Text(
+                        text = stringResource(id = textRes),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove settings icon from bottom sheet dialog titles
- add placeholder icons for each chat and message action item

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30fea31bc8327b31db0c0c4bde117