### PR TITLE
Add dialog and message pin/unpin API and use cases

### DIFF
--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -5,6 +5,7 @@ import uddug.com.data.services.chat.ChatApiService
 import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
 import uddug.com.data.services.models.request.chat.DialogImageRequestDto
+import uddug.com.data.services.models.request.chat.PinMessageRequestDto
 import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
 import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
 import uddug.com.data.services.models.response.chat.FileDto
@@ -128,6 +129,22 @@ class ChatRepositoryImpl @Inject constructor(
     override suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, status: Int) {
         val request = ReadMessagesRequestDto(dialogId, messages, status)
         apiService.markMessagesRead(request)
+    }
+
+    override suspend fun pinDialog(dialogId: Long) {
+        apiService.pinDialog(dialogId)
+    }
+
+    override suspend fun unpinDialog(dialogId: Long) {
+        apiService.unpinDialog(dialogId)
+    }
+
+    override suspend fun pinMessage(dialogId: Long, messageId: Long) {
+        apiService.pinMessage(PinMessageRequestDto(dialogId, messageId))
+    }
+
+    override suspend fun unpinMessage(dialogId: Long, messageId: Long) {
+        apiService.unpinMessage(PinMessageRequestDto(dialogId, messageId))
     }
 
     override suspend fun updateMessage(messageId: Long, text: String): MessageChat {

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -11,10 +11,11 @@ import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
+import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
+import uddug.com.data.services.models.request.chat.PinMessageRequestDto
 import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
 import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
-import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.response.chat.ChatDto
 import uddug.com.data.services.models.response.chat.DialogInfoDto
 import uddug.com.data.services.models.response.chat.MessageDto
@@ -60,11 +61,23 @@ interface ChatApiService {
         @Body request: CreateDialogRequestDto,
     ): DialogInfoDto
 
+    @POST("chat/v1/dialogs/pin/{dialogId}")
+    suspend fun pinDialog(@Path("dialogId") dialogId: Long)
+
+    @POST("chat/v1/dialogs/unpin/{dialogId}")
+    suspend fun unpinDialog(@Path("dialogId") dialogId: Long)
+
     @PATCH("chat/v1/messages/update")
     suspend fun updateMessage(@Body request: UpdateMessageRequestDto): MessageDto
 
     @PATCH("chat/v1/messages/read")
     suspend fun markMessagesRead(@Body request: ReadMessagesRequestDto)
+
+    @PATCH("chat/v1/messages/pin")
+    suspend fun pinMessage(@Body request: PinMessageRequestDto)
+
+    @PATCH("chat/v1/messages/unpin")
+    suspend fun unpinMessage(@Body request: PinMessageRequestDto)
 
     @DELETE("chat/v1/messages/{messageId}")
     suspend fun deleteMessage(

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/PinMessageRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/PinMessageRequestDto.kt
@@ -1,0 +1,6 @@
+package uddug.com.data.services.models.request.chat
+
+data class PinMessageRequestDto(
+    val dialogId: Long,
+    val messageId: Long,
+)

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -54,6 +54,16 @@ class ChatInteractor @Inject constructor(
     suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, status: Int) =
         chatRepository.markMessagesRead(dialogId, messages, status)
 
+    suspend fun pinDialog(dialogId: Long) = chatRepository.pinDialog(dialogId)
+
+    suspend fun unpinDialog(dialogId: Long) = chatRepository.unpinDialog(dialogId)
+
+    suspend fun pinMessage(dialogId: Long, messageId: Long) =
+        chatRepository.pinMessage(dialogId, messageId)
+
+    suspend fun unpinMessage(dialogId: Long, messageId: Long) =
+        chatRepository.unpinMessage(dialogId, messageId)
+
     suspend fun updateMessage(messageId: Long, text: String): MessageChat =
         chatRepository.updateMessage(messageId, text)
 

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -45,6 +45,14 @@ interface ChatRepository {
 
     suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, status: Int)
 
+    suspend fun pinDialog(dialogId: Long)
+
+    suspend fun unpinDialog(dialogId: Long)
+
+    suspend fun pinMessage(dialogId: Long, messageId: Long)
+
+    suspend fun unpinMessage(dialogId: Long, messageId: Long)
+
     suspend fun updateMessage(messageId: Long, text: String): MessageChat
 
     suspend fun deleteMessage(messageId: Long, forMe: Boolean = false)


### PR DESCRIPTION
## Summary
- extend chat API service with endpoints for pinning and unpinning dialogs and messages
- add repository and interactor methods with request DTO for pin/unpin message

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32123780c8327a4cf39493f5985e4