### PR TITLE
Improve chat list search UX

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -42,6 +42,9 @@ class ChatListViewModel @Inject constructor(
     private val _searchResults = MutableStateFlow<List<SearchResult>>(emptyList())
     val searchResults: StateFlow<List<SearchResult>> = _searchResults
 
+    private val _isSearchLoading = MutableStateFlow(false)
+    val isSearchLoading: StateFlow<Boolean> = _isSearchLoading
+
     fun loadFolders() {
         _uiState.value = ChatListUiState.Loading
         viewModelScope.launch {
@@ -155,11 +158,13 @@ class ChatListViewModel @Inject constructor(
     }
 
     fun search(query: String) {
-        if (query.isBlank()) {
+        if (query.length < 4) {
             _searchResults.value = emptyList()
+            _isSearchLoading.value = false
             return
         }
         viewModelScope.launch {
+            _isSearchLoading.value = true
             try {
                 val dialogs = chatRepository.searchDialogs(query)
                 val messages = chatRepository.searchMessages(query)
@@ -168,6 +173,8 @@ class ChatListViewModel @Inject constructor(
                 _searchResults.value = results
             } catch (_: Exception) {
                 _searchResults.value = emptyList()
+            } finally {
+                _isSearchLoading.value = false
             }
         }
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -19,6 +19,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
 import uddug.com.naukoteka.mvvm.chat.ChatListUiState
 import uddug.com.naukoteka.mvvm.chat.SearchResult
 import uddug.com.naukoteka.ui.chat.compose.components.ChatFunctionsBottomSheetDialog
+import uddug.com.naukoteka.ui.chat.compose.components.ChatListShimmer
 import uddug.com.naukoteka.ui.chat.compose.components.ChatTabBar
 import uddug.com.naukoteka.ui.chat.compose.components.ChatToolbarComponent
 import uddug.com.naukoteka.ui.chat.compose.components.SearchField
@@ -54,6 +55,7 @@ fun ChatListComponent(
         )
         var query by remember { mutableStateOf("") }
         val searchResults by viewModel.searchResults.collectAsState()
+        val isSearchLoading by viewModel.isSearchLoading.collectAsState()
 
         SearchField(
             title = stringResource(R.string.find_chat_message),
@@ -63,7 +65,7 @@ fun ChatListComponent(
                 viewModel.search(it)
             }
         )
-        if (query.isEmpty()) {
+        if (query.length < 4) {
             ChatTabBar(
                 viewModel = viewModel,
                 onChatLongClick = { id -> selectedDialogId = id },
@@ -74,10 +76,13 @@ fun ChatListComponent(
                 onChangeFolderOrder = onChangeFolderOrder
             )
         } else {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(searchResults) { result ->
-                    SearchResultItem(result = result) {
-                        viewModel.onChatClick(it)
+            when {
+                isSearchLoading -> ChatListShimmer()
+                else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(searchResults) { result ->
+                        SearchResultItem(result = result) {
+                            viewModel.onChatClick(it)
+                        }
                     }
                 }
             }

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -268,9 +268,9 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun searchDialogs(query: String, limit: Int): List<SearchDialog> {
+    override suspend fun searchDialogs(query: String): List<SearchDialog> {
         return try {
-            apiService.searchDialogs(query = query, limit = limit).map { it.toDomain() }
+            apiService.searchDialogs(query = query).map { it.toDomain() }
         } catch (e: Exception) {
             println("search dialogs error ${e.message}")
             emptyList()
@@ -280,10 +280,9 @@ class ChatRepositoryImpl @Inject constructor(
     override suspend fun searchMessages(
         query: String,
         lastMessageId: Long?,
-        limit: Int,
     ): List<SearchMessage> {
         return try {
-            apiService.searchMessages(query = query, lastMessageId = lastMessageId, limit = limit)
+            apiService.searchMessages(query = query, lastMessageId = lastMessageId)
                 .map { it.toDomain() }
         } catch (e: Exception) {
             println("search messages error ${e.message}")

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -143,7 +143,7 @@ interface ChatApiService {
     suspend fun searchDialogs(
         @Query("category") category: Int = 21,
         @Query("q") query: String,
-        @Query("limit") limit: Int = 10,
+        @Query("limit") limit: Int? = null,
     ): List<SearchDialogDto>
 
     @GET("chat/v1/dialogs/global/search")
@@ -151,7 +151,7 @@ interface ChatApiService {
         @Query("category") category: Int = 22,
         @Query("q") query: String,
         @Query("lastMessageId") lastMessageId: Long? = null,
-        @Query("limit") limit: Int = 10,
+        @Query("limit") limit: Int? = null,
     ): List<SearchMessageDto>
 
     @GET("chat/v1/users/search")

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -100,12 +100,11 @@ class ChatInteractor @Inject constructor(
     suspend fun getUsersStatus(userIds: List<String>): List<UserStatus> =
         chatRepository.getUsersStatus(userIds)
 
-    suspend fun searchDialogs(query: String, limit: Int = 10): List<SearchDialog> =
-        chatRepository.searchDialogs(query, limit)
+    suspend fun searchDialogs(query: String): List<SearchDialog> =
+        chatRepository.searchDialogs(query)
 
     suspend fun searchMessages(
         query: String,
         lastMessageId: Long? = null,
-        limit: Int = 10,
-    ): List<SearchMessage> = chatRepository.searchMessages(query, lastMessageId, limit)
+    ): List<SearchMessage> = chatRepository.searchMessages(query, lastMessageId)
 }

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -105,11 +105,10 @@ interface ChatRepository {
 
     suspend fun getUsersStatus(userIds: List<String>): List<UserStatus>
 
-    suspend fun searchDialogs(query: String, limit: Int = 10): List<SearchDialog>
+    suspend fun searchDialogs(query: String): List<SearchDialog>
 
     suspend fun searchMessages(
         query: String,
         lastMessageId: Long? = null,
-        limit: Int = 10,
     ): List<SearchMessage>
 }


### PR DESCRIPTION
## Summary
- Start chat search only after four characters are entered
- Display shimmering placeholder while search results load
- Remove API limit to return all dialog and message matches

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d069062c8327a62285d544b5ad95