### PR TITLE
Fix logout flow to clear credentials and navigate to login

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/fragments/profile/settings/ProfileSecurityFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/fragments/profile/settings/ProfileSecurityFragment.kt
@@ -3,6 +3,7 @@ package uddug.com.naukoteka.ui.fragments.profile.settings
 import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -27,6 +28,7 @@ import uddug.com.naukoteka.presentation.profile.edit.ProfileEditView
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.activities.main.ContainerActivity
 import uddug.com.naukoteka.ui.activities.main.ContainerActivity.Companion.PROFILE_ARGS
+import uddug.com.naukoteka.ui.activities.main.AuthActivity
 import uddug.com.naukoteka.ui.fragments.profile.edit.ProfileAvatarEditActionBottomSheetFragment
 import uddug.com.naukoteka.ui.fragments.profile.edit.ProfileAvatarEditActionBottomSheetFragment.Companion.DELETE_AVATAR_RESULT
 import uddug.com.naukoteka.ui.fragments.profile.edit.ProfileAvatarEditActionBottomSheetFragment.Companion.UPLOAD_AVATAR_RESULT
@@ -96,7 +98,9 @@ class ProfileSecurityFragment : BaseFragment(R.layout.fragment_profile_security)
     }
 
     override fun openLoginPage() {
-
+        val activity = requireActivity()
+        activity.finishAffinity()
+        activity.startActivity(Intent(activity, AuthActivity::class.java))
     }
 
     override fun openLogoutDialog() {
@@ -112,7 +116,7 @@ class ProfileSecurityFragment : BaseFragment(R.layout.fragment_profile_security)
         }
         (dialog.findViewById(R.id.deleteConfirmBtn) as? View)?.setOnClickListener {
             dialog.dismiss()
-            presenter.selectConfirmDelete(dialog.findViewById<EditText>(R.id.reason).text.toString())
+            presenter.selectConfirmExit()
         }
         dialog.show()
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/fragments/profile/settings/ProfileSecurityPresenter.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/fragments/profile/settings/ProfileSecurityPresenter.kt
@@ -2,6 +2,8 @@ package uddug.com.naukoteka.ui.fragments.profile.settings
 
 import moxy.InjectViewState
 import toothpick.InjectConstructor
+import uddug.com.data.cache.cookies.CookiesCache
+import uddug.com.data.cache.user_id.UserIdCache
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.interactors.user_profile.UserProfileInteractor
 import uddug.com.naukoteka.global.base.BasePresenterImpl
@@ -9,7 +11,9 @@ import uddug.com.naukoteka.global.base.BasePresenterImpl
 @InjectConstructor
 @InjectViewState
 class ProfileSecurityPresenter(
-    private val userProfileInteractor: UserProfileInteractor
+    private val userProfileInteractor: UserProfileInteractor,
+    private val cookiesCache: CookiesCache,
+    private val userIdCache: UserIdCache
 ) : BasePresenterImpl<ProfileSecurityView>() {
 
     var userProfileFullInfo: UserProfileFullInfo? = null
@@ -21,6 +25,12 @@ class ProfileSecurityPresenter(
 
     fun selectExitProfile() {
         viewState.openLogoutDialog()
+    }
+
+    fun selectConfirmExit() {
+        cookiesCache.clear()
+        userIdCache.clear()
+        viewState.openLoginPage()
     }
 
     fun selectDeleteAccount() {


### PR DESCRIPTION
## Summary
- Implement proper logout by clearing session caches
- Launch AuthActivity and remove erroneous dialog field
- Add new presenter method for exiting profile

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19922f5b883279b5a7c5ecb304afe