### PR TITLE
Add action handling and view models for chat and message options

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
@@ -1,0 +1,48 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import uddug.com.domain.repositories.chat.ChatRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatFunctionsViewModel @Inject constructor(
+    private val chatRepository: ChatRepository
+) : ViewModel() {
+
+    fun markUnread(dialogId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun showAttachments(dialogId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun pinChat(dialogId: Long) {
+        viewModelScope.launch {
+            try {
+                chatRepository.pinDialog(dialogId)
+            } catch (e: Exception) {
+                // handle error if needed
+            }
+        }
+    }
+
+    fun disableNotifications(dialogId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun selectMessages(dialogId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun blockChat(dialogId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun deleteChat(dialogId: Long) {
+        // TODO: implement when API is available
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/MessageFunctionsViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/MessageFunctionsViewModel.kt
@@ -1,0 +1,44 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import uddug.com.domain.repositories.chat.ChatRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class MessageFunctionsViewModel @Inject constructor(
+    private val chatRepository: ChatRepository
+) : ViewModel() {
+
+    fun reply(messageId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun forward(messageId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun copy(messageId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun select(messageId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun showOriginal(messageId: Long) {
+        // TODO: implement when API is available
+    }
+
+    fun delete(messageId: Long) {
+        viewModelScope.launch {
+            try {
+                chatRepository.deleteMessage(messageId)
+            } catch (e: Exception) {
+                // handle error if needed
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -158,8 +158,9 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                 }
             }
         }
-        selectedMessage?.let {
+        selectedMessage?.let { message ->
             MessageFunctionsBottomSheetDialog(
+                message = message,
                 onDismissRequest = { selectedMessage = null }
             )
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -1,6 +1,5 @@
 package uddug.com.naukoteka.ui.chat.compose
 
-
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,7 +18,6 @@ import uddug.com.naukoteka.ui.chat.compose.components.ChatTabBar
 import uddug.com.naukoteka.ui.chat.compose.components.ChatToolbarComponent
 import uddug.com.naukoteka.ui.chat.compose.components.SearchField
 
-
 @Composable
 fun ChatListComponent(
     modifier: Modifier = Modifier,
@@ -27,7 +25,7 @@ fun ChatListComponent(
     onBackPressed: () -> Unit,
     onCreateChatClick: () -> Unit
 ) {
-    var showOptions by remember { mutableStateOf(false) }
+    var selectedDialogId by remember { mutableStateOf<Long?>(null) }
 
     Column(
         modifier = Modifier.fillMaxSize().background(color = Color.White)
@@ -50,15 +48,16 @@ fun ChatListComponent(
         )
         ChatTabBar(
             viewModel = viewModel,
-            onChatLongClick = {
-                showOptions = true
+            onChatLongClick = { id ->
+                selectedDialogId = id
             }
         )
     }
 
-    if (showOptions) {
+    selectedDialogId?.let { id ->
         ChatFunctionsBottomSheetDialog(
-            onDismissRequest = { showOptions = false }
+            dialogId = id,
+            onDismissRequest = { selectedDialogId = null }
         )
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -20,12 +20,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatFunctionsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatFunctionsBottomSheetDialog(
+    dialogId: Long,
     onDismissRequest: () -> Unit,
+    viewModel: ChatFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -44,19 +48,22 @@ fun ChatFunctionsBottomSheetDialog(
             )
             Spacer(modifier = Modifier.height(20.dp))
             val items = listOf(
-                R.drawable.ic_mail to R.string.chat_mark_unread,
-                R.drawable.ic_attach to R.string.chat_show_attachments,
-                R.drawable.ic_save_post to R.string.chat_pin,
-                R.drawable.ic_mute to R.string.chat_disable_notifications,
-                R.drawable.ic_checkbox_unchecked to R.string.chat_select_messages,
-                R.drawable.ic_lock to R.string.chat_block_chat,
-                R.drawable.ic_trash to R.string.chat_delete_chat
+                Triple(R.drawable.ic_mail, R.string.chat_mark_unread) { viewModel.markUnread(dialogId) },
+                Triple(R.drawable.ic_attach, R.string.chat_show_attachments) { viewModel.showAttachments(dialogId) },
+                Triple(R.drawable.ic_save_post, R.string.chat_pin) { viewModel.pinChat(dialogId) },
+                Triple(R.drawable.ic_mute, R.string.chat_disable_notifications) { viewModel.disableNotifications(dialogId) },
+                Triple(R.drawable.ic_checkbox_unchecked, R.string.chat_select_messages) { viewModel.selectMessages(dialogId) },
+                Triple(R.drawable.ic_lock, R.string.chat_block_chat) { viewModel.blockChat(dialogId) },
+                Triple(R.drawable.ic_trash, R.string.chat_delete_chat) { viewModel.deleteChat(dialogId) }
             )
-            items.forEach { (iconRes, textRes) ->
+            items.forEach { (iconRes, textRes, action) ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { }
+                        .clickable {
+                            action()
+                            onDismissRequest()
+                        }
                         .padding(vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -20,12 +20,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.MessageFunctionsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MessageFunctionsBottomSheetDialog(
+    message: MessageChat,
     onDismissRequest: () -> Unit,
+    viewModel: MessageFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -44,18 +49,21 @@ fun MessageFunctionsBottomSheetDialog(
             )
             Spacer(modifier = Modifier.height(20.dp))
             val items = listOf(
-                R.drawable.ic_send to R.string.chat_message_reply,
-                R.drawable.ic_share to R.string.chat_message_forward,
-                R.drawable.ic_copy to R.string.chat_message_copy,
-                R.drawable.ic_checkbox_unchecked to R.string.chat_message_select,
-                R.drawable.ic_more_info to R.string.chat_message_show_original,
-                R.drawable.ic_trash to R.string.chat_message_delete
+                Triple(R.drawable.ic_send, R.string.chat_message_reply) { viewModel.reply(message.id) },
+                Triple(R.drawable.ic_share, R.string.chat_message_forward) { viewModel.forward(message.id) },
+                Triple(R.drawable.ic_copy, R.string.chat_message_copy) { viewModel.copy(message.id) },
+                Triple(R.drawable.ic_checkbox_unchecked, R.string.chat_message_select) { viewModel.select(message.id) },
+                Triple(R.drawable.ic_more_info, R.string.chat_message_show_original) { viewModel.showOriginal(message.id) },
+                Triple(R.drawable.ic_trash, R.string.chat_message_delete) { viewModel.delete(message.id) }
             )
-            items.forEach { (iconRes, textRes) ->
+            items.forEach { (iconRes, textRes, action) ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { }
+                        .clickable {
+                            action()
+                            onDismissRequest()
+                        }
                         .padding(vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -73,4 +81,3 @@ fun MessageFunctionsBottomSheetDialog(
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- add ChatFunctionsViewModel and integrate it with ChatFunctionsBottomSheetDialog
- add MessageFunctionsViewModel and hook up MessageFunctionsBottomSheetDialog
- wire ChatListComponent and ChatDialogComponent to provide selected IDs

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32476aed08327a1226479fff45412