### PR TITLE
Add create dialog API request

### DIFF
--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepository.kt
@@ -5,6 +5,7 @@ import uddug.com.data.mapper.mapChatDtoToDomain
 import uddug.com.data.mapper.mapUserStatusDtoToDomain
 
 import uddug.com.data.services.chat.ChatApiService
+import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.response.chat.DialogInfoDto
 import uddug.com.data.services.models.response.chat.mapDialogInfoDtoToDomain
 import uddug.com.domain.entities.chat.Chat
@@ -25,6 +26,12 @@ interface ChatRepository {
     ): List<MessageChat>
 
     suspend fun getDialogInfo(dialogId: Long): DialogInfo
+    suspend fun createDialog(
+        firstUserId: String,
+        firstUserLastName: String,
+        secondUserId: String,
+        secondUserLastName: String,
+    ): DialogInfo
     suspend fun getMessagesWithOwnerInfo(
         currentUserId: String,
         dialogId: Long,
@@ -78,6 +85,28 @@ class ChatRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             println("Error getting dialog info: ${e.message}")
             throw e // or return default DialogInfo
+        }
+    }
+
+    override suspend fun createDialog(
+        firstUserId: String,
+        firstUserLastName: String,
+        secondUserId: String,
+        secondUserLastName: String,
+    ): DialogInfo {
+        return try {
+            val request = CreateDialogRequestDto(
+                dialogName = "$firstUserLastName $secondUserLastName",
+                userRoles = mapOf(
+                    firstUserId to "37:202",
+                    secondUserId to "37:203"
+                )
+            )
+            val dialogInfoDto = apiService.createDialog(request)
+            mapDialogInfoDtoToDomain(dialogInfoDto)
+        } catch (e: Exception) {
+            println("Error creating dialog: ${e.message}")
+            throw e
         }
     }
 

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -1,20 +1,26 @@
 package uddug.com.data.services.chat
 
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
+import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.response.chat.ChatDto
 import uddug.com.data.services.models.response.chat.DialogInfoDto
 import uddug.com.data.services.models.response.chat.MessageDto
 import uddug.com.data.services.models.response.chat.UserStatusDto
-import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
-import uddug.com.domain.entities.chat.MessageChat
 
 interface ChatApiService {
 
     @GET("chat/v1/dialogs")
     suspend fun getDialogs(): ChatDto
+
+    @POST("chat/v1/dialogs")
+    suspend fun createDialog(
+        @Body request: CreateDialogRequestDto,
+    ): DialogInfoDto
 
     @GET("chat/v1/dialogs/{dialogId}")
     suspend fun getMessages(

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/CreateDialogRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/CreateDialogRequestDto.kt
@@ -1,0 +1,25 @@
+package uddug.com.data.services.models.request.chat
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Request body for creating a dialog in chat service.
+ */
+data class CreateDialogRequestDto(
+    @SerializedName("dialogName")
+    val dialogName: String,
+    @SerializedName("dialogImage")
+    val dialogImage: DialogImageDto? = null,
+    @SerializedName("userRoles")
+    val userRoles: Map<String, String>,
+)
+
+/**
+ * Represents dialog image information for create dialog request.
+ */
+data class DialogImageDto(
+    @SerializedName("id")
+    val id: String,
+    @SerializedName("fileType")
+    val fileType: Int,
+)


### PR DESCRIPTION
## Summary
- add `CreateDialogRequestDto` for specifying dialog name, image and user roles
- extend `ChatApiService` and `ChatRepository` to support creating dialogs for two users

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a426968d648327b58c43239e9dcdf6