### PR TITLE
Fix group chat placeholders and participant statuses

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
@@ -1,32 +1,39 @@
 package uddug.com.naukoteka.ui.chat.compose
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import uddug.com.domain.entities.chat.User
 import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailViewModel
 import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailUiState
+import uddug.com.naukoteka.mvvm.chat.Participant
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -42,6 +49,15 @@ fun ChatGroupDetailComponent(
             androidx.compose.material.TopAppBar(
                 title = {
                     Text(text = "Информация", fontSize = 20.sp, color = Color.Black)
+                },
+                actions = {
+                    androidx.compose.material.IconButton(onClick = { }) {
+                        androidx.compose.material.Icon(
+                            painter = painterResource(id = R.drawable.ic_search_chat),
+                            contentDescription = "Search Icon",
+                            tint = Color(0xFF2E83D9)
+                        )
+                    }
                 },
                 navigationIcon = {
                     androidx.compose.material.IconButton(onClick = { onBackPressed() }) {
@@ -91,8 +107,8 @@ fun ChatGroupDetailComponent(
                             .padding(16.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        AsyncImage(
-                            model = BuildConfig.IMAGE_SERVER_URL.plus(state.image.orEmpty()),
+                        Image(
+                            painter = painterResource(id = R.drawable.ic_logo_naukoteka),
                             contentDescription = "Avatar",
                             modifier = Modifier
                                 .size(100.dp)
@@ -108,8 +124,100 @@ fun ChatGroupDetailComponent(
                         Text(
                             text = "${state.participants.size} участников",
                             fontSize = 14.sp,
-                            color = Color.Gray
+                            color = Color.Gray,
+                            modifier = Modifier.fillMaxWidth(),
+                            textAlign = TextAlign.Center
                         )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Row {
+                            Column(
+                                Modifier
+                                    .weight(1f)
+                                    .padding(end = 4.dp)
+                                    .background(
+                                        shape = RoundedCornerShape(8.dp),
+                                        color = Color(0xFFF5F5F9)
+                                    )
+                                    .clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = null
+                                    ) { }
+                                    .padding(12.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Icon(
+                                    modifier = Modifier
+                                        .padding(start = 2.dp)
+                                        .size(24.dp),
+                                    painter = painterResource(id = R.drawable.ic_profile_call),
+                                    contentDescription = "Call",
+                                    tint = Color(0xFF2E83D9)
+                                )
+                                Text(
+                                    text = stringResource(R.string.call_user),
+                                    fontSize = 12.sp,
+                                    color = Color(0xFF8083A0)
+                                )
+                            }
+                            Column(
+                                Modifier
+                                    .weight(1f)
+                                    .padding(start = 4.dp, end = 4.dp)
+                                    .background(
+                                        shape = RoundedCornerShape(8.dp),
+                                        color = Color(0xFFF5F5F9)
+                                    )
+                                    .clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = null
+                                    ) { }
+                                    .padding(12.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Icon(
+                                    modifier = Modifier
+                                        .padding(start = 2.dp)
+                                        .size(24.dp),
+                                    painter = painterResource(id = R.drawable.ic_profile_send),
+                                    contentDescription = "Share",
+                                    tint = Color(0xFF2E83D9)
+                                )
+                                Text(
+                                    text = stringResource(R.string.profile_shasre),
+                                    fontSize = 12.sp,
+                                    color = Color(0xFF8083A0)
+                                )
+                            }
+                            Column(
+                                Modifier
+                                    .weight(1f)
+                                    .padding(start = 4.dp)
+                                    .background(
+                                        shape = RoundedCornerShape(8.dp),
+                                        color = Color(0xFFF5F5F9)
+                                    )
+                                    .clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = null
+                                    ) { }
+                                    .padding(12.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Icon(
+                                    modifier = Modifier
+                                        .padding(start = 2.dp)
+                                        .size(24.dp),
+                                    painter = painterResource(id = R.drawable.ic_profile_more),
+                                    contentDescription = "More",
+                                    tint = Color(0xFF2E83D9)
+                                )
+                                Text(
+                                    text = stringResource(R.string.profile_more),
+                                    fontSize = 12.sp,
+                                    color = Color(0xFF8083A0)
+                                )
+                            }
+                        }
                     }
                     TabRow(
                         modifier = Modifier
@@ -155,9 +263,9 @@ fun ChatGroupDetailComponent(
 }
 
 @Composable
-fun ParticipantsContent(users: List<User>) {
+fun ParticipantsContent(users: List<Participant>) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
-        items(users) { user ->
+        items(users) { participant ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -165,7 +273,7 @@ fun ParticipantsContent(users: List<User>) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 AsyncImage(
-                    model = BuildConfig.IMAGE_SERVER_URL.plus(user.image.orEmpty()),
+                    model = BuildConfig.IMAGE_SERVER_URL.plus(participant.user.image.orEmpty()),
                     contentDescription = "Avatar",
                     modifier = Modifier
                         .size(40.dp)
@@ -173,9 +281,22 @@ fun ParticipantsContent(users: List<User>) {
                     contentScale = ContentScale.Crop
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                Column {
-                    Text(text = user.fullName.orEmpty(), fontWeight = FontWeight.Bold)
-                    Text(text = user.nickname.orEmpty(), fontSize = 12.sp, color = Color.Gray)
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = participant.user.fullName.orEmpty(),
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    participant.status?.let {
+                        Text(
+                            text = it,
+                            fontSize = 12.sp,
+                            color = Color.Gray,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
             }
             androidx.compose.material3.Divider()

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.layout.ContentScale
 import coil.compose.AsyncImage
 import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
@@ -99,39 +100,17 @@ fun ChatCard(
                         )
                     }
                 }
-                if (avatarUrl.isNullOrEmpty()) {
-
-                    val initials = name.split(" ").let {
-                        (it.firstOrNull()?.firstOrNull()?.toString() ?: "") +
-                                (it.getOrNull(1)?.firstOrNull()?.toString() ?: "")
-                    }
-                    val gradientRes = getGradientForName(name)
-
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .background(
-                                color = Color(0xFF93DDFF), // Используем XML drawable
-                                shape = CircleShape
-                            )
-                    ) {
-
-                        Text(
-                            text = "Ч",
-                            style = TextStyle(color = Color.White, fontWeight = FontWeight.Bold),
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    }
-                } else {
-                    // Если URL не пустой, загружаем изображение
-                    AsyncImage(
-                        model = BuildConfig.IMAGE_SERVER_URL + avatarUrl,
-                        contentDescription = "Avatar",
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(CircleShape)
-                    )
-                }
+                AsyncImage(
+                    model = avatarUrl?.let { BuildConfig.IMAGE_SERVER_URL + it },
+                    contentDescription = "Avatar",
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop,
+                    placeholder = painterResource(id = R.drawable.ic_logo_naukoteka),
+                    error = painterResource(id = R.drawable.ic_logo_naukoteka),
+                    fallback = painterResource(id = R.drawable.ic_logo_naukoteka),
+                )
                 Spacer(modifier = Modifier.width(16.dp))
 
                 // Основной контент


### PR DESCRIPTION
## Summary
- show app logo while chat avatars load
- restore search, call, share and more actions on group details
- display last online status for group participants

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5925cc7dc8327a4d4063f79047661