### PR TITLE
feat: add chat selection mode

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -4,9 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,18 +27,21 @@ fun ChatListComponent(
     onCreateChatClick: () -> Unit
 ) {
     var selectedDialogId by remember { mutableStateOf<Long?>(null) }
+    val isSelectionMode by viewModel.isSelectionMode.collectAsState()
+    val selectedChats by viewModel.selectedChats.collectAsState()
 
     Column(
         modifier = Modifier.fillMaxSize().background(color = Color.White)
     ) {
         ChatToolbarComponent(
             viewModel = viewModel,
-            onCreateChatClick = {
-                onCreateChatClick()
-            },
-            onBackPressed = {
-                onBackPressed()
-            }
+            onCreateChatClick = { onCreateChatClick() },
+            onBackPressed = { onBackPressed() },
+            isSelectionMode = isSelectionMode,
+            selectedCount = selectedChats.size,
+            onCloseSelection = { viewModel.clearSelection() },
+            onDeleteSelected = { viewModel.deleteSelectedChats() },
+            onMoreClick = { }
         )
         SearchField(
             title = stringResource(R.string.find_chat_message),
@@ -48,16 +52,21 @@ fun ChatListComponent(
         )
         ChatTabBar(
             viewModel = viewModel,
-            onChatLongClick = { id ->
-                selectedDialogId = id
-            }
+            onChatLongClick = { id -> selectedDialogId = id },
+            isSelectionMode = isSelectionMode,
+            selectedChats = selectedChats,
+            onChatSelect = { viewModel.toggleChatSelection(it) }
         )
     }
 
     selectedDialogId?.let { id ->
         ChatFunctionsBottomSheetDialog(
             dialogId = id,
-            onDismissRequest = { selectedDialogId = null }
+            onDismissRequest = { selectedDialogId = null },
+            onSelectMessages = {
+                viewModel.startSelection(id)
+                selectedDialogId = null
+            }
         )
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -39,6 +39,9 @@ fun ChatCard(
     isRepost: Boolean = false,
     isMedia: Boolean = false,
     isFromMe: Boolean = false,
+    selectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onSelectChange: (Boolean) -> Unit = {},
     onChatClick: (Long) -> Unit,
     onChatLongClick: (Long) -> Unit
 ) {
@@ -50,8 +53,20 @@ fun ChatCard(
             .fillMaxWidth()
             .padding(0.dp)
             .combinedClickable(
-                onClick = { onChatClick(dialogId) },
-                onLongClick = { onChatLongClick(dialogId) }
+                onClick = {
+                    if (selectionMode) {
+                        onSelectChange(!isSelected)
+                    } else {
+                        onChatClick(dialogId)
+                    }
+                },
+                onLongClick = {
+                    if (selectionMode) {
+                        onSelectChange(!isSelected)
+                    } else {
+                        onChatLongClick(dialogId)
+                    }
+                }
             ),  // Убираем отступы
         colors = CardDefaults.cardColors(containerColor = Color.White)  // Белый фон
     ) {
@@ -179,6 +194,13 @@ fun ChatCard(
                             }
                         }
                     }
+                }
+                if (selectionMode) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Checkbox(
+                        checked = isSelected,
+                        onCheckedChange = { onSelectChange(it) }
+                    )
                 }
                 // Время
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -29,6 +29,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatFunctionsViewModel
 fun ChatFunctionsBottomSheetDialog(
     dialogId: Long,
     onDismissRequest: () -> Unit,
+    onSelectMessages: () -> Unit,
     viewModel: ChatFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -52,7 +53,10 @@ fun ChatFunctionsBottomSheetDialog(
                 Triple(R.drawable.ic_attach, R.string.chat_show_attachments) { viewModel.showAttachments(dialogId) },
                 Triple(R.drawable.ic_save_post, R.string.chat_pin) { viewModel.pinChat(dialogId) },
                 Triple(R.drawable.ic_mute, R.string.chat_disable_notifications) { viewModel.disableNotifications(dialogId) },
-                Triple(R.drawable.ic_checkbox_unchecked, R.string.chat_select_messages) { viewModel.selectMessages(dialogId) },
+                Triple(R.drawable.ic_checkbox_unchecked, R.string.chat_select_messages) {
+                    viewModel.selectMessages(dialogId)
+                    onSelectMessages()
+                },
                 Triple(R.drawable.ic_lock, R.string.chat_block_chat) { viewModel.blockChat(dialogId) },
                 Triple(R.drawable.ic_trash, R.string.chat_delete_chat) { viewModel.deleteChat(dialogId) }
             )

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -21,6 +21,9 @@ import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
 fun ChatTabBar(
     viewModel: ChatListViewModel,
     onChatLongClick: (Long) -> Unit,
+    isSelectionMode: Boolean,
+    selectedChats: Set<Long>,
+    onChatSelect: (Long) -> Unit,
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
 
@@ -102,11 +105,14 @@ fun ChatTabBar(
                                 isRepost = chat.lastMessage.type == 5,
                                 isMedia = chat.lastMessage.files?.isNotEmpty() == true,
                                 isFromMe = chat.lastMessage.ownerId == "",
+                                selectionMode = isSelectionMode,
+                                isSelected = selectedChats.contains(chat.dialogId),
+                                onSelectChange = { onChatSelect(chat.dialogId) },
                                 onChatClick = {
                                     viewModel.onChatClick(it)
                                 },
                                 onChatLongClick = {
-                                    onChatLongClick(it)
+                                    if (!isSelectionMode) onChatLongClick(it) else onChatSelect(it)
                                 }
                             )
                         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarComponent.kt
@@ -27,40 +27,78 @@ fun ChatToolbarComponent(
     modifier: Modifier = Modifier,
     viewModel: ChatListViewModel,
     onBackPressed: () -> Unit,
-    onCreateChatClick: () -> Unit
+    onCreateChatClick: () -> Unit,
+    isSelectionMode: Boolean,
+    selectedCount: Int,
+    onCloseSelection: () -> Unit,
+    onDeleteSelected: () -> Unit,
+    onMoreClick: () -> Unit
 ) {
-    TopAppBar(
-        title = {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    painter = painterResource(id = R.drawable.mock_avatar),
-                    contentDescription = "User Icon",
-                    modifier = Modifier.size(36.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(text = "НауЧат", fontSize = 20.sp, color = Color.Black)
-            }
-        },
-        actions = {
-            IconButton(onClick = {
-                onCreateChatClick()
-            }) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_create_chat),
-                    contentDescription = "Edit Icon",
-                    tint = Color.Black
-                )
-            }
-            IconButton(onClick = { }) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_more_chat),
-                    contentDescription = "Edit Icon",
-                    tint = Color.Black
-                )
-            }
-        },
-        navigationIcon = null,
-        backgroundColor = Color.White,
-        elevation = 0.dp
-    )
+    if (isSelectionMode) {
+        TopAppBar(
+            title = { Text(text = selectedCount.toString(), fontSize = 20.sp, color = Color.Black) },
+            navigationIcon = {
+                IconButton(onClick = onCloseSelection) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_close),
+                        contentDescription = "Close",
+                        tint = Color.Black
+                    )
+                }
+            },
+            actions = {
+                IconButton(onClick = onDeleteSelected) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_trash),
+                        contentDescription = "Delete",
+                        tint = Color.Black
+                    )
+                }
+                IconButton(onClick = onMoreClick) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_more_chat),
+                        contentDescription = "More",
+                        tint = Color.Black
+                    )
+                }
+            },
+            backgroundColor = Color.White,
+            elevation = 0.dp
+        )
+    } else {
+        TopAppBar(
+            title = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.mock_avatar),
+                        contentDescription = "User Icon",
+                        modifier = Modifier.size(36.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = "НауЧат", fontSize = 20.sp, color = Color.Black)
+                }
+            },
+            actions = {
+                IconButton(onClick = {
+                    onCreateChatClick()
+                }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_create_chat),
+                        contentDescription = "Edit Icon",
+                        tint = Color.Black
+                    )
+                }
+                IconButton(onClick = { }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_more_chat),
+                        contentDescription = "Edit Icon",
+                        tint = Color.Black
+                    )
+                }
+            },
+            navigationIcon = null,
+            backgroundColor = Color.White,
+            elevation = 0.dp
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- add selection mode state to chat list view model
- show checkboxes and selection toolbar for multiple chat operations
- trigger selection mode from chat functions sheet

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a33e38b2ac8327bf0fd08e8aa689f9