### PR TITLE
feat: allow selecting multiple attachments

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.net.Uri
 import android.provider.ContactsContract
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -85,6 +86,15 @@ fun ChatDialogComponent(
         }
     }
 
+    val mediaPickerLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickMultipleVisualMedia()
+    ) { uris: List<Uri> ->
+        val files = uris.mapNotNull { uri -> uriToFile(context, uri) }
+        if (files.isNotEmpty()) {
+            viewModel.attachFiles(files)
+        }
+    }
+
     val filePickerLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenMultipleDocuments()
     ) { uris: List<Uri> ->
@@ -110,7 +120,9 @@ fun ChatDialogComponent(
         if (granted) {
             when (pendingPickerType) {
                 AttachmentPickerType.MEDIA ->
-                    filePickerLauncher.launch(arrayOf("image/*", "video/*"))
+                    mediaPickerLauncher.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageAndVideo)
+                    )
                 AttachmentPickerType.FILE ->
                     filePickerLauncher.launch(arrayOf("*/*"))
                 AttachmentPickerType.CONTACT ->


### PR DESCRIPTION
## Summary
- allow selecting multiple images and files in chat dialog using ActivityResultContracts.PickMultipleVisualMedia

## Testing
- `./gradlew test` (fails: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68b198723ae8832792b9489ef3ac4e17