### PR TITLE
Enable dialog search for short queries

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
@@ -126,13 +126,14 @@ class ChatDialogDetailViewModel @Inject constructor(
     fun getCurrentUser(): UserProfileFullInfo? = currentUser
 
     fun search(dialogId: Long, query: String) {
-        if (query.length < 3) {
+        if (query.isBlank()) {
             _searchMessages.value = emptyList()
             _searchMedia.value = emptyList()
             _searchFiles.value = emptyList()
             _searchNotes.value = emptyList()
             return
         }
+
         val userId = currentUser?.id ?: return
         viewModelScope.launch {
             try {


### PR DESCRIPTION
## Summary
- allow chat dialog search API calls for any non-blank query

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b198c72f488327941b2626bacbee23