### PR TITLE
Fix message timestamps in chat

### DIFF
--- a/data/src/main/java/uddug/com/data/mapper/toDomain.kt
+++ b/data/src/main/java/uddug/com/data/mapper/toDomain.kt
@@ -14,9 +14,9 @@ fun MessageDto.toDomain(currentUserId: String): MessageChat = MessageChat(
     id = id,
     text = text,
     type = MessageType.fromInt(type),
-    files = listOf(),
+    files = files.map { it.toDomain() },
     ownerId = ownerId,
-    createdAt = Instant.now(),
+    createdAt = Instant.parse(createdAt),
     readCount = read,
     isMine = ownerId == currentUserId
 )

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/ChatDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/ChatDto.kt
@@ -79,7 +79,7 @@ data class MessageDto(
         type = MessageType.fromInt(type),
         files = files.map { it.toDomain() },
         ownerId = ownerId,
-        createdAt = Instant.now(),
+        createdAt = Instant.parse(createdAt),
         readCount = read,
         isMine = ownerId == currentUserId
     )


### PR DESCRIPTION
## Summary
- parse message creation timestamps from API instead of using device time
- ensure file attachments mapped when converting messages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58187d5408327a89825fde829f010