### PR TITLE
Show mute icon when chat notifications are disabled

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -40,6 +40,7 @@ fun ChatCard(
     isRepost: Boolean = false,
     isMedia: Boolean = false,
     isFromMe: Boolean = false,
+    isMuted: Boolean = false,
     selectionMode: Boolean = false,
     isSelected: Boolean = false,
     onSelectChange: (Boolean) -> Unit = {},
@@ -124,14 +125,16 @@ fun ChatCard(
                                 name
                             }, style = TextStyle(fontSize = 16.sp, color = Color.Black)
                         )
-                        Icon(
-                            modifier = Modifier
-                                .padding(start = 2.dp)
-                                .size(18.dp),
-                            painter = painterResource(id = R.drawable.ic_mute),
-                            contentDescription = "Media",
-                            tint = Color.Gray
-                        )
+                        if (isMuted) {
+                            Icon(
+                                modifier = Modifier
+                                    .padding(start = 2.dp)
+                                    .size(18.dp),
+                                painter = painterResource(id = R.drawable.ic_mute),
+                                contentDescription = "Muted",
+                                tint = Color.Gray
+                            )
+                        }
                     }
 
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -105,6 +105,7 @@ fun ChatTabBar(
                                 isRepost = chat.lastMessage.type == 5,
                                 isMedia = chat.lastMessage.files?.isNotEmpty() == true,
                                 isFromMe = chat.lastMessage.ownerId == "",
+                                isMuted = chat.notificationsDisable,
                                 selectionMode = isSelectionMode,
                                 isSelected = selectedChats.contains(chat.dialogId),
                                 onSelectChange = { onChatSelect(chat.dialogId) },


### PR DESCRIPTION
## Summary
- Display mute indicator for chats with disabled notifications
- Pass notification flag to chat card component

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a346c19ca08327b948c9641959cc1d