### PR TITLE
Handle user search response wrapper

### DIFF
--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -212,7 +212,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     override suspend fun searchUsers(searchField: String, limit: Int, page: Int): List<UserProfileFullInfo> {
         return try {
-            apiService.searchUsers(searchField, limit, page).map { it.toDomain() }
+            apiService.searchUsers(searchField, limit, page).users.map { it.toDomain() }
         } catch (e: Exception) {
             println("search users error ${e.message}")
             emptyList()

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -24,6 +24,7 @@ import uddug.com.data.services.models.response.chat.UserStatusDto
 import uddug.com.data.services.models.response.chat.MessageDto
 import uddug.com.data.services.models.response.chat.FileDto
 import uddug.com.data.services.models.response.user_profile.UserProfileFullInfoDto
+import uddug.com.data.services.models.response.chat.SearchUsersDto
 import uddug.com.domain.entities.chat.MediaMessage
 
 interface ChatApiService {
@@ -126,7 +127,7 @@ interface ChatApiService {
         @Query("searchField") searchField: String,
         @Query("limit") limit: Int = 10,
         @Query("page") page: Int = 1,
-    ): List<UserProfileFullInfoDto>
+    ): SearchUsersDto
 
     @POST("chat/v1/users/status")
     suspend fun getUsersStatus(@Body request: UsersStatusRequestDto): List<UserStatusDto>

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/SearchUsersDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/SearchUsersDto.kt
@@ -1,0 +1,8 @@
+package uddug.com.data.services.models.response.chat
+
+import uddug.com.data.services.models.response.user_profile.UserProfileFullInfoDto
+
+data class SearchUsersDto(
+    val users: List<UserProfileFullInfoDto>,
+    val count: Int
+)


### PR DESCRIPTION
## Summary
- parse user search API response object instead of expecting array
- add SearchUsersDto and map to domain

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :data:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3491feb9c83279a9e26c8994f6d06