### PR TITLE
feat(chat): add loading shimmer with minimum display

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
@@ -71,6 +72,7 @@ class ChatDialogViewModel @Inject constructor(
     @SuppressLint("CheckResult")
     fun loadMessages(dialogId: Long) {
         _uiState.value = ChatDialogUiState.Loading()
+        val startTime = System.currentTimeMillis()
         viewModelScope.launch {
             try {
                 userRepository.getProfileInfo().subscribeOn(Schedulers.io())
@@ -123,6 +125,8 @@ class ChatDialogViewModel @Inject constructor(
                                     limit = 50,
                                     lastMessageId = null,
                                 ).sortedBy { it.createdAt }
+                                val elapsed = System.currentTimeMillis() - startTime
+                                if (elapsed < 1500L) delay(1500L - elapsed)
                                 _uiState.value = ChatDialogUiState.Success(
                                     chats = messages,
                                     chatName = name,
@@ -150,6 +154,7 @@ class ChatDialogViewModel @Inject constructor(
     @SuppressLint("CheckResult")
     fun loadMessagesByPeer(interlocutorId: String) {
         _uiState.value = ChatDialogUiState.Loading()
+        val startTime = System.currentTimeMillis()
         viewModelScope.launch {
             try {
                 userRepository.getProfileInfo().subscribeOn(Schedulers.io())
@@ -198,6 +203,8 @@ class ChatDialogViewModel @Inject constructor(
                                         limit = 50,
                                         lastMessageId = null,
                                     ).sortedBy { it.createdAt }
+                                    val elapsed = System.currentTimeMillis() - startTime
+                                    if (elapsed < 1500L) delay(1500L - elapsed)
                                     _uiState.value = ChatDialogUiState.Success(
                                         chats = messages,
                                         chatName = name,
@@ -209,6 +216,8 @@ class ChatDialogViewModel @Inject constructor(
                                     markMessagesRead(dialogId, messages)
                                 }
                             } else {
+                                val elapsed = System.currentTimeMillis() - startTime
+                                if (elapsed < 1500L) delay(1500L - elapsed)
                                 _uiState.value = ChatDialogUiState.Success(
                                     chats = emptyList(),
                                     chatName = name,

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.repositories.chat.ChatRepository
@@ -37,6 +38,7 @@ class ChatListViewModel @Inject constructor(
     val selectedChats: StateFlow<Set<Long>> = _selectedChats
 
     fun loadFolders() {
+        _uiState.value = ChatListUiState.Loading
         viewModelScope.launch {
             try {
                 val folderList = chatRepository.getFolders()
@@ -51,10 +53,13 @@ class ChatListViewModel @Inject constructor(
 
     fun loadChats(folderId: Long? = currentFolderId) {
         _uiState.value = ChatListUiState.Loading
+        val startTime = System.currentTimeMillis()
         viewModelScope.launch {
             try {
                 val chats = chatRepository.getChats(folderId)
                 currentFolderId = folderId
+                val elapsed = System.currentTimeMillis() - startTime
+                if (elapsed < 1500L) delay(1500L - elapsed)
                 _uiState.value = ChatListUiState.Success(chats)
             } catch (e: Exception) {
                 _uiState.value = ChatListUiState.Error(e.message ?: "Unknown error")

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -75,6 +74,7 @@ import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatDetailUiState
 import uddug.com.naukoteka.ui.chat.compose.components.ChatDetailMoreSheetDialog
+import uddug.com.naukoteka.ui.chat.compose.components.ChatDetailShimmer
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -134,9 +134,9 @@ fun ChatDetailDialogComponent(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues),
-                    contentAlignment = Alignment.Center
+                    contentAlignment = Alignment.TopStart
                 ) {
-                    CircularProgressIndicator()
+                    ChatDetailShimmer()
                 }
             }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ShimmerComponents.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ShimmerComponents.kt
@@ -90,3 +90,27 @@ fun MessageListShimmer() {
         }
     }
 }
+
+@Composable
+fun ChatDetailShimmer() {
+    val shimmer: Shimmer = rememberShimmer(
+        shimmerBounds = ShimmerBounds.View
+    )
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        items((1..6).toList()) { _ ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(80.dp)
+                    .padding(vertical = 8.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0xFFE0E0E0))
+                    .shimmer(shimmer)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show loading shimmer before chat list and dialog data and keep it for at least 1.5 seconds
- add chat detail shimmer with same gray color as chat list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5973603248327a763949e6e5e898e