### PR TITLE
Fix selection mode checkbox alignment

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -82,11 +82,17 @@ fun ChatCard(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 if (selectionMode) {
-                    Checkbox(
-                        checked = isSelected,
-                        onCheckedChange = { onSelectChange(it) },
-                        modifier = Modifier.padding(end = 8.dp)
-                    )
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .padding(end = 8.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Checkbox(
+                            checked = isSelected,
+                            onCheckedChange = { onSelectChange(it) }
+                        )
+                    }
                 }
                 if (avatarUrl.isNullOrEmpty()) {
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -55,15 +56,21 @@ fun ChatMessageItem(
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (selectionMode) {
-            Checkbox(
-                checked = isSelected,
-                onCheckedChange = { onSelectChange() },
-                colors = CheckboxDefaults.colors(
-                    checkedColor = Color(0xFF2E83D9),
-                    uncheckedColor = Color(0xFF2E83D9)
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .padding(end = 8.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Checkbox(
+                    checked = isSelected,
+                    onCheckedChange = { onSelectChange() },
+                    colors = CheckboxDefaults.colors(
+                        checkedColor = Color(0xFF2E83D9),
+                        uncheckedColor = Color(0xFF2E83D9)
+                    )
                 )
-            )
-            Spacer(modifier = Modifier.width(8.dp))
+            }
         }
         Row(
             modifier = Modifier


### PR DESCRIPTION
## Summary
- keep selection checkboxes centered next to avatars in chat list and message items
- prevent card height jump when toggling selection mode

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a352a80b848327bafd6a81459155e5