### PR TITLE
Fix selection toolbar height and animate chat list checkboxes

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -22,6 +23,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -158,31 +160,42 @@ fun ChatDialogComponent(
                 is ChatDialogUiState.Success -> {
                     val messages = state.chats
                     if (isSelectionMode) {
-                        TopAppBar(
-                            title = {
-                                Text(text = selectedMessages.size.toString(), fontSize = 20.sp, color = Color.Black)
-                            },
-                            navigationIcon = {
-                                IconButton(onClick = { viewModel.clearSelection() }) {
-                                    Icon(
-                                        painter = painterResource(id = R.drawable.ic_close),
-                                        contentDescription = "Close",
-                                        tint = Color.Black
-                                    )
-                                }
-                            },
-                            actions = {
-                                IconButton(onClick = { viewModel.deleteSelectedMessages() }) {
-                                    Icon(
-                                        painter = painterResource(id = R.drawable.ic_trash),
-                                        contentDescription = "Delete",
-                                        tint = Color.Black
-                                    )
-                                }
-                            },
-                            backgroundColor = Color.White,
-                            elevation = 4.dp
-                        )
+                        Surface(elevation = 4.dp) {
+                            Column {
+                                TopAppBar(
+                                    modifier = Modifier.height(68.dp),
+                                    title = {
+                                        Text(text = selectedMessages.size.toString(), fontSize = 20.sp, color = Color.Black)
+                                    },
+                                    navigationIcon = {
+                                        IconButton(onClick = { viewModel.clearSelection() }) {
+                                            Icon(
+                                                painter = painterResource(id = R.drawable.ic_close),
+                                                contentDescription = "Close",
+                                                tint = Color.Black
+                                            )
+                                        }
+                                    },
+                                    actions = {
+                                        IconButton(onClick = { viewModel.deleteSelectedMessages() }) {
+                                            Icon(
+                                                painter = painterResource(id = R.drawable.ic_trash),
+                                                contentDescription = "Delete",
+                                                tint = Color.Black
+                                            )
+                                        }
+                                    },
+                                    backgroundColor = Color.White,
+                                    elevation = 0.dp
+                                )
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(1.dp)
+                                        .background(Color(0xFFEAEAF2))
+                                )
+                            }
+                        }
                     } else {
                         ChatTopBar(
                             name = state.chatName,

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -6,6 +6,10 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -79,16 +83,16 @@ fun ChatCard(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(16.dp)
+                    .animateContentSize(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (selectionMode) {
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .padding(end = 8.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
+                AnimatedVisibility(
+                    visible = selectionMode,
+                    enter = expandHorizontally(),
+                    exit = shrinkHorizontally()
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         Checkbox(
                             checked = isSelected,
                             onCheckedChange = { onSelectChange(it) },
@@ -98,6 +102,7 @@ fun ChatCard(
                                 checkmarkColor = Color.White
                             )
                         )
+                        Spacer(modifier = Modifier.width(8.dp))
                     }
                 }
                 AsyncImage(


### PR DESCRIPTION
## Summary
- Prevent ChatDialog layout jump by giving selection toolbar a fixed height and bottom divider
- Animate chat list checkboxes and layout when entering selection mode

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0ba9d44832797454bc947b1b0c6