### PR TITLE
Add global search API for chats and messages

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -9,16 +9,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
 import uddug.com.naukoteka.mvvm.chat.ChatListUiState
+import uddug.com.naukoteka.mvvm.chat.SearchResult
 import uddug.com.naukoteka.ui.chat.compose.components.ChatFunctionsBottomSheetDialog
 import uddug.com.naukoteka.ui.chat.compose.components.ChatTabBar
 import uddug.com.naukoteka.ui.chat.compose.components.ChatToolbarComponent
 import uddug.com.naukoteka.ui.chat.compose.components.SearchField
+import uddug.com.naukoteka.ui.chat.compose.components.SearchResultItem
 
 @Composable
 fun ChatListComponent(
@@ -48,22 +52,36 @@ fun ChatListComponent(
             onDeleteSelected = { viewModel.deleteSelectedChats() },
             onMoreClick = { }
         )
+        var query by remember { mutableStateOf("") }
+        val searchResults by viewModel.searchResults.collectAsState()
+
         SearchField(
             title = stringResource(R.string.find_chat_message),
-            query = "",
+            query = query,
             onSearchChanged = {
-
+                query = it
+                viewModel.search(it)
             }
         )
-        ChatTabBar(
-            viewModel = viewModel,
-            onChatLongClick = { id -> selectedDialogId = id },
-            isSelectionMode = isSelectionMode,
-            selectedChats = selectedChats,
-            onChatSelect = { viewModel.toggleChatSelection(it) },
-            onOpenFolderSettings = onFolderSettings,
-            onChangeFolderOrder = onChangeFolderOrder
-        )
+        if (query.isEmpty()) {
+            ChatTabBar(
+                viewModel = viewModel,
+                onChatLongClick = { id -> selectedDialogId = id },
+                isSelectionMode = isSelectionMode,
+                selectedChats = selectedChats,
+                onChatSelect = { viewModel.toggleChatSelection(it) },
+                onOpenFolderSettings = onFolderSettings,
+                onChangeFolderOrder = onChangeFolderOrder
+            )
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(searchResults) { result ->
+                    SearchResultItem(result = result) {
+                        viewModel.onChatClick(it)
+                    }
+                }
+            }
+        }
     }
 
     selectedDialogId?.let { id ->

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchResultItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchResultItem.kt
@@ -1,0 +1,37 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import uddug.com.naukoteka.mvvm.chat.SearchResult
+
+@Composable
+fun SearchResultItem(
+    result: SearchResult,
+    onClick: (Long) -> Unit,
+) {
+    val name = when (result) {
+        is SearchResult.Dialog -> result.data.fullName
+        is SearchResult.Message -> result.data.fullName
+    }
+    val message = when (result) {
+        is SearchResult.Dialog -> ""
+        is SearchResult.Message -> result.data.text ?: ""
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick(result.dialogId) }
+            .padding(16.dp)
+    ) {
+        Text(text = name)
+        if (message.isNotEmpty()) {
+            Text(text = message, modifier = Modifier.padding(top = 4.dp))
+        }
+    }
+}

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -25,6 +25,8 @@ import uddug.com.data.services.models.response.chat.MessageDto
 import uddug.com.data.services.models.response.chat.FileDto
 import uddug.com.data.services.models.response.user_profile.UserProfileFullInfoDto
 import uddug.com.data.services.models.response.chat.SearchUsersDto
+import uddug.com.data.services.models.response.chat.SearchDialogDto
+import uddug.com.data.services.models.response.chat.SearchMessageDto
 import uddug.com.domain.entities.chat.MediaMessage
 
 interface ChatApiService {
@@ -126,6 +128,21 @@ interface ChatApiService {
         @Body request: DeleteMessagesRequestDto,
         @Query("forMe") forMe: Boolean = false,
     )
+
+    @GET("chat/v1/dialogs/global/search")
+    suspend fun searchDialogs(
+        @Query("category") category: Int = 21,
+        @Query("q") query: String,
+        @Query("limit") limit: Int = 10,
+    ): List<SearchDialogDto>
+
+    @GET("chat/v1/dialogs/global/search")
+    suspend fun searchMessages(
+        @Query("category") category: Int = 22,
+        @Query("q") query: String,
+        @Query("lastMessageId") lastMessageId: Long? = null,
+        @Query("limit") limit: Int = 10,
+    ): List<SearchMessageDto>
 
     @GET("chat/v1/users/search")
     suspend fun searchUsers(

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/SearchDialogDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/SearchDialogDto.kt
@@ -1,0 +1,13 @@
+package uddug.com.data.services.models.response.chat
+
+import com.google.gson.annotations.SerializedName
+
+/** DTO for dialog search result */
+data class SearchDialogDto(
+    @SerializedName("dialogId") val dialogId: Long,
+    @SerializedName("dialogType") val dialogType: Int,
+    @SerializedName("messageId") val messageId: Long,
+    @SerializedName("fullName") val fullName: String,
+    @SerializedName("image") val image: ImageDto?,
+    @SerializedName("createdAt") val createdAt: String,
+)

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/SearchMessageDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/SearchMessageDto.kt
@@ -1,0 +1,15 @@
+package uddug.com.data.services.models.response.chat
+
+import com.google.gson.annotations.SerializedName
+
+/** DTO for message search result */
+data class SearchMessageDto(
+    @SerializedName("dialogId") val dialogId: Long,
+    @SerializedName("messageId") val messageId: Long,
+    @SerializedName("fullName") val fullName: String,
+    @SerializedName("image") val image: ImageDto?,
+    @SerializedName("userId") val userId: String,
+    @SerializedName("status") val status: StatusDto,
+    @SerializedName("text") val text: String?,
+    @SerializedName("createdAt") val createdAt: String,
+)

--- a/domain/src/main/java/uddug/com/domain/entities/chat/SearchResult.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/SearchResult.kt
@@ -1,0 +1,26 @@
+package uddug.com.domain.entities.chat
+
+import java.time.Instant
+
+/** Search result for dialog */
+data class SearchDialog(
+    val dialogId: Long,
+    val dialogType: Int,
+    val messageId: Long,
+    val fullName: String,
+    val image: String?,
+    val createdAt: Instant,
+)
+
+/** Search result for message */
+data class SearchMessage(
+    val dialogId: Long,
+    val messageId: Long,
+    val fullName: String,
+    val image: String?,
+    val userId: String,
+    val isOnline: Boolean,
+    val lastSeen: String?,
+    val text: String?,
+    val createdAt: Instant,
+)

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -5,6 +5,8 @@ import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.domain.entities.chat.SearchDialog
+import uddug.com.domain.entities.chat.SearchMessage
 import uddug.com.domain.entities.chat.UserStatus
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.repositories.chat.ChatRepository
@@ -86,4 +88,13 @@ class ChatInteractor @Inject constructor(
 
     suspend fun getUsersStatus(userIds: List<String>): List<UserStatus> =
         chatRepository.getUsersStatus(userIds)
+
+    suspend fun searchDialogs(query: String, limit: Int = 10): List<SearchDialog> =
+        chatRepository.searchDialogs(query, limit)
+
+    suspend fun searchMessages(
+        query: String,
+        lastMessageId: Long? = null,
+        limit: Int = 10,
+    ): List<SearchMessage> = chatRepository.searchMessages(query, lastMessageId, limit)
 }

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -5,6 +5,8 @@ import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.domain.entities.chat.SearchDialog
+import uddug.com.domain.entities.chat.SearchMessage
 import uddug.com.domain.entities.chat.UserStatus
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.entities.chat.File as ChatFile
@@ -92,4 +94,12 @@ interface ChatRepository {
     suspend fun uploadFiles(files: List<JavaFile>, raw: Boolean = false): List<ChatFile>
 
     suspend fun getUsersStatus(userIds: List<String>): List<UserStatus>
+
+    suspend fun searchDialogs(query: String, limit: Int = 10): List<SearchDialog>
+
+    suspend fun searchMessages(
+        query: String,
+        lastMessageId: Long? = null,
+        limit: Int = 10,
+    ): List<SearchMessage>
 }


### PR DESCRIPTION
## Summary
- implement `/dialogs/global/search` API for dialogs and messages
- add repository and interactor methods for global search
- integrate search into chat list with UI results

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c5cb043c8327a974702962262182