### PR TITLE
feat: add chat detail options and media categories

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
@@ -65,7 +65,7 @@ class ChatDialogDetailViewModel @Inject constructor(
                         )
                         val voices = chatInteractor.getDialogMedia(
                             dialogInfo.id,
-                            category = 6,
+                            category = 4,
                             limit = 50,
                             page = 1,
                             query = null,
@@ -74,7 +74,7 @@ class ChatDialogDetailViewModel @Inject constructor(
                         )
                         val notes = chatInteractor.getDialogMedia(
                             dialogInfo.id,
-                            category = 7,
+                            category = 2,
                             limit = 50,
                             page = 1,
                             query = null,
@@ -90,7 +90,8 @@ class ChatDialogDetailViewModel @Inject constructor(
                             media = media,
                             files = files,
                             voices = voices,
-                            notes = notes
+                            notes = notes,
+                            dialogId = dialogInfo.id
                         )
                     }
 
@@ -99,6 +100,7 @@ class ChatDialogDetailViewModel @Inject constructor(
         }
     }
 
+    fun getCurrentUser(): UserProfileFullInfo? = currentUser
 }
 
 sealed class ChatDetailUiState {
@@ -109,6 +111,7 @@ sealed class ChatDetailUiState {
         val files: List<MediaMessage>,
         val voices: List<MediaMessage>,
         val notes: List<MediaMessage>,
+        val dialogId: Long,
     ) : ChatDetailUiState()
 
     data class Error(val message: String) : ChatDetailUiState()

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
@@ -82,6 +82,9 @@ class ChatDetailDialogFragment : Fragment() {
                         viewModel = viewModel,
                         onBackPressed = {
                             requireActivity().onBackPressed()
+                        },
+                        onNavigateToProfile = {
+                            viewModel.getCurrentUser()?.let { navigationView?.selectShowEditFragment(it) }
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -17,7 +17,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -70,10 +73,15 @@ import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatDetailUiState
+import uddug.com.naukoteka.ui.chat.compose.components.ChatDetailMoreSheetDialog
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun ChatDetailDialogComponent(viewModel: ChatDialogDetailViewModel, onBackPressed: () -> Unit) {
+fun ChatDetailDialogComponent(
+    viewModel: ChatDialogDetailViewModel,
+    onBackPressed: () -> Unit,
+    onNavigateToProfile: () -> Unit,
+) {
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -141,6 +149,7 @@ fun ChatDetailDialogComponent(viewModel: ChatDialogDetailViewModel, onBackPresse
             }
 
             is ChatDetailUiState.Success -> {
+                var showMoreDialog by remember { mutableStateOf(false) }
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
@@ -244,7 +253,7 @@ fun ChatDetailDialogComponent(viewModel: ChatDialogDetailViewModel, onBackPresse
                                         shape = RoundedCornerShape(8.dp),
                                         color = Color(0xFFF5F5F9)
                                     )
-                                    .clickable { }
+                                    .clickable { showMoreDialog = true }
                                     .padding(12.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
@@ -324,6 +333,13 @@ fun ChatDetailDialogComponent(viewModel: ChatDialogDetailViewModel, onBackPresse
                         1 -> FilesContent(state.files)
                         2 -> VoiceContent(state.voices)
                         3 -> NotesContent(state.notes)
+                    }
+                    if (showMoreDialog) {
+                        ChatDetailMoreSheetDialog(
+                            dialogId = state.dialogId,
+                            onNavigateToProfile = onNavigateToProfile,
+                            onDismissRequest = { showMoreDialog = false },
+                        )
                     }
                 }
             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
@@ -1,0 +1,80 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatFunctionsViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatDetailMoreSheetDialog(
+    dialogId: Long,
+    onNavigateToProfile: () -> Unit,
+    onDismissRequest: () -> Unit,
+    viewModel: ChatFunctionsViewModel = hiltViewModel(),
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            val items = listOf(
+                Triple(R.drawable.ic_profile, R.string.chat_go_to_profile) {
+                    onNavigateToProfile()
+                },
+                Triple(R.drawable.ic_mute, R.string.chat_disable_notifications) {
+                    viewModel.disableNotifications(dialogId)
+                },
+                Triple(R.drawable.ic_trash, R.string.chat_delete_chat) {
+                    viewModel.deleteChat(dialogId)
+                }
+            )
+            items.forEach { (iconRes, textRes, action) ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            action()
+                            onDismissRequest()
+                        }
+                        .padding(vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        painter = painterResource(id = iconRes),
+                        contentDescription = null
+                    )
+                    Spacer(modifier = Modifier.width(14.dp))
+                    Text(
+                        text = stringResource(id = textRes),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -376,6 +376,7 @@
     <string name="chat_mark_unread">Отметить непрочитанным</string>
     <string name="chat_show_attachments">Показать вложения</string>
     <string name="chat_pin">Закрепить в списке</string>
+    <string name="chat_go_to_profile">Перейти в профиль</string>
     <string name="chat_disable_notifications">Отключить уведомления</string>
     <string name="chat_select_messages">Выделить сообщения</string>
     <string name="chat_block_chat">Заблокировать чат</string>


### PR DESCRIPTION
## Summary
- fetch chat media using updated audio and notes categories
- add more actions sheet for profile, notifications and delete
- wire profile navigation from chat details

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a33248a2348327929980389f4dc095