### PR TITLE
Send selected user names as dialog name for group chat

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateMultiViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateMultiViewModel.kt
@@ -96,7 +96,11 @@ class ChatCreateMultiViewModel @Inject constructor(
                             user.id?.let { id -> id to if (current.selected.contains(id)) "37:202" else null }
                         }
                         .toMap()
-                    val dialogId = chatInteractor.createGroupDialog(userRoles)
+                    val dialogName = allUsers
+                        .filter { user -> user.id?.let { current.selected.contains(it) } == true }
+                        .mapNotNull { it.fullName }
+                        .joinToString(", ")
+                    val dialogId = chatInteractor.createGroupDialog(dialogName, userRoles)
                     _events.emit(ChatCreateMultiEvent.GroupCreated(dialogId))
                 } catch (e: Exception) {
                     _uiState.value = ChatCreateMultiUiState.Error(e.message ?: "Unknown error")

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -48,8 +48,8 @@ class ChatInteractor @Inject constructor(
 
     suspend fun createDialog(userId: Long): Long = chatRepository.createDialog(userId)
 
-    suspend fun createGroupDialog(userRoles: Map<String, String?>): Long =
-        chatRepository.createGroupDialog(dialogName = null, userRoles = userRoles)
+    suspend fun createGroupDialog(dialogName: String, userRoles: Map<String, String?>): Long =
+        chatRepository.createGroupDialog(dialogName = dialogName, userRoles = userRoles)
 
     suspend fun searchUsers(query: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo> =
         chatRepository.searchUsers(query, limit, page)


### PR DESCRIPTION
## Summary
- include dialog name built from selected users when creating group chat
- allow dialog name parameter in ChatInteractor

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a33bd6e4c08327899678385b7cfe9e