### PR TITLE
Add unread badge and pin icon to chat list

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -40,6 +40,8 @@ fun ChatCard(
     isRepost: Boolean = false,
     isMedia: Boolean = false,
     isFromMe: Boolean = false,
+    notificationsDisable: Boolean = false,
+    isPinned: Boolean = false,
     selectionMode: Boolean = false,
     isSelected: Boolean = false,
     onSelectChange: (Boolean) -> Unit = {},
@@ -124,14 +126,16 @@ fun ChatCard(
                                 name
                             }, style = TextStyle(fontSize = 16.sp, color = Color.Black)
                         )
-                        Icon(
-                            modifier = Modifier
-                                .padding(start = 2.dp)
-                                .size(18.dp),
-                            painter = painterResource(id = R.drawable.ic_mute),
-                            contentDescription = "Media",
-                            tint = Color.Gray
-                        )
+                        if (notificationsDisable) {
+                            Icon(
+                                modifier = Modifier
+                                    .padding(start = 2.dp)
+                                    .size(18.dp),
+                                painter = painterResource(id = R.drawable.ic_mute),
+                                contentDescription = "Media",
+                                tint = Color.Gray
+                            )
+                        }
                     }
 
 
@@ -169,22 +173,33 @@ fun ChatCard(
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.End
                 ) {
-                    Text(
-                        text = formattedTime,
-                        style = TextStyle(fontSize = 12.sp, color = Color.Gray),
-                        modifier = Modifier
-                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        if (isPinned) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_chat_pin),
+                                contentDescription = "Pinned",
+                                tint = Color(0xFF2E83D9),
+                                modifier = Modifier
+                                    .size(16.dp)
+                                    .padding(end = 2.dp)
+                            )
+                        }
+                        Text(
+                            text = formattedTime,
+                            style = TextStyle(fontSize = 12.sp, color = Color.Gray),
+                        )
+                    }
 
                     // Число новых сообщений
                     newMessagesCount?.let {
                         if (it > 0) {
+                            val circleColor = if (notificationsDisable) Color.Gray else Color(0xFF2E83D9)
                             Box(
-
                                 contentAlignment = Alignment.Center,
                                 modifier = Modifier
                                     .padding(top = 4.dp)
                                     .size(24.dp)
-                                    .background(Color(0xFF2E83D9), CircleShape)
+                                    .background(circleColor, CircleShape)
                             ) {
                                 Text(
                                     text = it.toString(),

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -105,6 +105,8 @@ fun ChatTabBar(
                                 isRepost = chat.lastMessage.type == 5,
                                 isMedia = chat.lastMessage.files?.isNotEmpty() == true,
                                 isFromMe = chat.lastMessage.ownerId == "",
+                                notificationsDisable = chat.notificationsDisable,
+                                isPinned = chat.isPinned,
                                 selectionMode = isSelectionMode,
                                 isSelected = selectedChats.contains(chat.dialogId),
                                 onSelectChange = { onChatSelect(chat.dialogId) },

--- a/app/src/main/res/drawable/ic_chat_pin.xml
+++ b/app/src/main/res/drawable/ic_chat_pin.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2 L15,8 H13 V16 L15,18 V19 H9 V18 L11,16 V8 H9 Z"/>
+</vector>


### PR DESCRIPTION
## Summary
- show unread message count badge with mute-aware color
- display pin icon for pinned chats
- add pin vector asset and pass mute/pin flags to chat card

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a34769dea08327b25d511fd61fe7d9