### PR TITLE
Fix crash when switching chat folders

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -78,7 +78,7 @@ fun ChatTabBar(
                 }
             }
 
-            when (uiState) {
+            when (val state = uiState) {
                 is ChatListUiState.Error -> {
 
                 }
@@ -88,8 +88,9 @@ fun ChatTabBar(
                 }
 
                 is ChatListUiState.Success -> {
+                    val chats = state.chats
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        items((uiState as ChatListUiState.Success).chats) { chat ->
+                        items(chats) { chat ->
                             ChatCard(
                                 dialogId = chat.dialogId,
                                 avatarUrl = chat.interlocutor.image,


### PR DESCRIPTION
## Summary
- avoid casting `uiState` to `Success` inside `LazyColumn`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32bfaeedc83279d05e7cd54f62f3a