### PR TITLE
feat: add unblock chat option

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
@@ -66,6 +66,16 @@ class ChatFunctionsViewModel @Inject constructor(
         }
     }
 
+    fun unblockChat(dialogId: Long) {
+        viewModelScope.launch {
+            try {
+                chatRepository.unblockDialog(dialogId)
+            } catch (e: Exception) {
+                // handle error if needed
+            }
+        }
+    }
+
     fun deleteChat(dialogId: Long) {
         viewModelScope.launch {
             try {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
+import uddug.com.naukoteka.mvvm.chat.ChatListUiState
 import uddug.com.naukoteka.ui.chat.compose.components.ChatFunctionsBottomSheetDialog
 import uddug.com.naukoteka.ui.chat.compose.components.ChatTabBar
 import uddug.com.naukoteka.ui.chat.compose.components.ChatToolbarComponent
@@ -30,6 +31,7 @@ fun ChatListComponent(
     var selectedDialogId by remember { mutableStateOf<Long?>(null) }
     val isSelectionMode by viewModel.isSelectionMode.collectAsState()
     val selectedChats by viewModel.selectedChats.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
 
     Column(
         modifier = Modifier.fillMaxSize().background(color = Color.White)
@@ -61,8 +63,10 @@ fun ChatListComponent(
     }
 
     selectedDialogId?.let { id ->
+        val isBlocked = (uiState as? ChatListUiState.Success)?.chats?.firstOrNull { it.dialogId == id }?.isBlocked ?: false
         ChatFunctionsBottomSheetDialog(
             dialogId = id,
+            isBlocked = isBlocked,
             onDismissRequest = { selectedDialogId = null },
             onShowAttachments = onShowAttachments,
             onSelectMessages = {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -27,6 +27,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatFunctionsViewModel
 @Composable
 fun ChatFunctionsBottomSheetDialog(
     dialogId: Long,
+    isBlocked: Boolean = false,
     onDismissRequest: () -> Unit,
     onShowAttachments: (Long) -> Unit,
     onSelectMessages: () -> Unit,
@@ -41,13 +42,20 @@ fun ChatFunctionsBottomSheetDialog(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(20.dp)
+                .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 20.dp)
         ) {
             Text(
                 text = stringResource(R.string.chat_functions_title),
-                style = MaterialTheme.typography.titleMedium
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontSize = MaterialTheme.typography.titleMedium.fontSize * 1.3f
+                )
             )
-            Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(10.dp))
+            val blockItem = if (isBlocked) {
+                R.string.chat_unblock_chat to { viewModel.unblockChat(dialogId) }
+            } else {
+                R.string.chat_block_chat to { viewModel.blockChat(dialogId) }
+            }
             val items = listOf(
                 R.string.chat_mark_unread to { viewModel.markUnread(dialogId) },
                 R.string.chat_show_attachments to { onShowAttachments(dialogId) },
@@ -57,7 +65,7 @@ fun ChatFunctionsBottomSheetDialog(
                     viewModel.selectMessages(dialogId)
                     onSelectMessages()
                 },
-                R.string.chat_block_chat to { viewModel.blockChat(dialogId) },
+                blockItem,
                 R.string.chat_delete_chat to { viewModel.deleteChat(dialogId) }
             )
             items.forEach { (textRes, action) ->

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -40,13 +40,15 @@ fun MessageFunctionsBottomSheetDialog(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(20.dp)
+                .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 20.dp)
         ) {
             Text(
                 text = stringResource(R.string.message_functions_title),
-                style = MaterialTheme.typography.titleMedium
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontSize = MaterialTheme.typography.titleMedium.fontSize * 1.3f
+                )
             )
-            Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(10.dp))
             val items = listOf(
                 R.string.chat_message_reply to { viewModel.reply(message.id) },
                 R.string.chat_message_forward to { viewModel.forward(message.id) },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -380,6 +380,7 @@
     <string name="chat_disable_notifications">Отключить уведомления</string>
     <string name="chat_select_messages">Выделить сообщения</string>
     <string name="chat_block_chat">Заблокировать чат</string>
+    <string name="chat_unblock_chat">Разблокировать чат</string>
     <string name="chat_delete_chat">Удалить чат</string>
     <string name="message_functions_title">Действия с сообщением</string>
     <string name="chat_message_reply">Ответить</string>

--- a/data/src/main/java/uddug/com/data/mapper/mapChatDtoToDomain.kt
+++ b/data/src/main/java/uddug/com/data/mapper/mapChatDtoToDomain.kt
@@ -33,7 +33,8 @@ fun mapChatDtoToDomain(chatDto: ChatDto): List<Chat> {
                 )
             ),
             unreadMessages = dialog?.unreadMessages ?: 0,
-            notificationsDisable = dialog?.notificationsDisable ?: false
+            notificationsDisable = dialog?.notificationsDisable ?: false,
+            isBlocked = dialog?.isBlocked ?: false
         )
     }
 }

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/ChatDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/ChatDto.kt
@@ -30,6 +30,7 @@ data class DialogDto(
     val lastMessage: MessageDto,
     val unreadMessages: Int,
     val notificationsDisable: Boolean,
+    val isBlocked: Boolean = false,
 )
 
 data class UserDto(

--- a/domain/src/main/java/uddug/com/domain/entities/chat/Chat.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/Chat.kt
@@ -17,6 +17,7 @@ data class Chat(
     val lastMessage: Message,
     val unreadMessages: Int,
     val notificationsDisable: Boolean,
+    val isBlocked: Boolean,
 )
 
 @Parcelize


### PR DESCRIPTION
## Summary
- show unblock option when chat is blocked
- wire API call for unblocking a chat
- enlarge sheet dialog headers and reduce top padding

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-stdlib:2.0.20)*

------
https://chatgpt.com/codex/tasks/task_e_68a345a51c548327a3c06acdddae9acb