### PR TITLE
Handle media messages with correct metadata

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -170,12 +170,15 @@ class ChatDialogViewModel @Inject constructor(
             val fileDescriptors = uploaded.map {
                 ChatSocketMessage.FileDescriptor(
                     id = it.id,
-                    fileType = (it.fileType ?: 1).toString()
+                    fileType = it.fileType ?: 100
                 )
             }
 
+            val cType = if (fileDescriptors.isEmpty()) 1 else 3
+
             val message = ChatSocketMessage(
                 dialog = dialog.id,
+                cType = cType,
                 text = text,
                 owner = currentUser?.id.orEmpty(),
                 files = fileDescriptors.ifEmpty { null }

--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
@@ -10,5 +10,5 @@ data class ChatSocketMessage(
 
 data class FileDescriptor(
     val id: String,
-    val fileType: String
+    val fileType: Int
 )


### PR DESCRIPTION
## Summary
- Distinguish between text and media messages when sending over the socket
- Use numeric fileType in socket payload and default to 100 for raw files

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a322bc13288327aede1e3c8b21b7e6