### PR TITLE
Add voice message recording to chat

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <!-- Devices running Android 12L (API level 32) or lower  -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/AudioRecorder.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/AudioRecorder.kt
@@ -1,0 +1,45 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.content.Context
+import android.media.MediaRecorder
+import java.io.File
+import java.io.IOException
+
+class AudioRecorder(private val context: Context) {
+    private var recorder: MediaRecorder? = null
+    private var outputFile: File? = null
+
+    fun start(): File? {
+        return try {
+            val file = File.createTempFile("voice_", ".m4a", context.cacheDir)
+            recorder = MediaRecorder().apply {
+                setAudioSource(MediaRecorder.AudioSource.MIC)
+                setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+                setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+                setOutputFile(file.absolutePath)
+                prepare()
+                start()
+            }
+            outputFile = file
+            file
+        } catch (e: IOException) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+    fun stop(): File? {
+        return try {
+            recorder?.apply {
+                stop()
+                release()
+            }
+            recorder = null
+            outputFile
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+}
+

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -13,6 +13,8 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -36,8 +38,10 @@ fun ChatInputBar(
     currentMessage: String,
     attachedFiles: List<File>,
     replyMessage: MessageChat?,
+    isRecording: Boolean,
     onMessageChange: (String) -> Unit,
     onSendClick: () -> Unit,
+    onVoiceClick: () -> Unit,
     onAttachClick: () -> Unit,
     onRemoveFile: (File) -> Unit,
     onCancelReply: () -> Unit,
@@ -165,8 +169,18 @@ fun ChatInputBar(
                 shape = RoundedCornerShape(12.dp)
             )
 
-            IconButton(onClick = onSendClick) {
-                Icon(Icons.Default.Send, contentDescription = "Send", tint = Color(0XFF8083A0))
+            if (currentMessage.isBlank()) {
+                IconButton(onClick = onVoiceClick) {
+                    Icon(
+                        imageVector = if (isRecording) Icons.Filled.Stop else Icons.Filled.Mic,
+                        contentDescription = if (isRecording) "Stop" else "Record",
+                        tint = Color(0XFF8083A0)
+                    )
+                }
+            } else {
+                IconButton(onClick = onSendClick) {
+                    Icon(Icons.Default.Send, contentDescription = "Send", tint = Color(0XFF8083A0))
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add microphone button and voice recording in chat input
- support sending voice messages with cType 4 and fileType 21
- request audio recording permission

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c61bbe60832785380f198c0eadc4