### PR TITLE
feat: show placeholder for missing avatars

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/Avatar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/Avatar.kt
@@ -1,43 +1,67 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.naukoteka.BuildConfig
-import java.time.format.DateTimeFormatter
 
 @Composable
-fun Avatar(url: String?) {
-    if (url != null) {
+fun Avatar(url: String?, name: String?, size: Dp = 36.dp) {
+    if (!url.isNullOrEmpty()) {
         AsyncImage(
             model = BuildConfig.IMAGE_SERVER_URL.plus(url),
             contentDescription = "avatar",
             modifier = Modifier
-                .size(36.dp)
+                .size(size)
                 .clip(CircleShape)
         )
     } else {
+        val initials = name.orEmpty()
+            .split(" ")
+            .mapNotNull { it.firstOrNull()?.uppercase() }
+            .take(2)
+            .joinToString("")
+        val gradient = getGradientForName(name.orEmpty())
         Box(
             modifier = Modifier
-                .size(36.dp)
+                .size(size)
                 .clip(CircleShape)
-                .background(Color.Green)
-        )
+                .background(gradient),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = initials,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = (size.value * 0.4f).sp
+            )
+        }
     }
+}
+
+fun getGradientForName(name: String): Brush {
+    return when (getHashCodeToString(name.hashCode(), 5)) {
+        0 -> Brush.linearGradient(listOf(Color(0xFF00C6FF), Color(0xFF0072FF)))
+        1 -> Brush.linearGradient(listOf(Color(0xFFFFA17F), Color(0xFFFF6F91)))
+        2 -> Brush.linearGradient(listOf(Color(0xFFB5FFFC), Color(0xFF6DD5ED)))
+        3 -> Brush.linearGradient(listOf(Color(0xFFC3CFE2), Color(0xFFA5A5A5)))
+        else -> Brush.linearGradient(listOf(Color(0xFFF857A6), Color(0xFFFF5858)))
+    }
+}
+
+fun getHashCodeToString(value: Int, mod: Int): Int {
+    return kotlin.math.abs(value) % mod
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.painterResource
@@ -105,17 +104,7 @@ fun ChatCard(
                         Spacer(modifier = Modifier.width(8.dp))
                     }
                 }
-                AsyncImage(
-                    model = avatarUrl?.let { BuildConfig.IMAGE_SERVER_URL + it },
-                    contentDescription = "Avatar",
-                    modifier = Modifier
-                        .size(40.dp)
-                        .clip(CircleShape),
-                    contentScale = ContentScale.Crop,
-                    placeholder = painterResource(id = R.drawable.ic_logo_naukoteka),
-                    error = painterResource(id = R.drawable.ic_logo_naukoteka),
-                    fallback = painterResource(id = R.drawable.ic_logo_naukoteka),
-                )
+                Avatar(avatarUrl, name, size = 40.dp)
                 Spacer(modifier = Modifier.width(16.dp))
 
                 // Основной контент
@@ -227,23 +216,7 @@ fun ChatCard(
     }
 }
 
-fun getGradientForName(name: String): Brush {
-    val gradientRes = when (getHashCodeToString(name.hashCode(), 8)) {
-        0 -> Brush.linearGradient(listOf(Color.Red, Color.Yellow))
-        1 -> Brush.linearGradient(listOf(Color.Green, Color.Blue))
-        2 -> Brush.linearGradient(listOf(Color.Cyan, Color.Magenta))
-        3 -> Brush.linearGradient(listOf(Color.Gray, Color.Black))
-        4 -> Brush.linearGradient(listOf(Color.LightGray, Color.DarkGray))
-        else -> Brush.linearGradient(listOf(Color.White, Color.Black))
-    }
-    return gradientRes
-}
-
 fun formatMessageTime(time: String): String {
     // Ваш код для форматирования времени
     return time
-}
-
-fun getHashCodeToString(value: Int, mod: Int): Int {
-    return value % mod
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -99,7 +99,7 @@ fun ChatMessageItem(
         ) {
             if (!isMine) {
                 // Аватарка
-                Avatar(message.ownerAvatarUrl)
+                Avatar(message.ownerAvatarUrl, message.ownerName)
                 Spacer(modifier = Modifier.width(8.dp))
             }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
@@ -89,26 +89,16 @@ fun ChatTopBar(
                                 }
                         )
                     } else {
-                        val firstLetter = name.firstOrNull()?.uppercase() ?: ""
                         Box(
                             modifier = Modifier
-                                .size(36.dp)
-                                .clip(CircleShape)
-                                .background(Color(0xFF2E83D9))
                                 .clickable(
                                     interactionSource = remember { MutableInteractionSource() },
                                     indication = null
                                 ) {
                                     onDetailClick()
-                                },
-                            contentAlignment = Alignment.Center
+                                }
                         ) {
-                            Text(
-                                text = firstLetter,
-                                color = Color.White,
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Bold
-                            )
+                            Avatar(null, name, size = 36.dp)
                         }
                     }
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/CreateChatMemberCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/CreateChatMemberCard.kt
@@ -1,10 +1,6 @@
-import android.text.format.DateUtils
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
@@ -13,22 +9,13 @@ import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
-import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
-import uddug.com.naukoteka.core.deeplink.formatMessageTime
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
 
 @Composable
 fun CreateChatMemberCard(
@@ -77,39 +64,7 @@ fun CreateChatMemberCard(
                       )
                       Spacer(modifier = Modifier.width(16.dp))
                   }
-                  if (avatarUrl.isNullOrEmpty()) {
-
-                    val initials = name.split(" ").let {
-                        (it.firstOrNull()?.firstOrNull()?.toString() ?: "") +
-                                (it.getOrNull(1)?.firstOrNull()?.toString() ?: "")
-                    }
-                    val gradientRes = getGradientForName(name)
-
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .background(
-                                color = Color(0xFF93DDFF), // Используем XML drawable
-                                shape = CircleShape
-                            )
-                    ) {
-
-                        Text(
-                            text = "Ч",
-                            style = TextStyle(color = Color.White, fontWeight = FontWeight.Bold),
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    }
-                } else {
-                    // Если URL не пустой, загружаем изображение
-                    AsyncImage(
-                        model = BuildConfig.IMAGE_SERVER_URL + avatarUrl,
-                        contentDescription = "Avatar",
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(CircleShape)
-                    )
-                  }
+                  Avatar(avatarUrl.takeIf { it.isNotEmpty() }, name, size = 40.dp)
                   Spacer(modifier = Modifier.width(16.dp))
 
                 // Основной контент


### PR DESCRIPTION
## Summary
- show gradient placeholder with initials when user avatar is missing
- use new Avatar component across chat screens

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1973f82508327b419e035803d18d3