### PR TITLE
feat: add shimmer placeholders for chats and messages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,6 +119,7 @@ dependencies {
     implementation "androidx.compose.material3:material3:1.1.2"
     implementation "androidx.compose.runtime:runtime-livedata:1.5.4"
     implementation "androidx.navigation:navigation-compose:2.7.4"
+    implementation "com.valentinilk.shimmer:compose-shimmer:1.0.5"
 
     // Остальные зависимости
     implementation ui.glide

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -10,20 +10,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imeNestedScroll
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
-import androidx.compose.material.Scaffold
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -50,6 +44,7 @@ import uddug.com.naukoteka.ui.chat.compose.components.ChatInputBar
 import uddug.com.naukoteka.ui.chat.compose.components.ChatMessageItem
 import uddug.com.naukoteka.ui.chat.compose.components.MessageFunctionsBottomSheetDialog
 import uddug.com.naukoteka.ui.chat.compose.components.ChatTopBar
+import uddug.com.naukoteka.ui.chat.compose.components.MessageListShimmer
 import uddug.com.domain.entities.chat.MessageChat
 import java.io.File
 
@@ -96,9 +91,7 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
 
             when (uiState) {
                 is ChatDialogUiState.Loading -> {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator()
-                    }
+                    MessageListShimmer()
                 }
 
                 is ChatDialogUiState.Error -> {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -87,7 +87,7 @@ fun ChatTabBar(
                 }
 
                 ChatListUiState.Loading -> {
-
+                    ChatListShimmer()
                 }
 
                 is ChatListUiState.Success -> {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ShimmerComponents.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ShimmerComponents.kt
@@ -1,0 +1,87 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+import com.valentinilk.shimmer.Shimmer
+import com.valentinilk.shimmer.rememberShimmer
+import com.valentinilk.shimmer.shimmer
+
+@Composable
+fun ChatListShimmer() {
+    val shimmer: Shimmer = rememberShimmer()
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items((1..10).toList()) { _ ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .shimmer(shimmer),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFE0E0E0))
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.6f)
+                            .height(14.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(Color(0xFFE0E0E0))
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.4f)
+                            .height(12.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(Color(0xFFE0E0E0))
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun MessageListShimmer() {
+    val shimmer: Shimmer = rememberShimmer()
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 10.dp, vertical = 10.dp)
+    ) {
+        items((1..8).toList()) { index ->
+            val isMine = index % 2 == 0
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = if (isMine) Arrangement.End else Arrangement.Start
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(200.dp)
+                        .height(60.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(Color(0xFFE0E0E0))
+                        .shimmer(shimmer)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add compose-shimmer library
- display shimmer placeholder while chat list and messages load

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5816edfac83279c318c0a3345246e