### PR TITLE
Handle null content types for chat files

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -106,7 +106,7 @@ fun ChatMessageItem(
 
             message.files.firstOrNull()?.let { file ->
                 Spacer(modifier = Modifier.height(6.dp))
-                if (file.contentType.startsWith("image")) {
+                if (file.contentType?.startsWith("image") == true) {
                     Column {
                         AsyncImage(
                             model = BuildConfig.IMAGE_SERVER_URL.plus(file.path),

--- a/data/src/main/java/uddug/com/data/repositories/chat/dto/MessageDto.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/dto/MessageDto.kt
@@ -20,5 +20,5 @@ data class FileDto(
     val fileKind: Int,
     val fileName: String,
     val fileType: Int,
-    val contentType: String,
+    val contentType: String? = null,
 )

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/DialogInfoDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/DialogInfoDto.kt
@@ -22,7 +22,7 @@ data class FileDto(
     val id: String,
     val path: String,
     val fileName: String,
-    val contentType: String,
+    val contentType: String? = null,
     val fileSize: Int,
     val fileType: Int,
     val fileKind: Int,

--- a/domain/src/main/java/uddug/com/domain/entities/chat/DialogInfo.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/DialogInfo.kt
@@ -26,7 +26,7 @@ data class File(
     val id: String,
     val path: String,
     val fileName: String? = null,
-    val contentType: String,
+    val contentType: String? = null,
     val fileSize: Int? = null,
     val fileType: Int? = null,
     val fileKind: Int? = null,

--- a/domain/src/main/java/uddug/com/domain/entities/chat/MediaMessage.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/MediaMessage.kt
@@ -15,7 +15,7 @@ data class MediaFile(
     val fileKind: Int,
     val fileName: String,
     val fileType: Int,
-    val contentType: String,
+    val contentType: String? = null,
     // Опциональные поля (если их нет в JSON, будет null)
     val fileSize: Int? = null,
     val duration: String? = null,

--- a/domain/src/main/java/uddug/com/domain/entities/chat/Message.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/Message.kt
@@ -25,7 +25,7 @@ data class Attachment(
     val kind: FileKind,
     val name: String,
     val type: FileType,
-    val contentType: String
+    val contentType: String?
 )
 
 enum class MessageType {


### PR DESCRIPTION
## Summary
- Allow nullable `contentType` in chat file and attachment models
- Support nullable `contentType` in API DTOs for uploaded files
- Guard UI against missing `contentType` when rendering messages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32cd4dd4c83278f160f963361d2a7