### PR TITLE
feat: add chat detail search screen

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -18,6 +19,7 @@ import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.naukoteka.mvvm.chat.ChatDialogDetailViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatDetailDialogComponent
+import uddug.com.naukoteka.R
 
 @AndroidEntryPoint
 class ChatDetailDialogFragment : Fragment() {
@@ -77,6 +79,9 @@ class ChatDetailDialogFragment : Fragment() {
                         },
                         onNavigateToProfile = {
                             viewModel.getCurrentUser()?.let { navigationView?.selectShowEditFragment(it) }
+                        },
+                        onSearchClick = {
+                            findNavController().navigate(R.id.chatDetailSearchFragment)
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogSearchFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogSearchFragment.kt
@@ -1,0 +1,44 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import uddug.com.naukoteka.mvvm.chat.ChatDialogDetailViewModel
+import uddug.com.naukoteka.ui.chat.compose.ChatDetailDialogSearchComponent
+
+@AndroidEntryPoint
+class ChatDetailDialogSearchFragment : Fragment() {
+
+    private val viewModel: ChatDialogDetailViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatDetailDialogSearchComponent(
+                        viewModel = viewModel,
+                        onBackPressed = { requireActivity().onBackPressed() }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_UNSPECIFIED)
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -82,6 +82,7 @@ fun ChatDetailDialogComponent(
     viewModel: ChatDialogDetailViewModel,
     onBackPressed: () -> Unit,
     onNavigateToProfile: () -> Unit,
+    onSearchClick: () -> Unit,
 ) {
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope()
@@ -102,7 +103,7 @@ fun ChatDetailDialogComponent(
                 },
                 actions = {
 
-                    androidx.compose.material.IconButton(onClick = { }) {
+                    androidx.compose.material.IconButton(onClick = { onSearchClick() }) {
                         androidx.compose.material.Icon(
                             painter = painterResource(id = R.drawable.ic_search_chat),
                             contentDescription = "Edit Icon",

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
@@ -1,0 +1,108 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.*
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatDialogDetailViewModel
+import uddug.com.naukoteka.ui.chat.compose.components.SearchField
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatDetailDialogSearchComponent(
+    viewModel: ChatDialogDetailViewModel,
+    onBackPressed: () -> Unit,
+) {
+    var searchQuery by remember { mutableStateOf("") }
+    var selectedTabIndex by remember { mutableStateOf(0) }
+    val tabs = listOf("Сообщения", "Медиа", "Файлы", "Записи")
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    SearchField(
+                        title = stringResource(R.string.search_country),
+                        query = searchQuery,
+                        onSearchChanged = { searchQuery = it }
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_back),
+                            contentDescription = "Back",
+                            tint = Color(0xFF2E83D9)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White)
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .background(Color.White)
+        ) {
+            TabRow(
+                selectedTabIndex = selectedTabIndex,
+                indicator = { tabPositions ->
+                    TabRowDefaults.Indicator(
+                        Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+                        color = Color(0xFF2E83D9)
+                    )
+                },
+                divider = {},
+            ) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = selectedTabIndex == index,
+                        onClick = { selectedTabIndex = index },
+                        text = {
+                            Text(
+                                text = title,
+                                maxLines = 1,
+                                style = TextStyle(
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = if (selectedTabIndex == index) Color.Black else Color(0xFF8083A0)
+                                )
+                            )
+                        }
+                    )
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                Text(
+                    text = "Нет результатов",
+                    modifier = Modifier.padding(top = 24.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -25,6 +25,12 @@
 
     </fragment>
 
+    <fragment
+        android:id="@+id/chatDetailSearchFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatDetailDialogSearchFragment">
+
+    </fragment>
+
 
     <fragment
         android:id="@+id/chatCreateSingleFragment"


### PR DESCRIPTION
## Summary
- enable search action in chat detail and navigate to a dedicated search fragment
- add search UI with four tabs (Messages, Media, Files, Notes)
- wire new screen into navigation graph

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58f288ecc83278e0a35a810fe9be5