### PR TITLE
feat: add dialog management actions

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
@@ -13,7 +13,13 @@ class ChatFunctionsViewModel @Inject constructor(
 ) : ViewModel() {
 
     fun markUnread(dialogId: Long) {
-        // TODO: implement when API is available
+        viewModelScope.launch {
+            try {
+                chatRepository.setDialogUnread(dialogId)
+            } catch (e: Exception) {
+                // handle error if needed
+            }
+        }
     }
 
     fun showAttachments(dialogId: Long) {
@@ -39,10 +45,22 @@ class ChatFunctionsViewModel @Inject constructor(
     }
 
     fun blockChat(dialogId: Long) {
-        // TODO: implement when API is available
+        viewModelScope.launch {
+            try {
+                chatRepository.blockDialog(dialogId)
+            } catch (e: Exception) {
+                // handle error if needed
+            }
+        }
     }
 
     fun deleteChat(dialogId: Long) {
-        // TODO: implement when API is available
+        viewModelScope.launch {
+            try {
+                chatRepository.deleteDialog(dialogId)
+            } catch (e: Exception) {
+                // handle error if needed
+            }
+        }
     }
 }

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -143,6 +143,30 @@ class ChatRepositoryImpl @Inject constructor(
         apiService.unpinDialog(dialogId)
     }
 
+    override suspend fun setDialogUnread(dialogId: Long) {
+        apiService.setDialogUnread(dialogId)
+    }
+
+    override suspend fun unsetDialogUnread(dialogId: Long) {
+        apiService.unsetDialogUnread(dialogId)
+    }
+
+    override suspend fun blockDialog(dialogId: Long) {
+        apiService.blockDialog(dialogId)
+    }
+
+    override suspend fun unblockDialog(dialogId: Long) {
+        apiService.unblockDialog(dialogId)
+    }
+
+    override suspend fun clearDialog(dialogId: Long) {
+        apiService.clearDialog(dialogId)
+    }
+
+    override suspend fun deleteDialog(dialogId: Long) {
+        apiService.deleteDialog(dialogId)
+    }
+
     override suspend fun pinMessage(dialogId: Long, messageId: Long) {
         apiService.pinMessage(PinMessageRequestDto(dialogId, messageId))
     }

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -67,6 +67,24 @@ interface ChatApiService {
     @POST("chat/v1/dialogs/unpin/{dialogId}")
     suspend fun unpinDialog(@Path("dialogId") dialogId: Long)
 
+    @POST("chat/v1/dialogs/set_unread/{dialogId}")
+    suspend fun setDialogUnread(@Path("dialogId") dialogId: Long)
+
+    @POST("chat/v1/dialogs/unset_unread/{dialogId}")
+    suspend fun unsetDialogUnread(@Path("dialogId") dialogId: Long)
+
+    @POST("chat/v1/dialogs/block/{dialogId}")
+    suspend fun blockDialog(@Path("dialogId") dialogId: Long)
+
+    @POST("chat/v1/dialogs/unblock/{dialogId}")
+    suspend fun unblockDialog(@Path("dialogId") dialogId: Long)
+
+    @DELETE("chat/v1/dialogs/clear/{dialogId}")
+    suspend fun clearDialog(@Path("dialogId") dialogId: Long)
+
+    @DELETE("chat/v1/dialogs/{dialogId}")
+    suspend fun deleteDialog(@Path("dialogId") dialogId: Long)
+
     @PATCH("chat/v1/messages/update")
     suspend fun updateMessage(@Body request: UpdateMessageRequestDto): MessageDto
 

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -53,6 +53,18 @@ interface ChatRepository {
 
     suspend fun unpinDialog(dialogId: Long)
 
+    suspend fun setDialogUnread(dialogId: Long)
+
+    suspend fun unsetDialogUnread(dialogId: Long)
+
+    suspend fun blockDialog(dialogId: Long)
+
+    suspend fun unblockDialog(dialogId: Long)
+
+    suspend fun clearDialog(dialogId: Long)
+
+    suspend fun deleteDialog(dialogId: Long)
+
     suspend fun pinMessage(dialogId: Long, messageId: Long)
 
     suspend fun unpinMessage(dialogId: Long, messageId: Long)


### PR DESCRIPTION
## Summary
- support marking, blocking, and deleting dialogs via API
- wire chat functions bottom sheet to repository methods

## Testing
- `./gradlew test` (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a328a35dc08327a77fc8b817249fc0