### PR TITLE
feat(chat): add attachment options bottom sheet

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -43,10 +43,13 @@ import uddug.com.naukoteka.R
 import uddug.com.naukoteka.ui.chat.compose.components.ChatInputBar
 import uddug.com.naukoteka.ui.chat.compose.components.ChatMessageItem
 import uddug.com.naukoteka.ui.chat.compose.components.MessageFunctionsBottomSheetDialog
+import uddug.com.naukoteka.ui.chat.compose.components.AttachOptionsBottomSheetDialog
 import uddug.com.naukoteka.ui.chat.compose.components.ChatTopBar
 import uddug.com.naukoteka.ui.chat.compose.components.MessageListShimmer
 import uddug.com.domain.entities.chat.MessageChat
 import java.io.File
+
+private enum class AttachmentPickerType { MEDIA, FILE }
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -59,6 +62,8 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
     var selectedMessage by remember { mutableStateOf<MessageChat?>(null) }
     val isSelectionMode by viewModel.isSelectionMode.collectAsState()
     val selectedMessages by viewModel.selectedMessages.collectAsState()
+    var showAttachmentSheet by remember { mutableStateOf(false) }
+    var pendingPickerType by remember { mutableStateOf<AttachmentPickerType?>(null) }
 
     val filePickerLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenMultipleDocuments()
@@ -73,8 +78,15 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
         ActivityResultContracts.RequestPermission()
     ) { granted: Boolean ->
         if (granted) {
-            filePickerLauncher.launch(arrayOf("*/*"))
+            when (pendingPickerType) {
+                AttachmentPickerType.MEDIA ->
+                    filePickerLauncher.launch(arrayOf("image/*", "video/*"))
+                AttachmentPickerType.FILE ->
+                    filePickerLauncher.launch(arrayOf("*/*"))
+                null -> {}
+            }
         }
+        pendingPickerType = null
     }
 
     Box(
@@ -177,7 +189,7 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                             }
                         },
                         onAttachClick = {
-                            permissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+                            showAttachmentSheet = true
                         },
                         onRemoveFile = { file ->
                             viewModel.removeAttachedFile(file)
@@ -185,6 +197,23 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                     )
                 }
             }
+        }
+        if (showAttachmentSheet) {
+            AttachOptionsBottomSheetDialog(
+                onDismissRequest = { showAttachmentSheet = false },
+                onMediaClick = {
+                    pendingPickerType = AttachmentPickerType.MEDIA
+                    permissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+                    showAttachmentSheet = false
+                },
+                onFileClick = {
+                    pendingPickerType = AttachmentPickerType.FILE
+                    permissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+                    showAttachmentSheet = false
+                },
+                onPollClick = { showAttachmentSheet = false },
+                onContactClick = { showAttachmentSheet = false }
+            )
         }
         selectedMessage?.let { message ->
             MessageFunctionsBottomSheetDialog(

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
@@ -1,0 +1,95 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.InsertDriveFile
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Poll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import uddug.com.naukoteka.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AttachOptionsBottomSheetDialog(
+    onDismissRequest: () -> Unit,
+    onMediaClick: () -> Unit,
+    onFileClick: () -> Unit,
+    onPollClick: () -> Unit,
+    onContactClick: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            BottomSheetItem(
+                icon = Icons.Filled.Image,
+                text = stringResource(R.string.chat_attach_photo_video),
+                onClick = onMediaClick
+            )
+            BottomSheetItem(
+                icon = Icons.Filled.InsertDriveFile,
+                text = stringResource(R.string.chat_attach_file),
+                onClick = onFileClick
+            )
+            BottomSheetItem(
+                icon = Icons.Filled.Poll,
+                text = stringResource(R.string.chat_attach_poll),
+                onClick = onPollClick
+            )
+            BottomSheetItem(
+                icon = Icons.Filled.Person,
+                text = stringResource(R.string.chat_attach_contact),
+                onClick = onContactClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun BottomSheetItem(
+    icon: ImageVector,
+    text: String,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .width(72.dp)
+            .clickable { onClick() },
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = text,
+            modifier = Modifier.height(40.dp)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(text = text)
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -392,4 +392,10 @@
     <string name="create_group_chat">Создать групповой чат</string>
     <string name="subs">Подписки</string>
 
+    <!-- Chat attachment options -->
+    <string name="chat_attach_photo_video">Фотографии и видео</string>
+    <string name="chat_attach_file">Файлы</string>
+    <string name="chat_attach_poll">Опросы</string>
+    <string name="chat_attach_contact">Контакты</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- add bottom sheet with attachment choices
- show bottom sheet from chat dialog and handle file picker
- add strings for new attachment options

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a587c1984c8327aad444d072f4fcb1