### PR TITLE
Fix chat tab switching and folder settings navigation

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -42,6 +42,8 @@ class ChatListViewModel @Inject constructor(
     private val _searchResults = MutableStateFlow<List<SearchResult>>(emptyList())
     val searchResults: StateFlow<List<SearchResult>> = _searchResults
 
+    private var loadChatsJob: kotlinx.coroutines.Job? = null
+
     fun loadFolders() {
         _uiState.value = ChatListUiState.Loading
         viewModelScope.launch {
@@ -58,11 +60,12 @@ class ChatListViewModel @Inject constructor(
 
     fun loadChats(folderId: Long? = currentFolderId) {
         _uiState.value = ChatListUiState.Loading
+        loadChatsJob?.cancel()
         val startTime = System.currentTimeMillis()
-        viewModelScope.launch {
+        currentFolderId = folderId
+        loadChatsJob = viewModelScope.launch {
             try {
                 val chats = chatRepository.getChats(folderId)
-                currentFolderId = folderId
                 val elapsed = System.currentTimeMillis() - startTime
                 if (elapsed < 1500L) delay(1500L - elapsed)
                 _uiState.value = ChatListUiState.Success(chats)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
@@ -123,7 +123,9 @@ class ChatListFragment : Fragment() {
                                 }
                             )
                         },
-                        onFolderSettings = { },
+                        onFolderSettings = {
+                            findNavController().navigate(R.id.chatFolderSettingsFragment)
+                        },
                         onChangeFolderOrder = {
                             findNavController().navigate(R.id.chatFolderSettingsFragment)
                         }


### PR DESCRIPTION
## Summary
- Cancel previous chat loading when switching folders to ensure tab changes take effect
- Wire up navigation to the folder settings screen from the chat list menu

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cf3176448327a18b02722de0d151