### PR TITLE
Show group chat initials when avatar is missing

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -93,6 +93,7 @@ class ChatDialogViewModel @Inject constructor(
                                     info.interlocutor != null -> info.interlocutor?.image.orEmpty()
                                     else -> info.name.orEmpty()
                                 }
+                                val firstParticipantName = info.users?.firstOrNull()?.fullName.orEmpty()
                                 var status: String? = null
                                 val isGroup = (info.users?.size ?: 0) > 2
                                 if (!isGroup) {
@@ -115,6 +116,7 @@ class ChatDialogViewModel @Inject constructor(
                                     chatName = name,
                                     chatImage = image,
                                     isGroup = isGroup,
+                                    firstParticipantName = firstParticipantName,
                                     status = status
                                 )
                                 markMessagesRead(dialogId, messages)
@@ -156,6 +158,7 @@ class ChatDialogViewModel @Inject constructor(
                                     )
                                     val name = info.interlocutor?.fullName.orEmpty()
                                     val image = info.interlocutor?.image.orEmpty()
+                                    val firstParticipantName = info.users?.firstOrNull()?.fullName.orEmpty()
                                     var status: String? = null
                                     val isGroup = (info.users?.size ?: 0) > 2
                                     if (!isGroup) {
@@ -178,6 +181,7 @@ class ChatDialogViewModel @Inject constructor(
                                         chatName = name,
                                         chatImage = image,
                                         isGroup = isGroup,
+                                        firstParticipantName = firstParticipantName,
                                         status = status
                                     )
                                     markMessagesRead(dialogId, messages)
@@ -185,11 +189,13 @@ class ChatDialogViewModel @Inject constructor(
                             } else {
                                 val name = info.interlocutor?.fullName.orEmpty()
                                 val image = info.interlocutor?.image.orEmpty()
+                                val firstParticipantName = info.users?.firstOrNull()?.fullName.orEmpty()
                                 _uiState.value = ChatDialogUiState.Success(
                                     chats = emptyList(),
                                     chatName = name,
                                     chatImage = image,
                                     isGroup = false,
+                                    firstParticipantName = firstParticipantName,
                                     status = null
                                 )
                             }
@@ -458,6 +464,7 @@ sealed class ChatDialogUiState {
         val chatName: String,
         val chatImage: String,
         val isGroup: Boolean,
+        val firstParticipantName: String = "",
         val currentMessage: String = "",
         val attachedFiles: List<File> = emptyList(),
         val status: String? = null,

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -148,6 +148,7 @@ fun ChatDialogComponent(viewModel: ChatDialogViewModel, onBackPressed: () -> Uni
                             image = state.chatImage,
                             isGroup = state.isGroup,
                             status = state.status,
+                            firstParticipantName = state.firstParticipantName,
                             onBackPressed = { onBackPressed() },
                             onDetailClick = {
                                 viewModel.onChatDetailClick()

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
@@ -38,6 +38,7 @@ fun ChatTopBar(
     image: String,
     isGroup: Boolean,
     status: String?,
+    firstParticipantName: String? = null,
     onDetailClick: () -> Unit,
     onBackPressed: () -> Unit,
 ) {
@@ -68,7 +69,11 @@ fun ChatTopBar(
                             }
                     )
                 } else {
-                    val firstLetter = name.firstOrNull()?.uppercase() ?: ""
+                    val firstLetter = if (isGroup) {
+                        firstParticipantName?.firstOrNull()?.uppercase() ?: ""
+                    } else {
+                        name.firstOrNull()?.uppercase() ?: ""
+                    }
                     Box(
                         modifier = Modifier
                             .size(36.dp)


### PR DESCRIPTION
## Summary
- add first participant fallback for missing group avatar
- render letter placeholder in ChatTopBar when no group image

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58b9b56188327a1a7dd7ca0b00bd2