### PR TITLE
Enable search in group chat details

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
@@ -11,10 +11,12 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import uddug.com.domain.entities.chat.DialogInfo
+import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatGroupDetailComponent
@@ -72,7 +74,8 @@ class ChatGroupDetailFragment : Fragment() {
                 MaterialTheme {
                     ChatGroupDetailComponent(
                         viewModel = viewModel,
-                        onBackPressed = { requireActivity().onBackPressed() }
+                        onBackPressed = { requireActivity().onBackPressed() },
+                        onSearchClick = { findNavController().navigate(R.id.chatDetailSearchFragment) }
                     )
                 }
             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
@@ -41,6 +41,7 @@ import uddug.com.naukoteka.mvvm.chat.Participant
 fun ChatGroupDetailComponent(
     viewModel: ChatGroupDetailViewModel,
     onBackPressed: () -> Unit,
+    onSearchClick: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val selectedTabIndex by viewModel.selectedTabIndex.collectAsState()
@@ -52,7 +53,7 @@ fun ChatGroupDetailComponent(
                     Text(text = "Информация", fontSize = 20.sp, color = Color.Black)
                 },
                 actions = {
-                    androidx.compose.material.IconButton(onClick = { }) {
+                    androidx.compose.material.IconButton(onClick = { onSearchClick() }) {
                         androidx.compose.material.Icon(
                             painter = painterResource(id = R.drawable.ic_search_chat),
                             contentDescription = "Search Icon",


### PR DESCRIPTION
## Summary
- open search screen from group chat details when toolbar search icon is tapped

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a597f3124083279003de76074db067