### PR TITLE
Restore chat detail dialog navigation

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -118,7 +118,7 @@ class ChatDialogViewModel @Inject constructor(
             viewModelScope.launch {
                 _events.emit(
                     ChatDialogEvents.OpenChatProfileDetail(
-                        dialogId = 0,
+                        dialogId = currentDialogID ?: 0,
                         dialogInfo = info
                     )
                 )

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -67,13 +67,13 @@ class ChatDialogFragment : Fragment() {
             viewModel.events.collectLatest { state ->
                 when (state) {
                     is ChatDialogEvents.OpenChatProfileDetail -> {
-//                        findNavController().navigate(
-//                            R.id.chatDetailDialog,
-//                            args = Bundle().apply {
-//                                putLong(DIALOG_ID, state.dialogId)
-//                                putParcelable(DIALOG_DETAIL, state.dialogInfo)
-//                            }
-//                        )
+                        findNavController().navigate(
+                            R.id.chatDetailDialog,
+                            args = Bundle().apply {
+                                putLong(DIALOG_ID, state.dialogId)
+                                putParcelable(DIALOG_DETAIL, state.dialogInfo)
+                            }
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- navigate to chat detail dialog when tapping avatar or name
- emit correct dialog id when requesting chat detail

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32b01bc388327ad7256a52497423a