### PR TITLE
feat: add folder settings screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,6 +119,7 @@ dependencies {
     implementation "androidx.compose.material3:material3:1.1.2"
     implementation "androidx.compose.runtime:runtime-livedata:1.5.4"
     implementation "androidx.navigation:navigation-compose:2.7.4"
+    implementation "org.burnoutcrew.composereorderable:reorderable:0.9.6"
 
     // Остальные зависимости
     implementation ui.glide

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -66,6 +66,17 @@ class ChatListViewModel @Inject constructor(
         loadChats(currentFolderId)
     }
 
+    fun reorderFolders(fromIndex: Int, toIndex: Int) {
+        _folders.update { current ->
+            val mutable = current.toMutableList()
+            if (fromIndex in mutable.indices && toIndex in mutable.indices) {
+                val item = mutable.removeAt(fromIndex)
+                mutable.add(if (toIndex > fromIndex) toIndex - 1 else toIndex, item)
+            }
+            mutable
+        }
+    }
+
     fun updateDialogNotifications(dialogId: Long, disabled: Boolean) {
         viewModelScope.launch {
             try {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatFolderSettingsFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatFolderSettingsFragment.kt
@@ -1,0 +1,42 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
+import uddug.com.naukoteka.ui.chat.compose.ChatFolderSettingsComponent
+
+@AndroidEntryPoint
+class ChatFolderSettingsFragment : Fragment() {
+
+    private val viewModel: ChatListViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatFolderSettingsComponent(
+                        viewModel = viewModel,
+                        onBackPressed = { findNavController().popBackStack() }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.loadFolders()
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
@@ -122,6 +122,9 @@ class ChatListFragment : Fragment() {
                                     putLong(ChatDetailDialogFragment.DIALOG_ID, dialogId)
                                 }
                             )
+                        },
+                        onFolderSettings = {
+                            findNavController().navigate(R.id.chatFolderSettingsFragment)
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatFolderSettingsComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatFolderSettingsComponent.kt
@@ -1,0 +1,119 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.burnoutcrew.reorderable.ReorderableItem
+import org.burnoutcrew.reorderable.detectReorderAfterLongPress
+import org.burnoutcrew.reorderable.rememberReorderableLazyListState
+import org.burnoutcrew.reorderable.reorderable
+import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ChatFolderSettingsComponent(
+    viewModel: ChatListViewModel,
+    onBackPressed: () -> Unit,
+) {
+    val folders by viewModel.folders.collectAsState()
+    val reorderState = rememberReorderableLazyListState(onMove = { from, to ->
+        viewModel.reorderFolders(from.index, to.index)
+    })
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(text = "Настроить папки", color = Color.Black) },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = null, tint = Color(0xFF2E83D9))
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+                .padding(padding)
+        ) {
+            Text(
+                text = "Вы можете создать папки с нужными чатами и переключаться между ними.\nЧтобы удалить папку или изменить порядок сортировки, нажмите кнопку «Изменить».",
+                modifier = Modifier.padding(16.dp),
+                fontSize = 14.sp,
+                color = Color(0xFF8083A0)
+            )
+            Text(
+                text = "Выбранные чаты или группы",
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                fontSize = 16.sp,
+                color = Color.Black
+            )
+            androidx.compose.material.TextButton(
+                onClick = { },
+                modifier = Modifier.padding(horizontal = 16.dp)
+            ) {
+                Text(text = "Добавить новую папку", color = Color(0xFF2E83D9))
+            }
+            LazyColumn(
+                state = reorderState.listState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .reorderable(reorderState)
+            ) {
+                items(folders, key = { it.id }) { folder ->
+                    ReorderableItem(reorderState, key = folder.id) { _ ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 8.dp)
+                                .detectReorderAfterLongPress(reorderState),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = null,
+                                tint = Color.Red
+                            )
+                            Text(
+                                text = folder.name,
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(horizontal = 16.dp),
+                                fontSize = 16.sp,
+                                color = Color.Black
+                            )
+                            Icon(
+                                imageVector = Icons.Filled.Menu,
+                                contentDescription = null,
+                                tint = Color(0xFF8083A0)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -27,6 +27,7 @@ fun ChatListComponent(
     onBackPressed: () -> Unit,
     onCreateChatClick: () -> Unit,
     onShowAttachments: (Long) -> Unit,
+    onFolderSettings: () -> Unit,
 ) {
     var selectedDialogId by remember { mutableStateOf<Long?>(null) }
     val isSelectionMode by viewModel.isSelectionMode.collectAsState()
@@ -58,7 +59,8 @@ fun ChatListComponent(
             onChatLongClick = { id -> selectedDialogId = id },
             isSelectionMode = isSelectionMode,
             selectedChats = selectedChats,
-            onChatSelect = { viewModel.toggleChatSelection(it) }
+            onChatSelect = { viewModel.toggleChatSelection(it) },
+            onOpenFolderSettings = onFolderSettings
         )
     }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -2,6 +2,7 @@ package uddug.com.naukoteka.ui.chat.compose.components
 
 import ChatCard
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -24,6 +25,7 @@ fun ChatTabBar(
     isSelectionMode: Boolean,
     selectedChats: Set<Long>,
     onChatSelect: (Long) -> Unit,
+    onOpenFolderSettings: () -> Unit,
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
 
@@ -43,7 +45,10 @@ fun ChatTabBar(
                 TabRow(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(Color.White),
+                        .background(Color.White)
+                        .pointerInput(Unit) {
+                            detectTapGestures(onLongPress = { onOpenFolderSettings() })
+                        },
                     selectedTabIndex = selectedTabIndex,
                     indicator = { tabPositions ->
                         TabRowDefaults.Indicator(

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -38,4 +38,10 @@
 
     </fragment>
 
+    <fragment
+        android:id="@+id/chatFolderSettingsFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatFolderSettingsFragment">
+
+    </fragment>
+
 </navigation>


### PR DESCRIPTION
## Summary
- open folder settings screen on long press in chat list
- allow rearranging chat folders via drag & drop
- wire navigation and view model updates for folder ordering

## Testing
- `./gradlew app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a583ad2df48327b7f3480ad2ec2528