### PR TITLE
Fix message list layout in chat dialog

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -113,26 +113,21 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                             viewModel.onChatDetailClick()
                         }
                     )
-                    // LazyColumn будет использовать оставшееся пространство
-                    Box(
+                    // Список сообщений занимает всё оставшееся пространство экрана
+                    LazyColumn(
+                        state = scrollState,
                         modifier = Modifier
+                            .weight(1f)
                             .fillMaxWidth()
-                            .weight(1f) // Занимает оставшееся место
+                            .padding(vertical = 10.dp),
+                        reverseLayout = true,
                     ) {
-                        LazyColumn(
-                            state = scrollState,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 10.dp),
-                            reverseLayout = true,
-                        ) {
-                            items(messages) { message ->
-                                ChatMessageItem(
-                                    message,
-                                    isMine = message.isMine,
-                                    onLongPress = { selectedMessage = it }
-                                )
-                            }
+                        items(messages) { message ->
+                            ChatMessageItem(
+                                message,
+                                isMine = message.isMine,
+                                onLongPress = { selectedMessage = it }
+                            )
                         }
                     }
 


### PR DESCRIPTION
## Summary
- Ensure chat messages take up remaining space by using LazyColumn with weight

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a345dca11883279c74c60c4c452289