### PR TITLE
feat: add message selection mode

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -77,6 +77,13 @@ fun ChatCard(
                     .padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                if (selectionMode) {
+                    Checkbox(
+                        checked = isSelected,
+                        onCheckedChange = { onSelectChange(it) },
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                }
                 if (avatarUrl.isNullOrEmpty()) {
 
                     val initials = name.split(" ").let {
@@ -194,13 +201,6 @@ fun ChatCard(
                             }
                         }
                     }
-                }
-                if (selectionMode) {
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Checkbox(
-                        checked = isSelected,
-                        onCheckedChange = { onSelectChange(it) }
-                    )
                 }
                 // Время
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Checkbox
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -44,6 +45,9 @@ import java.time.LocalTime // если toLocalTime() возвращает LocalT
 fun ChatMessageItem(
     message: MessageChat,
     isMine: Boolean,
+    selectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onSelectChange: () -> Unit = {},
     onLongPress: (MessageChat) -> Unit
 ) {
     Row(
@@ -51,29 +55,45 @@ fun ChatMessageItem(
             .padding(horizontal = 10.dp)
             .fillMaxWidth()
             .defaultMinSize(minWidth = 150.dp)
-            .padding(vertical = 4.dp)
-            .combinedClickable(
-                onClick = {},
-                onLongClick = { onLongPress(message) }
-            ),
-        horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start,
+            .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        if (!isMine) {
-            // Аватарка
-            Avatar(message.ownerAvatarUrl)
+        if (selectionMode) {
+            Checkbox(
+                checked = isSelected,
+                onCheckedChange = { onSelectChange() }
+            )
             Spacer(modifier = Modifier.width(8.dp))
         }
-
-        Column(
+        Row(
             modifier = Modifier
-                .background(
-                    color = if (isMine) Color(0xFF2E83D9) else Color(0xFFF5F5F9),
-                    shape = RoundedCornerShape(12.dp)
-                )
-                .padding(8.dp)
-                .widthIn(max = 300.dp)
+                .weight(1f)
+                .combinedClickable(
+                    onClick = {
+                        if (selectionMode) onSelectChange()
+                    },
+                    onLongClick = {
+                        if (selectionMode) onSelectChange() else onLongPress(message)
+                    }
+                ),
+            horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically
         ) {
+            if (!isMine) {
+                // Аватарка
+                Avatar(message.ownerAvatarUrl)
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+
+            Column(
+                modifier = Modifier
+                    .background(
+                        color = if (isMine) Color(0xFF2E83D9) else Color(0xFFF5F5F9),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .padding(8.dp)
+                    .widthIn(max = 300.dp)
+            ) {
             if (!isMine && message.ownerName?.isNotEmpty() == true) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -29,6 +29,7 @@ import uddug.com.naukoteka.mvvm.chat.MessageFunctionsViewModel
 fun MessageFunctionsBottomSheetDialog(
     message: MessageChat,
     onDismissRequest: () -> Unit,
+    onSelectMessage: () -> Unit,
     viewModel: MessageFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -51,7 +52,10 @@ fun MessageFunctionsBottomSheetDialog(
                 R.string.chat_message_reply to { viewModel.reply(message.id) },
                 R.string.chat_message_forward to { viewModel.forward(message.id) },
                 R.string.chat_message_copy to { viewModel.copy(message.id) },
-                R.string.chat_message_select to { viewModel.select(message.id) },
+                R.string.chat_message_select to {
+                    viewModel.select(message.id)
+                    onSelectMessage()
+                },
                 R.string.chat_message_show_original to { viewModel.showOriginal(message.id) },
                 R.string.chat_message_delete to { viewModel.delete(message.id) }
             )


### PR DESCRIPTION
## Summary
- show selection checkboxes on the left in chat list items
- enable selecting messages in chat dialog with a dedicated toolbar
- wire up bottom sheet action to start message selection

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a343ff15a88327a5f0c3a953106500