### PR TITLE
Add JetBrains annotations dependency to fix Hilt build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     implementation ui.lifecycle
     implementation ui.lifecycleCommon
     implementation ui.localeChanger
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 
     // MVVM и Compose зависимости
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2"


### PR DESCRIPTION
## Summary
- Add JetBrains annotations compileOnly dependency so Hilt's generated components can resolve `@NotNull`

## Testing
- `./gradlew app:hiltJavaCompileDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4333e868c8327b1c8c061ff6cc900