### PR TITLE
feat: add voice message preview state

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -1,5 +1,6 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -13,17 +14,22 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
@@ -31,15 +37,10 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.draw.scale
 import coil.compose.AsyncImage
 import uddug.com.naukoteka.R
 import uddug.com.domain.entities.chat.MessageChat
 import java.io.File
-
 
 @Composable
 fun ChatInputBar(
@@ -48,12 +49,17 @@ fun ChatInputBar(
     attachedFiles: List<File>,
     replyMessage: MessageChat?,
     isRecording: Boolean,
+    recordedAudio: File?,
+    recordingTime: String,
     onMessageChange: (String) -> Unit,
     onSendClick: () -> Unit,
     onVoiceClick: () -> Unit,
     onAttachClick: () -> Unit,
     onRemoveFile: (File) -> Unit,
     onCancelReply: () -> Unit,
+    onDeleteRecording: () -> Unit,
+    onSendRecording: () -> Unit,
+    onPlayRecording: () -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -132,7 +138,7 @@ fun ChatInputBar(
                         ) {
                             Icon(
                                 imageVector = Icons.Filled.Close,
-                                contentDescription = "Remove", 
+                                contentDescription = "Remove",
                                 tint = Color.White,
                                 modifier = Modifier.size(10.dp)
                             )
@@ -142,45 +148,61 @@ fun ChatInputBar(
             }
         }
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(Color.White)
-                .padding(horizontal = 8.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = onAttachClick) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_attach),
-                    contentDescription = "Attach",
-                    tint = Color(0XFF8083A0)
-                )
+        when {
+            recordedAudio != null -> {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White)
+                        .padding(horizontal = 8.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onDeleteRecording) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete",
+                            tint = Color(0XFF8083A0)
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(horizontal = 6.dp)
+                    ) {
+                        RecordedAudioPreview(duration = recordingTime, onPlay = onPlayRecording)
+                    }
+                    IconButton(onClick = onSendRecording) {
+                        Icon(Icons.Default.Send, contentDescription = "Send", tint = Color(0XFF8083A0))
+                    }
+                }
             }
-
-            TextField(
-                value = currentMessage,
-                onValueChange = onMessageChange,
-                placeholder = { Text("Напишите сообщение") },
-                modifier = Modifier
-                    .padding(horizontal = 6.dp)
-                    .weight(1f)
-                    .height(54.dp)
-                    .border(
-                        width = 1.dp,
-                        color = Color(0xFFEAEAF2),
-                        shape = RoundedCornerShape(12.dp)
-                    ),
-                colors = TextFieldDefaults.textFieldColors(
-                    backgroundColor = Color.White,
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent
-                ),
-                shape = RoundedCornerShape(12.dp)
-            )
-
-            if (currentMessage.isBlank()) {
-                IconButton(onClick = onVoiceClick) {
-                    if (isRecording) {
+            isRecording -> {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White)
+                        .padding(horizontal = 8.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier
+                                .size(8.dp)
+                                .background(Color.Red, CircleShape)
+                        )
+                        Text(
+                            text = recordingTime,
+                            color = Color(0XFF8083A0),
+                            modifier = Modifier.padding(start = 4.dp)
+                        )
+                    }
+                    Text(
+                        text = "Ведите влево для отмены",
+                        color = Color(0XFF8083A0),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = onVoiceClick) {
                         val transition = rememberInfiniteTransition()
                         val scale by transition.animateFloat(
                             initialValue = 1f,
@@ -193,21 +215,101 @@ fun ChatInputBar(
                         Image(
                             painter = painterResource(id = R.drawable.ic_rec_mic_active),
                             contentDescription = "Stop",
-
                             modifier = Modifier.scale(scale)
-                        )
-                    } else {
-                        Image(
-                            painter = painterResource(id = R.drawable.ic_rec_mic_inactive),
-                            contentDescription = "Record",
                         )
                     }
                 }
-            } else {
-                IconButton(onClick = onSendClick) {
-                    Icon(Icons.Default.Send, contentDescription = "Send", tint = Color(0XFF8083A0))
+            }
+            else -> {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White)
+                        .padding(horizontal = 8.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onAttachClick) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_attach),
+                            contentDescription = "Attach",
+                            tint = Color(0XFF8083A0)
+                        )
+                    }
+
+                    TextField(
+                        value = currentMessage,
+                        onValueChange = onMessageChange,
+                        placeholder = { Text("Напишите сообщение") },
+                        modifier = Modifier
+                            .padding(horizontal = 6.dp)
+                            .weight(1f)
+                            .height(54.dp)
+                            .border(
+                                width = 1.dp,
+                                color = Color(0xFFEAEAF2),
+                                shape = RoundedCornerShape(12.dp)
+                            ),
+                        colors = TextFieldDefaults.textFieldColors(
+                            backgroundColor = Color.White,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        shape = RoundedCornerShape(12.dp),
+                    )
+
+                    if (currentMessage.isBlank()) {
+                        IconButton(onClick = onVoiceClick) {
+                            Image(
+                                painter = painterResource(id = R.drawable.ic_rec_mic_inactive),
+                                contentDescription = "Record",
+                            )
+                        }
+                    } else {
+                        IconButton(onClick = onSendClick) {
+                            Icon(Icons.Default.Send, contentDescription = "Send", tint = Color(0XFF8083A0))
+                        }
+                    }
                 }
             }
+        }
+    }
+}
+
+@Composable
+fun RecordedAudioPreview(duration: String, onPlay: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .height(40.dp)
+            .fillMaxWidth()
+            .clickable { onPlay() },
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.background_voice_wave),
+            contentDescription = null,
+            modifier = Modifier.fillMaxWidth(),
+            contentScale = ContentScale.FillWidth
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .background(Color.White, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.PlayArrow,
+                    contentDescription = "Play",
+                    tint = Color(0xFF3F7AFF)
+                )
+            }
+            Text(text = duration, color = Color.White)
         }
     }
 }


### PR DESCRIPTION
## Summary
- show recording timer with cancel hint
- preview recorded audio with playback, delete and send actions

## Testing
- `./gradlew test` (fails: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68b197ff62a883278b9a66d6bd505263