### PR TITLE
feat: open chat via interlocutor lookup

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
@@ -21,7 +21,7 @@ import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatCreateSingleEvent
 import uddug.com.naukoteka.mvvm.chat.ChatCreateSingleViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
-import uddug.com.naukoteka.ui.chat.ChatDialogFragment.Companion.DIALOG_ID
+import uddug.com.naukoteka.ui.chat.ChatDialogFragment.Companion.INTERLOCUTOR_ID
 import uddug.com.naukoteka.ui.chat.compose.ChatCreateSingleScreen
 
 @AndroidEntryPoint
@@ -57,7 +57,7 @@ class ChatCreateSingleFragment : Fragment() {
                         navController.getBackStackEntry(R.id.chatListFragment).savedStateHandle["refreshChats"] = true
                         navController.navigate(
                             R.id.chatDialogFragment,
-                            Bundle().apply { putLong(DIALOG_ID, state.dialogId) },
+                            Bundle().apply { putString(INTERLOCUTOR_ID, state.interlocutorId) },
                             navOptions {
                                 popUpTo(R.id.chatCreateSingleFragment) { inclusive = true }
                             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -47,12 +47,19 @@ class ChatDialogFragment : Fragment() {
 
     companion object {
         const val DIALOG_ID = "DIALOG_ID"
+        const val INTERLOCUTOR_ID = "INTERLOCUTOR_ID"
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
-        viewModel.loadMessages(arguments?.getLong(DIALOG_ID) ?: 0)
+        val dialogId = arguments?.getLong(DIALOG_ID) ?: 0
+        val peerId = arguments?.getString(INTERLOCUTOR_ID)
+        if (dialogId != 0L) {
+            viewModel.loadMessages(dialogId)
+        } else if (!peerId.isNullOrEmpty()) {
+            viewModel.loadMessagesByPeer(peerId)
+        }
     }
 
     private fun setupObservers() {

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -89,6 +89,16 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getDialogInfoByPeer(interlocutorId: String): DialogInfo {
+        return try {
+            val dialogInfoDto = apiService.getDialogInfoByPeer(interlocutorId)
+            mapDialogInfoDtoToDomain(dialogInfoDto)
+        } catch (e: Exception) {
+            println("Error getting dialog info by peer: ${e.message}")
+            throw e
+        }
+    }
+
 
     override suspend fun getDialogMedia(
         dialogId: Long,

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -47,6 +47,11 @@ interface ChatApiService {
         @Path("dialogId") dialogId: Long,
     ): DialogInfoDto
 
+    @GET("chat/v1/dialogs/info/by-peer/{interlocutorId}")
+    suspend fun getDialogInfoByPeer(
+        @Path("interlocutorId") interlocutorId: String,
+    ): DialogInfoDto
+
     @GET("chat/v1/dialogs/media/{dialogId}")
     suspend fun getDialogMedia(
         @Path("dialogId") dialogId: Long,

--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
@@ -1,11 +1,12 @@
 package uddug.com.domain.entities.chat
 
 data class ChatSocketMessage(
-    val dialog: Long,
+    val dialog: Long? = null,
+    val interlocutor: String? = null,
     val cType: Int = 1,
     val text: String,
     val owner: String? = null,
-    val files: List<FileDescriptor>? = null
+    val files: List<FileDescriptor>? = null,
 )
 
 public data class FileDescriptor(

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -29,6 +29,9 @@ class ChatInteractor @Inject constructor(
 
     suspend fun getDialogInfo(dialogId: Long): DialogInfo = chatRepository.getDialogInfo(dialogId)
 
+    suspend fun getDialogInfoByPeer(interlocutorId: String): DialogInfo =
+        chatRepository.getDialogInfoByPeer(interlocutorId)
+
     suspend fun getMessagesWithOwnerInfo(
         currentUserId: String,
         dialogId: Long,

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -31,6 +31,8 @@ interface ChatRepository {
 
     suspend fun getDialogInfo(dialogId: Long): DialogInfo
 
+    suspend fun getDialogInfoByPeer(interlocutorId: String): DialogInfo
+
     suspend fun getDialogMedia(
         dialogId: Long,
         category: Int,


### PR DESCRIPTION
## Summary
- add API to fetch dialog by peer and support creating first message without dialog
- open ChatDialog when selecting user and request dialog info by peer
- send initial messages with interlocutor and update dialog when server responds

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a43d194850832781a2d8cc9f67d43f