### PR TITLE
Fix chat dialog message order and visuals

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -135,7 +135,7 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                                 }
                             },
                             backgroundColor = Color.White,
-                            elevation = 0.dp
+                            elevation = 4.dp
                         )
                     } else {
                         ChatTopBar(
@@ -155,8 +155,7 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                         modifier = Modifier
                             .weight(1f)
                             .fillMaxWidth()
-                            .padding(vertical = 10.dp),
-                        reverseLayout = true,
+                            .padding(vertical = 10.dp)
                     ) {
                         items(messages) { message ->
                             ChatMessageItem(
@@ -180,7 +179,7 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                         onSendClick = {
                             scope.launch {
                                 viewModel.sendMessage(state.currentMessage)
-                                scrollState.animateScrollToItem(0)
+                                scrollState.animateScrollToItem(messages.size - 1)
                                 // keyboardController?.hide()
                             }
                         },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -1,9 +1,9 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,22 +14,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Checkbox
+import androidx.compose.material.CheckboxDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Menu
-
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -37,8 +35,6 @@ import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.naukoteka.BuildConfig
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.time.LocalTime // если toLocalTime() возвращает LocalTime
-
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -61,7 +57,11 @@ fun ChatMessageItem(
         if (selectionMode) {
             Checkbox(
                 checked = isSelected,
-                onCheckedChange = { onSelectChange() }
+                onCheckedChange = { onSelectChange() },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = Color(0xFF2E83D9),
+                    uncheckedColor = Color(0xFF2E83D9)
+                )
             )
             Spacer(modifier = Modifier.width(8.dp))
         }
@@ -69,6 +69,8 @@ fun ChatMessageItem(
             modifier = Modifier
                 .weight(1f)
                 .combinedClickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
                     onClick = {
                         if (selectionMode) onSelectChange()
                     },
@@ -77,7 +79,7 @@ fun ChatMessageItem(
                     }
                 ),
             horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start,
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             if (!isMine) {
                 // Аватарка
@@ -94,67 +96,67 @@ fun ChatMessageItem(
                     .padding(8.dp)
                     .widthIn(max = 300.dp)
             ) {
-            if (!isMine && message.ownerName?.isNotEmpty() == true) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = message.ownerName.orEmpty(),
-                        color = Color(0xFF2E83D9),
-                        fontSize = 14.sp
-                    )
-                    if (message.ownerIsAdmin) {
-                        Spacer(modifier = Modifier.width(6.dp))
+                if (!isMine && message.ownerName?.isNotEmpty() == true) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = "админ",
-                            fontSize = 10.sp,
-                            color = Color.Gray
+                            text = message.ownerName.orEmpty(),
+                            color = Color(0xFF2E83D9),
+                            fontSize = 14.sp
                         )
-                    }
-                }
-            }
-
-            if (message.replyTo != null) {
-                ReplyBlock(message.replyTo!!)
-                Spacer(modifier = Modifier.height(4.dp))
-            }
-            if (!message.text.isNullOrBlank()) {
-                Text(
-                    text = message.text.orEmpty(),
-                    color = if (isMine) Color.White else Color.Black,
-                    fontSize = 14.sp
-                )
-            }
-
-            message.files.firstOrNull()?.let { file ->
-                Spacer(modifier = Modifier.height(6.dp))
-                if (file.contentType?.startsWith("image") == true) {
-                    Column {
-                        AsyncImage(
-                            model = BuildConfig.IMAGE_SERVER_URL.plus(file.path),
-                            contentDescription = "image",
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier
-                                .clip(RoundedCornerShape(12.dp))
-                                .fillMaxWidth()
-                                .height(140.dp)
-                        )
-                        if (file.fileName != null) {
+                        if (message.ownerIsAdmin) {
+                            Spacer(modifier = Modifier.width(6.dp))
                             Text(
-                                modifier = Modifier.padding(top = 4.dp),
-                                text = file.fileName.orEmpty(),
-                                fontSize = 12.sp,
-                                color = Color.White
+                                text = "админ",
+                                fontSize = 10.sp,
+                                color = Color.Gray
                             )
                         }
                     }
-                } else {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Default.Menu, contentDescription = "PDF", tint = Color.White)
-                        Spacer(Modifier.width(8.dp))
-                        Text("Медиа Сообщение", fontSize = 12.sp, color = Color.White)
+                }
+
+                if (message.replyTo != null) {
+                    ReplyBlock(message.replyTo!!)
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+                if (!message.text.isNullOrBlank()) {
+                    Text(
+                        text = message.text.orEmpty(),
+                        color = if (isMine) Color.White else Color.Black,
+                        fontSize = 14.sp
+                    )
+                }
+
+                message.files.firstOrNull()?.let { file ->
+                    Spacer(modifier = Modifier.height(6.dp))
+                    if (file.contentType?.startsWith("image") == true) {
+                        Column {
+                            AsyncImage(
+                                model = BuildConfig.IMAGE_SERVER_URL.plus(file.path),
+                                contentDescription = "image",
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .fillMaxWidth()
+                                    .height(140.dp)
+                            )
+                            file.fileName?.let { name ->
+                                Text(
+                                    modifier = Modifier.padding(top = 4.dp),
+                                    text = name,
+                                    fontSize = 12.sp,
+                                    color = Color.White
+                                )
+                            }
+                        }
+                    } else {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(Icons.Default.Menu, contentDescription = "PDF", tint = Color.White)
+                            Spacer(Modifier.width(8.dp))
+                            Text("Медиа Сообщение", fontSize = 12.sp, color = Color.White)
+                        }
                     }
                 }
-            }
-            if (message.ownerName?.isNotEmpty() == true) {
+
                 Text(
                     text = LocalDateTime.parse(
                         message.createdAt.toString().substringBeforeLast('.'),
@@ -165,7 +167,7 @@ fun ChatMessageItem(
                     modifier = Modifier.align(Alignment.End)
                 )
             }
-
         }
     }
 }
+

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
@@ -12,11 +12,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
@@ -27,7 +26,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -43,89 +41,93 @@ fun ChatTopBar(
     onDetailClick: () -> Unit,
     onBackPressed: () -> Unit,
 ) {
-    Column {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 16.dp, horizontal = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = { onBackPressed() }) {
-                Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color(0xFF2E83D9))
-            }
-            if (image.isNotEmpty()) {
-                AsyncImage(
-                    model = BuildConfig.IMAGE_SERVER_URL.plus(image),
-                    contentDescription = "image",
-                    contentScale = ContentScale.Crop,
+    Surface(elevation = 4.dp) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp, horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { onBackPressed() }) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color(0xFF2E83D9))
+                }
+                if (image.isNotEmpty()) {
+                    AsyncImage(
+                        model = BuildConfig.IMAGE_SERVER_URL.plus(image),
+                        contentDescription = "image",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .clip(CircleShape)
+                            .size(36.dp)
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                onDetailClick()
+                            }
+                    )
+                } else {
+                    val firstLetter = name.firstOrNull()?.uppercase() ?: ""
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape)
+                            .background(Color(0xFF2E83D9))
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                onDetailClick()
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = firstLetter,
+                            color = Color.White,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+                Column(
                     modifier = Modifier
-                        .clip(CircleShape)
-                        .size(36.dp)
+                        .padding(start = 16.dp)
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null
                         ) {
                             onDetailClick()
                         }
-                )
-            } else {
-                val firstLetter = name.firstOrNull()?.uppercase() ?: ""
-                Box(
-                    modifier = Modifier
-                        .size(36.dp)
-                        .clip(CircleShape)
-                        .background(Color(0xFF2E83D9))
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            onDetailClick()
-                        },
-                    contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = firstLetter,
-                        color = Color.White,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
-            }
-            Column(modifier = Modifier
-                .padding(start = 16.dp)
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null
-                ) {
-                    onDetailClick()
-                }) {
-                Text(
-                    text = name,
-                    color = Color.Black,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 16.sp
-                )
-                status?.let {
-                    Text(
-                        text = it,
-                        color = Color(0xFF8083A0),
+                        text = name,
+                        color = Color.Black,
+                        fontWeight = FontWeight.Bold,
                         fontSize = 16.sp
                     )
+                    status?.let {
+                        Text(
+                            text = it,
+                            color = Color(0xFF8083A0),
+                            fontSize = 16.sp
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                IconButton(onClick = { }) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "More", tint = Color(0xFF2E83D9))
                 }
             }
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            IconButton(onClick = { }) {
-                Icon(Icons.Default.MoreVert, contentDescription = "More", tint = Color(0xFF2E83D9))
-            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Color(0xFFEAEAF2))
+            )
         }
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(1.dp)
-                .background(Color(0xFFEAEAF2))
-        )
     }
-
 }
+


### PR DESCRIPTION
## Summary
- remove ripple from chat messages and align checkbox color with list
- show timestamp on user messages and display messages top-down
- restore toolbar shadow

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a34d0102208327aa92826f7e2048eb