### PR TITLE
Fix single chat creation from search results

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
@@ -83,11 +83,10 @@ class ChatCreateSingleViewModel @Inject constructor(
         }
     }
 
-    fun onUserClick(userId: String) {
+    fun onUserClick(userId: Long) {
         viewModelScope.launch {
             try {
-                val id = userId.toLongOrNull() ?: throw IllegalArgumentException("Invalid user id")
-                val dialogId = chatInteractor.createDialog(id)
+                val dialogId = chatInteractor.createDialog(userId)
                 _events.emit(ChatCreateSingleEvent.OpenDialogDetail(dialogId))
             } catch (e: Exception) {
                 _uiState.value = ChatCreateSingleUiState.Error(e.message ?: "Unknown error")

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
@@ -81,7 +81,7 @@ fun ChatCreateSingleScreen(
                                 avatarUrl = user.image?.path.orEmpty(),
                                 time = "",
                                 onMemberClick = {
-                                    user.id?.let { viewModel.onUserClick(it) }
+                                    user.id?.toLongOrNull()?.let { viewModel.onUserClick(it) }
                                 },
                                 showCheckbox = false,
                             )
@@ -125,7 +125,7 @@ fun ChatCreateSingleScreen(
                             avatarUrl = user.image?.path.orEmpty(),
                             time = "",
                             onMemberClick = {
-                                user.id?.let { viewModel.onUserClick(it) }
+                                user.id?.toLongOrNull()?.let { viewModel.onUserClick(it) }
                             },
                             showCheckbox = false,
                         )


### PR DESCRIPTION
## Summary
- Convert search result user IDs to `Long` before invoking `onUserClick`
- Update `ChatCreateSingleViewModel` to accept `Long` user IDs and create dialog directly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a41e1e960c832795a8f138efaf3355