### PR TITLE
Animate mic during voice recording and send message

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -248,13 +248,14 @@ fun ChatDialogComponent(
                         },
                         onVoiceClick = {
                             if (isRecording) {
-                                audioRecorder.stop()?.let { file ->
+                                val recordedFile = audioRecorder.stop()
+                                isRecording = false
+                                recordedFile?.let { file ->
                                     scope.launch {
                                         viewModel.sendVoiceMessage(file)
                                         scrollState.animateScrollToItem(messages.size - 1)
                                     }
                                 }
-                                isRecording = false
                             } else {
                                 audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -14,18 +14,24 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Mic
-import androidx.compose.material.icons.filled.Stop
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import coil.compose.AsyncImage
 import uddug.com.naukoteka.R
 import uddug.com.domain.entities.chat.MessageChat
@@ -171,11 +177,29 @@ fun ChatInputBar(
 
             if (currentMessage.isBlank()) {
                 IconButton(onClick = onVoiceClick) {
-                    Icon(
-                        imageVector = if (isRecording) Icons.Filled.Stop else Icons.Filled.Mic,
-                        contentDescription = if (isRecording) "Stop" else "Record",
-                        tint = Color(0XFF8083A0)
-                    )
+                    if (isRecording) {
+                        val transition = rememberInfiniteTransition()
+                        val scale by transition.animateFloat(
+                            initialValue = 1f,
+                            targetValue = 1.3f,
+                            animationSpec = infiniteRepeatable(
+                                animation = tween(500, easing = FastOutSlowInEasing),
+                                repeatMode = RepeatMode.Reverse
+                            )
+                        )
+                        Icon(
+                            imageVector = Icons.Filled.Mic,
+                            contentDescription = "Stop",
+                            tint = Color.Red,
+                            modifier = Modifier.scale(scale)
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Filled.Mic,
+                            contentDescription = "Record",
+                            tint = Color(0XFF8083A0)
+                        )
+                    }
                 }
             } else {
                 IconButton(onClick = onSendClick) {


### PR DESCRIPTION
## Summary
- Animate microphone icon during voice message recording
- Send recorded voice file after stopping

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b18f797ea48327a5dd55e3b01a1684