### PR TITLE
Fix chat message ordering

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -83,7 +83,7 @@ class ChatDialogViewModel @Inject constructor(
                                     dialogId = dialogId,
                                     limit = 50,
                                     lastMessageId = null,
-                                )
+                                ).sortedBy { it.createdAt }
                             //    currentDialogID = dialogId
                                 val name: String = when {
                                     info.interlocutor != null -> info.interlocutor?.fullName.orEmpty()
@@ -155,7 +155,7 @@ class ChatDialogViewModel @Inject constructor(
                                         dialogId = dialogId,
                                         limit = 50,
                                         lastMessageId = null,
-                                    )
+                                    ).sortedBy { it.createdAt }
                                     val name = info.interlocutor?.fullName.orEmpty()
                                     val image = info.interlocutor?.image.orEmpty()
                                     val firstParticipantName = info.users?.firstOrNull()?.fullName.orEmpty()
@@ -437,7 +437,7 @@ class ChatDialogViewModel @Inject constructor(
                 val currentState = _uiState.value
                 if (currentState is ChatDialogUiState.Success) {
                     val updatedChats = currentState.chats.toMutableList().apply {
-                        add(0,newMessage)
+                        add(newMessage)
                     }
                     _uiState.value = currentState.copy(chats = updatedChats)
                 }


### PR DESCRIPTION
## Summary
- sort loaded chat messages chronologically
- append incoming messages to the end so new messages appear last

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a59354efa08327b46b516bf393bde2