### PR TITLE
Fix single chat creation user click

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
@@ -83,10 +83,11 @@ class ChatCreateSingleViewModel @Inject constructor(
         }
     }
 
-    fun onUserClick(userId: Long) {
+    fun onUserClick(userId: String) {
         viewModelScope.launch {
             try {
-                val dialogId = chatInteractor.createDialog(userId)
+                val id = userId.toLongOrNull() ?: throw IllegalArgumentException("Invalid user id")
+                val dialogId = chatInteractor.createDialog(id)
                 _events.emit(ChatCreateSingleEvent.OpenDialogDetail(dialogId))
             } catch (e: Exception) {
                 _uiState.value = ChatCreateSingleUiState.Error(e.message ?: "Unknown error")

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
@@ -81,7 +81,7 @@ fun ChatCreateSingleScreen(
                                 avatarUrl = user.image?.path.orEmpty(),
                                 time = "",
                                 onMemberClick = {
-                                    user.id?.toLongOrNull()?.let { viewModel.onUserClick(it) }
+                                    user.id?.let { viewModel.onUserClick(it) }
                                 },
                                 showCheckbox = false,
                             )
@@ -125,7 +125,7 @@ fun ChatCreateSingleScreen(
                             avatarUrl = user.image?.path.orEmpty(),
                             time = "",
                             onMemberClick = {
-                                user.id?.toLongOrNull()?.let { viewModel.onUserClick(it) }
+                                user.id?.let { viewModel.onUserClick(it) }
                             },
                             showCheckbox = false,
                         )


### PR DESCRIPTION
## Summary
- make member click in single chat creation trigger dialog creation
- handle invalid user id in single chat creation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a34f2ec3388327ba9b204acd7b814a