### PR TITLE
Refactor dialog creation API to send participants data

### DIFF
--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -115,9 +115,18 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun createDialog(userId: String): Long {
+    override suspend fun createDialog(
+        dialogName: String?,
+        userRoles: Map<String, String?>,
+        imageId: String?,
+    ): Long {
         return try {
-            val dialog = apiService.createDialog(userId)
+            val request = CreateDialogRequestDto(
+                dialogName = dialogName,
+                dialogImage = imageId?.let { DialogImageRequestDto(it) },
+                userRoles = userRoles,
+            )
+            val dialog = apiService.createDialog(request)
             dialog.id
         } catch (e: Exception) {
             println("Error creating dialog: ${e.message}")

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -58,9 +58,9 @@ interface ChatApiService {
         @Query("ed") ed: String? = null,
     ): List<MediaMessage>
 
-    @POST("chat/v1/dialogs/{userId}")
+    @POST("chat/v1/dialogs")
     suspend fun createDialog(
-        @Path("userId") userId: String,
+        @Body request: CreateDialogRequestDto,
     ): DialogInfoDto
 
     @POST("chat/v2/dialogs/create")

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/CreateDialogRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/CreateDialogRequestDto.kt
@@ -9,5 +9,6 @@ data class CreateDialogRequestDto(
 )
 
 data class DialogImageRequestDto(
-    @SerializedName("id") val id: String
+    @SerializedName("id") val id: String,
+    @SerializedName("fileType") val fileType: Int = 0,
 )

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -47,7 +47,8 @@ class ChatInteractor @Inject constructor(
     ): List<MediaMessage> =
         chatRepository.getDialogMedia(dialogId, category, limit, page, query, sd, ed)
 
-    suspend fun createDialog(userId: String): Long = chatRepository.createDialog(userId)
+    suspend fun createDialog(dialogName: String?, userRoles: Map<String, String?>): Long =
+        chatRepository.createDialog(dialogName = dialogName, userRoles = userRoles)
 
     suspend fun createGroupDialog(dialogName: String, userRoles: Map<String, String?>): Long =
         chatRepository.createGroupDialog(dialogName = dialogName, userRoles = userRoles)

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -41,7 +41,11 @@ interface ChatRepository {
         ed: String?,
     ): List<MediaMessage>
 
-    suspend fun createDialog(userId: String): Long
+    suspend fun createDialog(
+        dialogName: String?,
+        userRoles: Map<String, String?>,
+        imageId: String? = null,
+    ): Long
 
     suspend fun createGroupDialog(
         dialogName: String?,


### PR DESCRIPTION
## Summary
- update chat API to accept dialog creation payload with participant roles
- build dialog name from both participants in single-chat creation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42b4c1b9c832792e39562fdea1f43