### PR TITLE
Fix group dialog creation user role mapping

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
@@ -62,7 +62,7 @@ fun ChatCreateMultiScreen(
                             avatarUrl = user.image?.path.orEmpty(),
                             time = "",
                             onMemberClick = {
-                                user.id?.toLongOrNull()?.let { viewModel.onUserClick(it) }
+                                user.id?.let { viewModel.onUserClick(it) }
                             },
                             showCheckbox = true,
                             checkboxOnLeft = true

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -110,12 +110,16 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun createGroupDialog(dialogName: String?, userIds: List<Long>, imageId: String?): Long {
+    override suspend fun createGroupDialog(
+        dialogName: String?,
+        userRoles: Map<String, String?>,
+        imageId: String?,
+    ): Long {
         return try {
             val request = CreateDialogRequestDto(
                 dialogName = dialogName,
                 dialogImage = imageId?.let { DialogImageRequestDto(it) },
-                userRoles = userIds.associate { it.toString() to "37:202" }
+                userRoles = userRoles,
             )
             val dialog = apiService.createGroupDialog(request)
             dialog.id

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -45,8 +45,8 @@ class ChatInteractor @Inject constructor(
 
     suspend fun createDialog(userId: Long): Long = chatRepository.createDialog(userId)
 
-    suspend fun createGroupDialog(userIds: List<Long>): Long =
-        chatRepository.createGroupDialog(dialogName = null, userIds = userIds)
+    suspend fun createGroupDialog(userRoles: Map<String, String?>): Long =
+        chatRepository.createGroupDialog(dialogName = null, userRoles = userRoles)
 
     suspend fun searchUsers(query: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo> =
         chatRepository.searchUsers(query, limit, page)

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -39,7 +39,11 @@ interface ChatRepository {
 
     suspend fun createDialog(userId: Long): Long
 
-    suspend fun createGroupDialog(dialogName: String?, userIds: List<Long>, imageId: String? = null): Long
+    suspend fun createGroupDialog(
+        dialogName: String?,
+        userRoles: Map<String, String?>,
+        imageId: String? = null,
+    ): Long
 
     suspend fun searchUsers(searchField: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo>
 


### PR DESCRIPTION
## Summary
- handle user IDs as strings in multi chat creation
- send userRoles map to backend with selected IDs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a320b567988327a05ffb3a1ab4efa7