### PR TITLE
Trigger search after dialog info loads

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -51,13 +52,7 @@ fun ChatDetailDialogSearchComponent(
                     SearchField(
                         title = stringResource(R.string.search_country),
                         query = searchQuery,
-                        onSearchChanged = {
-                            searchQuery = it
-                            val state = uiState
-                            if (state is ChatDetailUiState.Success) {
-                                viewModel.search(state.dialogId, searchQuery)
-                            }
-                        }
+                        onSearchChanged = { searchQuery = it }
                     )
                 },
                 navigationIcon = {
@@ -73,6 +68,12 @@ fun ChatDetailDialogSearchComponent(
             )
         }
     ) { paddingValues ->
+        LaunchedEffect(uiState, searchQuery) {
+            val state = uiState
+            if (state is ChatDetailUiState.Success) {
+                viewModel.search(state.dialogId, searchQuery)
+            }
+        }
         Column(
             modifier = Modifier
                 .fillMaxSize()


### PR DESCRIPTION
## Summary
- Trigger chat dialog search when dialog info finishes loading
- Simplify search field handling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1997ded5c8327bc31f25d413eda91