### PR TITLE
Switch mic icon to send when attachments exist

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -178,7 +178,7 @@ fun ChatInputBar(
                 shape = RoundedCornerShape(12.dp)
             )
 
-            if (currentMessage.isBlank()) {
+            if (currentMessage.isBlank() && attachedFiles.isEmpty()) {
                 IconButton(onClick = onVoiceClick) {
                     if (isRecording) {
                         val transition = rememberInfiniteTransition()


### PR DESCRIPTION
## Summary
- replace voice recorder button with send button when files are attached in chat input bar

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :domain:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b198463c1c8327a7a9328557802351