### PR TITLE
Use device timezone for chat message times

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/core/deeplink/Extensions.kt
+++ b/app/src/main/java/uddug/com/naukoteka/core/deeplink/Extensions.kt
@@ -11,10 +11,8 @@ import androidx.core.content.ContextCompat
 import uddug.com.naukoteka.R
 import java.net.URLDecoder
 import java.net.URLEncoder
-import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
-import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 private const val ENCODING_SYSTEM = "utf-8"
@@ -50,7 +48,8 @@ fun Context.launchCustomTabsByUrl(
 
 fun formatMessageTime(time: String): String {
     val messageDate = ZonedDateTime.parse(time, DateTimeFormatter.ISO_DATE_TIME)
-    val currentDate = ZonedDateTime.now(ZoneOffset.UTC)
+        .withZoneSameInstant(ZoneId.systemDefault())
+    val currentDate = ZonedDateTime.now(ZoneId.systemDefault())
 
     return when {
         messageDate.toLocalDate().isEqual(currentDate.toLocalDate()) -> {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.naukoteka.BuildConfig
-import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -163,10 +163,10 @@ fun ChatMessageItem(
                 }
 
                 Text(
-                    text = LocalDateTime.parse(
-                        message.createdAt.toString().substringBeforeLast('.'),
-                        DateTimeFormatter.ISO_LOCAL_DATE_TIME
-                    ).format(DateTimeFormatter.ofPattern("HH:mm")),
+                    text = DateTimeFormatter
+                        .ofPattern("HH:mm")
+                        .withZone(ZoneId.systemDefault())
+                        .format(message.createdAt),
                     fontSize = 10.sp,
                     color = if (isMine) Color.White.copy(alpha = 0.8f) else Color.Gray,
                     modifier = Modifier.align(Alignment.End)


### PR DESCRIPTION
## Summary
- respect the user's timezone when rendering message timestamps in chat items
- adjust chat card time formatter to convert timestamps to the device's timezone

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a43f48dc108327ac071131ff5bcc34