### PR TITLE
Fix hilt compile failure by keeping JetBrains annotations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,11 +95,6 @@ android {
     namespace 'uddug.com.naukoteka'
 }
 
-configurations {
-    cleanedAnnotations
-    implementation.exclude group: 'org.jetbrains', module: 'annotations'
-}
-
 dependencies {
     // Основные зависимости
     implementation presentation.kotlin


### PR DESCRIPTION
## Summary
- Remove global exclusion of JetBrains annotations to allow Hilt annotation processing to resolve @NotNull

## Testing
- `./gradlew app:hiltJavaCompileDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4309bf2448327a2dd439ec325b33c