### PR TITLE
Refresh chat after disabling notifications

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -66,6 +66,25 @@ class ChatListViewModel @Inject constructor(
         loadChats(currentFolderId)
     }
 
+    fun updateDialogNotifications(dialogId: Long, disabled: Boolean) {
+        viewModelScope.launch {
+            try {
+                chatRepository.getDialogInfo(dialogId)
+                _uiState.update { state ->
+                    if (state is ChatListUiState.Success) {
+                        val updatedChats = state.chats.map { chat ->
+                            if (chat.dialogId == dialogId) {
+                                chat.copy(notificationsDisable = disabled)
+                            } else chat
+                        }
+                        ChatListUiState.Success(updatedChats)
+                    } else state
+                }
+            } catch (_: Exception) {
+            }
+        }
+    }
+
     fun onFolderSelected(folderId: Long) {
         loadChats(folderId)
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -72,6 +72,9 @@ fun ChatListComponent(
             onSelectMessages = {
                 viewModel.startSelection(id)
                 selectedDialogId = null
+            },
+            onNotificationsChange = { dialogId, disabled ->
+                viewModel.updateDialogNotifications(dialogId, disabled)
             }
         )
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -31,6 +31,7 @@ fun ChatFunctionsBottomSheetDialog(
     onDismissRequest: () -> Unit,
     onShowAttachments: (Long) -> Unit,
     onSelectMessages: () -> Unit,
+    onNotificationsChange: (Long, Boolean) -> Unit = { _, _ -> },
     viewModel: ChatFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -60,7 +61,10 @@ fun ChatFunctionsBottomSheetDialog(
                 R.string.chat_mark_unread to { viewModel.markUnread(dialogId) },
                 R.string.chat_show_attachments to { onShowAttachments(dialogId) },
                 R.string.chat_pin to { viewModel.pinChat(dialogId) },
-                R.string.chat_disable_notifications to { viewModel.disableNotifications(dialogId) },
+                R.string.chat_disable_notifications to {
+                    viewModel.disableNotifications(dialogId)
+                    onNotificationsChange(dialogId, true)
+                },
                 R.string.chat_select_messages to {
                     viewModel.selectMessages(dialogId)
                     onSelectMessages()


### PR DESCRIPTION
## Summary
- trigger chat info refresh after muting a dialog
- propagate notification changes from chat actions to chat list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a34dfb560083278694c757b97b4cc5