### PR TITLE
Implement dialog search feature

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessagesList.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessagesList.kt
@@ -8,10 +8,25 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.material.Text
 import uddug.com.domain.entities.chat.MessageChat
-import uddug.com.naukoteka.utils.ui.dp
 
 @Composable
 fun ChatMessagesList(messages: List<MessageChat>) {
-
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(8.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        items(messages) { message ->
+            Text(
+                text = message.text.orEmpty(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp)
+            )
+        }
+    }
 }

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -125,6 +125,31 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun searchMessages(
+        currentUserId: String,
+        dialogId: Long,
+        searchField: String,
+        limit: Int,
+        lastMessageId: Long?,
+        sd: String?,
+        ed: String?,
+    ): List<MessageChat> {
+        return try {
+            val messages = apiService.searchMessages(
+                dialogId,
+                searchField = searchField,
+                limit = limit,
+                lastMessageId = lastMessageId,
+                sd = sd,
+                ed = ed,
+            )
+            messages.map { it.toDomain(currentUserId) }
+        } catch (e: Exception) {
+            println("Error searching messages: ${e.message}")
+            emptyList()
+        }
+    }
+
     override suspend fun createDialog(
         dialogName: String?,
         userRoles: Map<String, String?>,

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -52,6 +52,16 @@ interface ChatApiService {
         @Path("interlocutorId") interlocutorId: String,
     ): DialogInfoDto
 
+    @GET("chat/v1/dialogs/search-messages/{dialogId}")
+    suspend fun searchMessages(
+        @Path("dialogId") dialogId: Long,
+        @Query("searchField") searchField: String,
+        @Query("limit") limit: Int? = null,
+        @Query("lastMessageId") lastMessageId: Long? = null,
+        @Query("sd") sd: String? = null,
+        @Query("ed") ed: String? = null,
+    ): List<MessageDto>
+
     @GET("chat/v1/dialogs/media/{dialogId}")
     suspend fun getDialogMedia(
         @Path("dialogId") dialogId: Long,

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -50,6 +50,17 @@ class ChatInteractor @Inject constructor(
     ): List<MediaMessage> =
         chatRepository.getDialogMedia(dialogId, category, limit, page, query, sd, ed)
 
+    suspend fun searchMessages(
+        currentUserId: String,
+        dialogId: Long,
+        searchField: String,
+        limit: Int = 50,
+        lastMessageId: Long? = null,
+        sd: String? = null,
+        ed: String? = null,
+    ): List<MessageChat> =
+        chatRepository.searchMessages(currentUserId, dialogId, searchField, limit, lastMessageId, sd, ed)
+
     suspend fun createDialog(dialogName: String?, userRoles: Map<String, String?>): Long =
         chatRepository.createDialog(dialogName = dialogName, userRoles = userRoles)
 

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -43,6 +43,16 @@ interface ChatRepository {
         ed: String?,
     ): List<MediaMessage>
 
+    suspend fun searchMessages(
+        currentUserId: String,
+        dialogId: Long,
+        searchField: String,
+        limit: Int = 50,
+        lastMessageId: Long? = null,
+        sd: String? = null,
+        ed: String? = null,
+    ): List<MessageChat>
+
     suspend fun createDialog(
         dialogName: String?,
         userRoles: Map<String, String?>,


### PR DESCRIPTION
## Summary
- add API, repository, and interactor methods to search messages in a dialog
- expose search results in dialog view model and trigger search from search screen with tabbed media results
- display matched messages in a simple list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c7671c688327a93ac8d87d396e3c