### PR TITLE
feat: add reply support for chat messages

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -362,6 +362,9 @@ class ChatDialogViewModel @Inject constructor(
     fun sendMessage(text: String) {
         viewModelScope.launch {
             val dialog = currentDialogInfo ?: return@launch
+            val currentState = _uiState.value
+            val replyId = (currentState as? ChatDialogUiState.Success)?.replyMessage?.id
+
             if (text.isBlank() && attachedFiles.isEmpty()) {
                 Log.d("ChatViewModel", "Message is blank and no files attached — skipping")
                 return@launch
@@ -391,7 +394,8 @@ class ChatDialogViewModel @Inject constructor(
                     cType = cType,
                     text = text,
                     owner = currentUser?.id.orEmpty(),
-                    files = fileDescriptors.ifEmpty { null }
+                    files = fileDescriptors.ifEmpty { null },
+                    answered = replyId
                 )
             } else {
                 val peer = dialog.interlocutor?.userId ?: return@launch
@@ -400,10 +404,10 @@ class ChatDialogViewModel @Inject constructor(
                     cType = cType,
                     text = text,
                     owner = currentUser?.id.orEmpty(),
-                    files = fileDescriptors.ifEmpty { null }
+                    files = fileDescriptors.ifEmpty { null },
+                    answered = replyId
                 )
             }
-            val currentState = _uiState.value
             if (currentState is ChatDialogUiState.Success) {
                 _uiState.value = currentState.copy(currentMessage = "")
             }
@@ -464,6 +468,23 @@ class ChatDialogViewModel @Inject constructor(
                     currentDialogID = socketMessage.dialog
                 }
 
+                val replyPreview = socketMessage.ansPreview?.let { preview ->
+                    MessageChat(
+                        id = preview.i,
+                        text = preview.t,
+                        type = MessageType.TEXT,
+                        files = emptyList(),
+                        ownerId = preview.o?.i,
+                        createdAt = Instant.now(),
+                        readCount = 0,
+                        ownerName = preview.o?.fn,
+                        ownerAvatarUrl = preview.o?.im,
+                        ownerIsAdmin = false,
+                        isMine = preview.o?.i == currentUser?.id,
+                        replyTo = null
+                    )
+                }
+
                 val newMessage = MessageChat(
                     id = 0,
                     text = socketMessage.text,
@@ -476,7 +497,7 @@ class ChatDialogViewModel @Inject constructor(
                     ownerAvatarUrl = currentDialogInfo?.interlocutor?.image,
                     ownerIsAdmin = false,
                     isMine = socketMessage.owner == currentUser?.id,
-                    replyTo = null
+                    replyTo = replyPreview
                 )
 
                 val currentState = _uiState.value

--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
@@ -7,9 +7,37 @@ data class ChatSocketMessage(
     val text: String,
     val owner: String? = null,
     val files: List<FileDescriptor>? = null,
+    val answered: Long? = null,
+    val ansPreview: AnswerPreview? = null,
 )
 
 public data class FileDescriptor(
     val id: String,
     val fileType: Int
+)
+
+data class AnswerPreview(
+    val i: Long,
+    val mt: Int? = null,
+    val o: PreviewOwner? = null,
+    val t: String? = null,
+    val f: PreviewFile? = null,
+    val st: List<PreviewFileStat>? = null,
+)
+
+data class PreviewOwner(
+    val i: String? = null,
+    val fn: String? = null,
+    val im: String? = null,
+)
+
+data class PreviewFile(
+    val path: String? = null,
+    val fileName: String? = null,
+    val fileType: Int? = null,
+)
+
+data class PreviewFileStat(
+    val c: Int? = null,
+    val ft: Int? = null,
 )


### PR DESCRIPTION
## Summary
- handle message replies by passing answered message ID via sockets
- parse reply previews from socket messages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c67a29f083278eef3e76502c0a5d