### PR TITLE
Load chat folders from API

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -1,6 +1,5 @@
 package uddug.com.naukoteka.mvvm.chat
 
-import android.annotation.SuppressLint
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,44 +9,58 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.repositories.chat.ChatRepository
-import uddug.com.domain.entities.profile.UserProfileFullInfo
 import javax.inject.Inject
 
 @HiltViewModel
 class ChatListViewModel @Inject constructor(
     private val chatRepository: ChatRepository,
-
-    ) : ViewModel() {
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow<ChatListUiState>(ChatListUiState.Loading)
     val uiState: StateFlow<ChatListUiState> = _uiState
 
+    private val _folders = MutableStateFlow<List<ChatFolder>>(emptyList())
+    val folders: StateFlow<List<ChatFolder>> = _folders
+
+    private var currentFolderId: Long? = null
 
     private val _events = MutableSharedFlow<ChatListEvents>()
     val events: SharedFlow<ChatListEvents> = _events.asSharedFlow()
 
-    @SuppressLint("CheckResult")
-    fun loadChats() {
-        _uiState.value = ChatListUiState.Loading
+    fun loadFolders() {
         viewModelScope.launch {
-
             try {
-                viewModelScope.launch {
-                    val chats = chatRepository.getChats()
-                    println("chat count ${chats.size}")
-                    _uiState.value = ChatListUiState.Success(chats)
-                }
-
+                val folderList = chatRepository.getFolders()
+                _folders.value = folderList
+                currentFolderId = folderList.firstOrNull()?.id
+                loadChats(currentFolderId)
             } catch (e: Exception) {
                 _uiState.value = ChatListUiState.Error(e.message ?: "Unknown error")
             }
+        }
+    }
 
+    fun loadChats(folderId: Long? = currentFolderId) {
+        _uiState.value = ChatListUiState.Loading
+        viewModelScope.launch {
+            try {
+                val chats = chatRepository.getChats(folderId)
+                currentFolderId = folderId
+                _uiState.value = ChatListUiState.Success(chats)
+            } catch (e: Exception) {
+                _uiState.value = ChatListUiState.Error(e.message ?: "Unknown error")
+            }
         }
     }
 
     fun refreshChats() {
-        loadChats()
+        loadChats(currentFolderId)
+    }
+
+    fun onFolderSelected(folderId: Long) {
+        loadChats(folderId)
     }
 
     fun onChatClick(dialogId: Long) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
@@ -41,7 +41,7 @@ class ChatListFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setupObservers()
-        viewModel.loadChats()
+        viewModel.loadFolders()
 
         findNavController().currentBackStackEntry?.savedStateHandle
             ?.getLiveData<Boolean>("refreshChats")

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -11,27 +11,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 import uddug.com.naukoteka.mvvm.chat.ChatListUiState
 import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
-
-
-enum class MessageState {
-    REPOST,  // Репост
-    MEDIA,   // Медиа-вложение
-    FROM_ME, // Сообщение от меня
-    NORMAL   // Обычное сообщение
-}
-
-enum class TabContent(val content: String) {
-    ALL("Все сообщения"),
-    PEOPLE("Сообщения от людей"),
-    WORK("Сообщения по работе"),
-    SCIENCE("Научные сообщения"),
-    STUDY("Учебные сообщения")
-}
 
 @Composable
 fun ChatTabBar(
@@ -40,11 +24,10 @@ fun ChatTabBar(
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
 
-    val tabTitles = listOf("Все", "Люди", "Работа", "Наука", "Учеба")
+    val folders by viewModel.folders.collectAsState()
+    val tabTitles = folders.map { it.name }
 
     val uiState by viewModel.uiState.collectAsState()
-
-    val selectedTabContent = TabContent.values()[selectedTabIndex]
 
     Box {
         Column(
@@ -53,59 +36,47 @@ fun ChatTabBar(
                 .background(Color.White),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            TabRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Color.White),
-                selectedTabIndex = selectedTabIndex,
-                indicator = { tabPositions ->
-                    TabRowDefaults.Indicator(
-                        Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
-                        color = Color(0xFF2E83D9)
-                    )
-                },
-                divider = {}
-            ) {
-                tabTitles.forEachIndexed { index, title ->
-                    Tab(
-                        modifier = Modifier.background(Color.White),
-                        selected = selectedTabIndex == index,
-                        onClick = { selectedTabIndex = index },
-                        text = {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Text(
-                                    text = title,
-                                    maxLines = 1,
-                                    style = TextStyle(
-                                        fontSize = 14.sp,
-                                        fontWeight = if (selectedTabIndex == index) FontWeight.Bold else FontWeight.Bold,
-                                        color = if (selectedTabIndex == index) Color.Black else Color(
-                                            0xFF8083A0
+            if (tabTitles.isNotEmpty()) {
+                TabRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White),
+                    selectedTabIndex = selectedTabIndex,
+                    indicator = { tabPositions ->
+                        TabRowDefaults.Indicator(
+                            Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+                            color = Color(0xFF2E83D9)
+                        )
+                    },
+                    divider = {},
+                ) {
+                    tabTitles.forEachIndexed { index, title ->
+                        Tab(
+                            modifier = Modifier.background(Color.White),
+                            selected = selectedTabIndex == index,
+                            onClick = {
+                                selectedTabIndex = index
+                                viewModel.onFolderSelected(folders[index].id)
+                            },
+                            text = {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(
+                                        text = title,
+                                        maxLines = 1,
+                                        style = TextStyle(
+                                            fontSize = 14.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = if (selectedTabIndex == index) Color.Black else Color(
+                                                0xFF8083A0
+                                            )
                                         )
                                     )
-                                )
-//                            Spacer(modifier = Modifier.width(4.dp))
-//                            if (tabCounts[index].isNotEmpty()) {
-//                                Box(
-//                                    contentAlignment = Alignment.Center,
-//                                    modifier = Modifier
-//                                        .size(20.dp)
-//                                        .background(Color.Blue, shape = CircleShape)
-//                                ) {
-//                                    Text(
-//                                        text = tabCounts[index],
-//                                        color = Color.White,
-//                                        fontSize = 12.sp,
-//                                        fontWeight = FontWeight.Bold
-//                                    )
-//                                }
-//                            }
+                                }
                             }
-                        }
-                    )
+                        )
+                    }
                 }
             }
-
 
             when (uiState) {
                 is ChatListUiState.Error -> {
@@ -117,59 +88,30 @@ fun ChatTabBar(
                 }
 
                 is ChatListUiState.Success -> {
-
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        when (selectedTabContent) {
-                            TabContent.ALL -> {
-                                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                                    items((uiState as ChatListUiState.Success).chats) { chat ->
-                                        ChatCard(
-                                            dialogId = chat.dialogId,
-                                            avatarUrl = chat.interlocutor.image,
-                                            name = chat.interlocutor.fullName ?: "Неизвестный",
-                                            message = chat.lastMessage.text ?: "Нет сообщений",
-                                            time = chat.lastMessage.createdAt ?: "Неизвестно",
-                                            newMessagesCount = chat.unreadMessages,
-                                            attachment = chat.lastMessage.files?.firstOrNull()?.path,
-                                            isRepost = chat.lastMessage.type == 5,
-                                            isMedia = chat.lastMessage.files?.isNotEmpty() == true,
-                                            isFromMe = chat.lastMessage.ownerId == "",
-                                            onChatClick = {
-                                                viewModel.onChatClick(it)
-                                            },
-                                            onChatLongClick = {
-                                                onChatLongClick(it)
-                                            }
-                                        )
-                                    }
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items((uiState as ChatListUiState.Success).chats) { chat ->
+                            ChatCard(
+                                dialogId = chat.dialogId,
+                                avatarUrl = chat.interlocutor.image,
+                                name = chat.interlocutor.fullName ?: "Неизвестный",
+                                message = chat.lastMessage.text ?: "Нет сообщений",
+                                time = chat.lastMessage.createdAt ?: "Неизвестно",
+                                newMessagesCount = chat.unreadMessages,
+                                attachment = chat.lastMessage.files?.firstOrNull()?.path,
+                                isRepost = chat.lastMessage.type == 5,
+                                isMedia = chat.lastMessage.files?.isNotEmpty() == true,
+                                isFromMe = chat.lastMessage.ownerId == "",
+                                onChatClick = {
+                                    viewModel.onChatClick(it)
+                                },
+                                onChatLongClick = {
+                                    onChatLongClick(it)
                                 }
-                            }
-
-                            TabContent.PEOPLE -> {
-
-                            }
-
-                            TabContent.WORK -> {
-
-                            }
-
-                            TabContent.SCIENCE -> {
-
-                            }
-
-                            TabContent.STUDY -> {
-
-                            }
+                            )
                         }
                     }
                 }
             }
         }
-
-
-
     }
-
-
-
 }

--- a/data/src/main/java/uddug/com/data/mapper/mapFolderDtoToDomain.kt
+++ b/data/src/main/java/uddug/com/data/mapper/mapFolderDtoToDomain.kt
@@ -1,0 +1,11 @@
+package uddug.com.data.mapper
+
+import uddug.com.data.services.models.response.chat.FolderDto
+import uddug.com.domain.entities.chat.ChatFolder
+
+fun mapFolderDtoToDomain(folderDto: FolderDto): ChatFolder = ChatFolder(
+    id = folderDto.id,
+    name = folderDto.name,
+    ord = folderDto.ord,
+    unreadCount = folderDto.unreadCount
+)

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package uddug.com.data.repositories.chat
 
 import uddug.com.data.mapper.mapChatDtoToDomain
+import uddug.com.data.mapper.mapFolderDtoToDomain
 import uddug.com.data.services.chat.ChatApiService
 import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
@@ -11,6 +12,7 @@ import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
 import uddug.com.data.services.models.response.chat.FileDto
 import uddug.com.data.services.models.response.chat.mapDialogInfoDtoToDomain
 import uddug.com.domain.entities.chat.Chat
+import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
@@ -29,12 +31,21 @@ class ChatRepositoryImpl @Inject constructor(
     private val apiService: ChatApiService,
 ) : ChatRepository {
 
-    override suspend fun getChats(): List<Chat> {
+    override suspend fun getChats(folderId: Long?): List<Chat> {
         return try {
-            val chatDto = apiService.getDialogs()
+            val chatDto = apiService.getDialogs(folderId)
             mapChatDtoToDomain(chatDto)
         } catch (e: Exception) {
             println("mapping error ${e.message}")
+            emptyList()
+        }
+    }
+
+    override suspend fun getFolders(): List<ChatFolder> {
+        return try {
+            apiService.getFolders().folders.map { mapFolderDtoToDomain(it) }
+        } catch (e: Exception) {
+            println("get folders error ${e.message}")
             emptyList()
         }
     }

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -18,6 +18,7 @@ import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
 import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
 import uddug.com.data.services.models.response.chat.ChatDto
 import uddug.com.data.services.models.response.chat.DialogInfoDto
+import uddug.com.data.services.models.response.chat.FoldersDto
 import uddug.com.data.services.models.response.chat.MessageDto
 import uddug.com.data.services.models.response.chat.FileDto
 import uddug.com.data.services.models.response.user_profile.UserProfileFullInfoDto
@@ -26,7 +27,10 @@ import uddug.com.domain.entities.chat.MediaMessage
 interface ChatApiService {
 
     @GET("chat/v1/dialogs")
-    suspend fun getDialogs(): ChatDto
+    suspend fun getDialogs(@Query("folderId") folderId: Long? = null): ChatDto
+
+    @GET("chat/v1/dialogs/folder")
+    suspend fun getFolders(): FoldersDto
 
     @GET("chat/v1/dialogs/{dialogId}")
     suspend fun getMessages(

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/FolderDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/FolderDto.kt
@@ -1,0 +1,13 @@
+package uddug.com.data.services.models.response.chat
+
+data class FoldersDto(
+    val userId: String,
+    val folders: List<FolderDto>
+)
+
+data class FolderDto(
+    val id: Long,
+    val name: String,
+    val ord: Int,
+    val unreadCount: Int
+)

--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatFolder.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatFolder.kt
@@ -1,0 +1,11 @@
+package uddug.com.domain.entities.chat
+
+/**
+ * Represents a dialog folder grouping chat dialogs.
+ */
+data class ChatFolder(
+    val id: Long,
+    val name: String,
+    val ord: Int,
+    val unreadCount: Int
+)

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -1,6 +1,7 @@
 package uddug.com.domain.interactors.chat
 
 import uddug.com.domain.entities.chat.Chat
+import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
@@ -14,7 +15,9 @@ class ChatInteractor @Inject constructor(
     private val chatRepository: ChatRepository,
 ) {
 
-    suspend fun getDialogs(): List<Chat> = chatRepository.getChats()
+    suspend fun getDialogs(folderId: Long? = null): List<Chat> = chatRepository.getChats(folderId)
+
+    suspend fun getFolders(): List<ChatFolder> = chatRepository.getFolders()
 
     suspend fun getMessages(
         currentUserId: String,

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -1,6 +1,7 @@
 package uddug.com.domain.repositories.chat
 
 import uddug.com.domain.entities.chat.Chat
+import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
@@ -9,7 +10,9 @@ import uddug.com.domain.entities.chat.File as ChatFile
 import java.io.File as JavaFile
 
 interface ChatRepository {
-    suspend fun getChats(): List<Chat>
+    suspend fun getChats(folderId: Long? = null): List<Chat>
+
+    suspend fun getFolders(): List<ChatFolder>
 
     suspend fun getMessages(
         currentUserId: String,


### PR DESCRIPTION
## Summary
- fetch chat folders and chats by folder via API
- expose folder list in ChatListViewModel and handle selection
- show dynamic folder tabs and request dialogs per folder

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a325904444832786532f4111efdd4c