### PR TITLE
Show toolbar during chat loading and shrink shimmer messages

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -103,7 +103,17 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
 
             when (uiState) {
                 is ChatDialogUiState.Loading -> {
-                    MessageListShimmer()
+                    ChatTopBar(
+                        name = "",
+                        image = "",
+                        isGroup = false,
+                        status = null,
+                        onBackPressed = { onBackPressed() },
+                        onDetailClick = {}
+                    )
+                    Box(modifier = Modifier.weight(1f)) {
+                        MessageListShimmer()
+                    }
                 }
 
                 is ChatDialogUiState.Error -> {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ShimmerComponents.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ShimmerComponents.kt
@@ -75,8 +75,8 @@ fun MessageListShimmer() {
             ) {
                 Box(
                     modifier = Modifier
-                        .width(200.dp)
-                        .height(60.dp)
+                        .width(100.dp)
+                        .height(30.dp)
                         .clip(RoundedCornerShape(12.dp))
                         .background(Color(0xFFE0E0E0))
                         .shimmer(shimmer)


### PR DESCRIPTION
## Summary
- Display chat toolbar during loading state
- Reduce shimmer message size by 50%

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58b7cc6308327abb321b2e74fadf4