### PR TITLE
Fix search in chat details by passing dialog ID

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.naukoteka.mvvm.chat.ChatDialogDetailViewModel
+import uddug.com.naukoteka.mvvm.chat.ChatDetailUiState
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatDetailDialogComponent
@@ -80,7 +81,13 @@ class ChatDetailDialogFragment : Fragment() {
                             viewModel.getCurrentUser()?.let { navigationView?.selectShowEditFragment(it) }
                         },
                         onSearchClick = {
-                            findNavController().navigate(R.id.chatDetailSearchFragment)
+                            val dialogId = (viewModel.uiState.value as? ChatDetailUiState.Success)?.dialogId
+                                ?: arguments?.getLong(DIALOG_ID)
+                                ?: 0L
+                            findNavController().navigate(
+                                R.id.chatDetailSearchFragment,
+                                Bundle().apply { putLong(DIALOG_ID, dialogId) }
+                            )
                         },
                         onChatDeleted = {
                             findNavController().popBackStack(R.id.chatListFragment, false)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogSearchFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogSearchFragment.kt
@@ -25,6 +25,8 @@ class ChatDetailDialogSearchFragment : Fragment() {
     ): View? {
         requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
 
+        arguments?.getLong(ChatDetailDialogFragment.DIALOG_ID)?.let { viewModel.loadDialogInfo(it) }
+
         return ComposeView(requireContext()).apply {
             setContent {
                 MaterialTheme {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -35,6 +35,8 @@ class ChatDialogFragment : Fragment() {
 
     private val viewModel: ChatDialogViewModel by viewModels()
 
+    private var dialogId: Long = 0
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         navigationView = requireActivity() as ContainerNavigationView
@@ -53,7 +55,7 @@ class ChatDialogFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
-        val dialogId = arguments?.getLong(DIALOG_ID) ?: 0
+        dialogId = arguments?.getLong(DIALOG_ID) ?: 0
         val peerId = arguments?.getString(INTERLOCUTOR_ID)
         if (dialogId != 0L) {
             viewModel.loadMessages(dialogId)
@@ -109,7 +111,10 @@ class ChatDialogFragment : Fragment() {
                             requireActivity().onBackPressed()
                         },
                         onSearchClick = {
-                            findNavController().navigate(R.id.chatDetailSearchFragment)
+                            findNavController().navigate(
+                                R.id.chatDetailSearchFragment,
+                                Bundle().apply { putLong(ChatDetailDialogFragment.DIALOG_ID, dialogId) }
+                            )
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailViewModel
+import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailUiState
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatGroupDetailComponent
 
@@ -75,7 +76,13 @@ class ChatGroupDetailFragment : Fragment() {
                     ChatGroupDetailComponent(
                         viewModel = viewModel,
                         onBackPressed = { requireActivity().onBackPressed() },
-                        onSearchClick = { findNavController().navigate(R.id.chatDetailSearchFragment) }
+                        onSearchClick = {
+                            val dialogId = (viewModel.uiState.value as? ChatGroupDetailUiState.Success)?.dialogId ?: 0L
+                            findNavController().navigate(
+                                R.id.chatDetailSearchFragment,
+                                Bundle().apply { putLong(ChatDetailDialogFragment.DIALOG_ID, dialogId) }
+                            )
+                        }
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- pass dialog id when navigating to search from chat, dialog detail and group detail screens
- load dialog info in search fragment so API is triggered

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d03bf1448327a497f4d64f1353d8