### PR TITLE
feat: add group chat detail screen

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
@@ -1,0 +1,89 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import uddug.com.domain.entities.chat.DialogInfo
+import uddug.com.domain.entities.chat.MediaMessage
+import uddug.com.domain.entities.chat.User
+import uddug.com.domain.interactors.chat.ChatInteractor
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatGroupDetailViewModel @Inject constructor(
+    private val chatInteractor: ChatInteractor,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<ChatGroupDetailUiState>(ChatGroupDetailUiState.Loading)
+    val uiState: StateFlow<ChatGroupDetailUiState> = _uiState
+
+    private val _selectedTabIndex = MutableStateFlow(0)
+    val selectedTabIndex: StateFlow<Int> = _selectedTabIndex
+
+    fun selectTab(index: Int) {
+        _selectedTabIndex.value = index
+    }
+
+    fun loadDialogInfo(dialogId: Long) {
+        viewModelScope.launch {
+            try {
+                val info = chatInteractor.getDialogInfo(dialogId)
+                setDialogInfo(info)
+            } catch (e: Exception) {
+                _uiState.value = ChatGroupDetailUiState.Error(e.message ?: "Error")
+            }
+        }
+    }
+
+    fun setDialogInfo(dialogInfo: DialogInfo) {
+        viewModelScope.launch {
+            try {
+                val media = chatInteractor.getDialogMedia(
+                    dialogInfo.id,
+                    category = 1,
+                    limit = 50,
+                    page = 1,
+                    query = null,
+                    sd = null,
+                    ed = null,
+                )
+                val files = chatInteractor.getDialogMedia(
+                    dialogInfo.id,
+                    category = 3,
+                    limit = 50,
+                    page = 1,
+                    query = null,
+                    sd = null,
+                    ed = null,
+                )
+                _uiState.value = ChatGroupDetailUiState.Success(
+                    name = dialogInfo.name.orEmpty(),
+                    image = dialogInfo.dialogImage?.path,
+                    participants = dialogInfo.users.orEmpty(),
+                    media = media,
+                    files = files,
+                    dialogId = dialogInfo.id,
+                )
+            } catch (e: Exception) {
+                _uiState.value = ChatGroupDetailUiState.Error(e.message ?: "Error")
+            }
+        }
+    }
+}
+
+sealed class ChatGroupDetailUiState {
+    object Loading : ChatGroupDetailUiState()
+    data class Success(
+        val name: String,
+        val image: String?,
+        val participants: List<User>,
+        val media: List<MediaMessage>,
+        val files: List<MediaMessage>,
+        val dialogId: Long,
+    ) : ChatGroupDetailUiState()
+
+    data class Error(val message: String) : ChatGroupDetailUiState()
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -74,8 +74,14 @@ class ChatDialogFragment : Fragment() {
             viewModel.events.collectLatest { state ->
                 when (state) {
                     is ChatDialogEvents.OpenChatProfileDetail -> {
+                        val isGroup = (state.dialogInfo.users?.size ?: 0) > 2
+                        val destination = if (isGroup) {
+                            R.id.chatGroupDetailFragment
+                        } else {
+                            R.id.chatDetailDialog
+                        }
                         findNavController().navigate(
-                            R.id.chatDetailDialog,
+                            destination,
                             args = Bundle().apply {
                                 putLong(DIALOG_ID, state.dialogId)
                                 putParcelable(DIALOG_DETAIL, state.dialogInfo)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
@@ -1,0 +1,86 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import uddug.com.domain.entities.chat.DialogInfo
+import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailViewModel
+import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
+import uddug.com.naukoteka.ui.chat.compose.ChatGroupDetailComponent
+
+@AndroidEntryPoint
+class ChatGroupDetailFragment : Fragment() {
+
+    private var navigationView: ContainerNavigationView? = null
+
+    private val viewModel: ChatGroupDetailViewModel by viewModels()
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        navigationView = requireActivity() as ContainerNavigationView
+    }
+
+    override fun onResume() {
+        super.onResume()
+        navigationView?.showNavigationBottomBar(false)
+    }
+
+    companion object {
+        const val DIALOG_ID = "DIALOG_ID"
+        const val DIALOG_DETAIL = "DIALOG_DETAIL"
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        lifecycleScope.launch {
+            viewModel.uiState.collectLatest { state ->
+                when (state) {
+                    else -> {}
+                }
+            }
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+
+        arguments?.getParcelable<DialogInfo>(DIALOG_DETAIL)
+            ?.let { viewModel.setDialogInfo(it) }
+            ?: arguments?.getLong(DIALOG_ID)?.let { viewModel.loadDialogInfo(it) }
+
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatGroupDetailComponent(
+                        viewModel = viewModel,
+                        onBackPressed = { requireActivity().onBackPressed() }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_UNSPECIFIED)
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
@@ -1,0 +1,184 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import uddug.com.domain.entities.chat.User
+import uddug.com.naukoteka.BuildConfig
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailViewModel
+import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailUiState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatGroupDetailComponent(
+    viewModel: ChatGroupDetailViewModel,
+    onBackPressed: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val selectedTabIndex by viewModel.selectedTabIndex.collectAsState()
+    val tabs = listOf("Участники", "Медиа", "Файлы")
+    Scaffold(
+        topBar = {
+            androidx.compose.material.TopAppBar(
+                title = {
+                    Text(text = "Информация", fontSize = 20.sp, color = Color.Black)
+                },
+                navigationIcon = {
+                    androidx.compose.material.IconButton(onClick = { onBackPressed() }) {
+                        androidx.compose.material.Icon(
+                            painter = painterResource(id = R.drawable.ic_back),
+                            contentDescription = "Back Icon",
+                            tint = Color(0xFF2E83D9)
+                        )
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp
+            )
+        }
+    ) { paddingValues ->
+        when (val state = uiState) {
+            is ChatGroupDetailUiState.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            is ChatGroupDetailUiState.Error -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(text = state.message)
+                }
+            }
+            is ChatGroupDetailUiState.Success -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.White)
+                        .padding(paddingValues)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        AsyncImage(
+                            model = BuildConfig.IMAGE_SERVER_URL.plus(state.image.orEmpty()),
+                            contentDescription = "Avatar",
+                            modifier = Modifier
+                                .size(100.dp)
+                                .clip(CircleShape),
+                            contentScale = ContentScale.Crop
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = state.name,
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = "${state.participants.size} участников",
+                            fontSize = 14.sp,
+                            color = Color.Gray
+                        )
+                    }
+                    TabRow(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(Color.White),
+                        selectedTabIndex = selectedTabIndex,
+                        indicator = { tabPositions ->
+                            TabRowDefaults.Indicator(
+                                Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+                                color = Color(0xFF2E83D9)
+                            )
+                        },
+                        divider = {}
+                    ) {
+                        tabs.forEachIndexed { index, title ->
+                            Tab(
+                                selected = selectedTabIndex == index,
+                                onClick = { viewModel.selectTab(index) },
+                                text = {
+                                    Text(
+                                        text = title,
+                                        maxLines = 1,
+                                        style = TextStyle(
+                                            fontSize = 14.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = if (selectedTabIndex == index) Color.Black else Color(0xFF8083A0)
+                                        )
+                                    )
+                                }
+                            )
+                        }
+                    }
+                    androidx.compose.material3.Divider()
+                    when (selectedTabIndex) {
+                        0 -> ParticipantsContent(state.participants)
+                        1 -> MediaContent(state.media)
+                        2 -> FilesContent(state.files)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ParticipantsContent(users: List<User>) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(users) { user ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                AsyncImage(
+                    model = BuildConfig.IMAGE_SERVER_URL.plus(user.image.orEmpty()),
+                    contentDescription = "Avatar",
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column {
+                    Text(text = user.fullName.orEmpty(), fontWeight = FontWeight.Bold)
+                    Text(text = user.nickname.orEmpty(), fontSize = 12.sp, color = Color.Gray)
+                }
+            }
+            androidx.compose.material3.Divider()
+        }
+    }
+}

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -24,6 +24,12 @@
         android:name="uddug.com.naukoteka.ui.chat.ChatDetailDialogFragment">
 
     </fragment>
+    <fragment
+        android:id="@+id/chatGroupDetailFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatGroupDetailFragment">
+
+    </fragment>
+
 
 
     <fragment


### PR DESCRIPTION
## Summary
- split chat details into separate group detail screen with participants tab
- navigate to group or dialog detail depending on chat type

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58bfee8c883278b1aee6ad37de4ab