### PR TITLE
Fix chat dialog selection layout and checkbox colors

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -90,7 +90,12 @@ fun ChatCard(
                     ) {
                         Checkbox(
                             checked = isSelected,
-                            onCheckedChange = { onSelectChange(it) }
+                            onCheckedChange = { onSelectChange(it) },
+                            colors = CheckboxDefaults.colors(
+                                checkedColor = Color(0xFF2E83D9),
+                                uncheckedColor = Color(0xFF2E83D9),
+                                checkmarkColor = Color.White
+                            )
                         )
                     }
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -52,29 +51,26 @@ fun ChatMessageItem(
             .padding(horizontal = 10.dp)
             .fillMaxWidth()
             .defaultMinSize(minWidth = 150.dp)
-            .padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .padding(vertical = 4.dp)
+            .animateContentSize(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start
     ) {
-        if (selectionMode) {
-            Box(
-                modifier = Modifier
-                    .size(36.dp)
-                    .padding(end = 8.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Checkbox(
-                    checked = isSelected,
-                    onCheckedChange = { onSelectChange() },
-                    colors = CheckboxDefaults.colors(
-                        checkedColor = Color(0xFF2E83D9),
-                        uncheckedColor = Color(0xFF2E83D9)
-                    )
+        if (!isMine && selectionMode) {
+            Checkbox(
+                checked = isSelected,
+                onCheckedChange = { onSelectChange() },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = Color(0xFF2E83D9),
+                    uncheckedColor = Color(0xFF2E83D9),
+                    checkmarkColor = Color.White
                 )
-            }
+            )
+            Spacer(modifier = Modifier.width(8.dp))
         }
         Row(
             modifier = Modifier
-                .weight(1f)
+                .weight(1f, fill = false)
                 .combinedClickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
@@ -175,6 +171,18 @@ fun ChatMessageItem(
                 )
             }
 
+        }
+        if (isMine && selectionMode) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Checkbox(
+                checked = isSelected,
+                onCheckedChange = { onSelectChange() },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = Color(0xFF2E83D9),
+                    uncheckedColor = Color(0xFF2E83D9),
+                    checkmarkColor = Color.White
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent message cards from jumping when selecting by adjusting layout and adding animation
- use consistent blue checkboxes in chat list and dialog

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3578d2d9483278a794dee13b60653