### PR TITLE
feat: show reply preview in chat input

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -251,6 +251,20 @@ class ChatDialogViewModel @Inject constructor(
         }
     }
 
+    fun setReplyMessage(message: MessageChat) {
+        val currentState = _uiState.value
+        if (currentState is ChatDialogUiState.Success) {
+            _uiState.value = currentState.copy(replyMessage = message)
+        }
+    }
+
+    fun clearReplyMessage() {
+        val currentState = _uiState.value
+        if (currentState is ChatDialogUiState.Success) {
+            _uiState.value = currentState.copy(replyMessage = null)
+        }
+    }
+
     fun startSelection(messageId: Long) {
         _isSelectionMode.value = true
         _selectedMessages.value = setOf(messageId)
@@ -346,6 +360,7 @@ class ChatDialogViewModel @Inject constructor(
             Log.d("ChatViewModel", "Sending socket message: $message")
             socketService.sendMessage("message", message)
             clearAttachedFiles()
+            clearReplyMessage()
         }
     }
 
@@ -446,6 +461,7 @@ sealed class ChatDialogUiState {
         val currentMessage: String = "",
         val attachedFiles: List<File> = emptyList(),
         val status: String? = null,
+        val replyMessage: MessageChat? = null,
     ) : ChatDialogUiState()
 
     data class Error(val message: String) : ChatDialogUiState()

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -166,6 +166,7 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                     ChatInputBar(
                         currentMessage = state.currentMessage,
                         attachedFiles = state.attachedFiles,
+                        replyMessage = state.replyMessage,
                         onMessageChange = { newMessage ->
                             viewModel.updateCurrentMessage(newMessage)
                         },
@@ -181,6 +182,9 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                         },
                         onRemoveFile = { file ->
                             viewModel.removeAttachedFile(file)
+                        },
+                        onCancelReply = {
+                            viewModel.clearReplyMessage()
                         }
                     )
                 }
@@ -193,6 +197,9 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                 onSelectMessage = {
                     viewModel.startSelection(message.id)
                     selectedMessage = null
+                },
+                onReply = { msg ->
+                    viewModel.setReplyMessage(msg)
                 }
             )
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -22,8 +22,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import uddug.com.naukoteka.R
+import uddug.com.domain.entities.chat.MessageChat
 import java.io.File
 
 
@@ -32,10 +35,12 @@ fun ChatInputBar(
     modifier: Modifier = Modifier,
     currentMessage: String,
     attachedFiles: List<File>,
+    replyMessage: MessageChat?,
     onMessageChange: (String) -> Unit,
     onSendClick: () -> Unit,
     onAttachClick: () -> Unit,
     onRemoveFile: (File) -> Unit,
+    onCancelReply: () -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -48,6 +53,38 @@ fun ChatInputBar(
                 .background(Color(0xFFEAEAF2))
                 .height(1.dp)
         )
+
+        replyMessage?.let { reply ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.White)
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = reply.ownerName ?: "",
+                        color = Color(0XFF8083A0),
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 12.sp
+                    )
+                    Text(
+                        text = reply.text.orEmpty(),
+                        color = Color(0XFF8083A0),
+                        fontSize = 12.sp,
+                        maxLines = 1
+                    )
+                }
+                IconButton(onClick = onCancelReply) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Cancel reply",
+                        tint = Color(0XFF8083A0)
+                    )
+                }
+            }
+        }
 
         if (attachedFiles.isNotEmpty()) {
             LazyRow(

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -30,6 +30,7 @@ fun MessageFunctionsBottomSheetDialog(
     message: MessageChat,
     onDismissRequest: () -> Unit,
     onSelectMessage: () -> Unit,
+    onReply: (MessageChat) -> Unit,
     viewModel: MessageFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -51,7 +52,7 @@ fun MessageFunctionsBottomSheetDialog(
             )
             Spacer(modifier = Modifier.height(10.dp))
             val items = listOf(
-                R.string.chat_message_reply to { viewModel.reply(message.id) },
+                R.string.chat_message_reply to { onReply(message) },
                 R.string.chat_message_forward to { viewModel.forward(message.id) },
                 R.string.chat_message_copy to { viewModel.copy(message.id) },
                 R.string.chat_message_select to {


### PR DESCRIPTION
## Summary
- show selected reply message above chat input
- allow replying from message options
- manage reply state in ChatDialogViewModel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a587a07bf8832788650301d62c63c2