### PR TITLE
fix: show placeholder avatar in chat dialogs

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -39,7 +39,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.icons.Icons
@@ -73,6 +72,7 @@ import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatDetailUiState
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
 import uddug.com.naukoteka.ui.chat.compose.components.ChatDetailMoreSheetDialog
 import uddug.com.naukoteka.ui.chat.compose.components.ChatDetailShimmer
 
@@ -167,13 +167,10 @@ fun ChatDetailDialogComponent(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         // Аватарка
-                        AsyncImage(
-                            model = BuildConfig.IMAGE_SERVER_URL.plus(state.profile.image),
-                            contentDescription = "Аватар",
-                            modifier = Modifier
-                                .size(100.dp)
-                                .clip(CircleShape),
-                            contentScale = ContentScale.Crop
+                        Avatar(
+                            state.profile.image.takeIf { it.isNotEmpty() },
+                            state.profile.fullName,
+                            size = 100.dp
                         )
 
                         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
@@ -1,13 +1,11 @@
 package uddug.com.naukoteka.ui.chat.compose
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
@@ -21,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -29,9 +26,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
-import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
 import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailViewModel
 import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailUiState
 import uddug.com.naukoteka.mvvm.chat.Participant
@@ -103,20 +99,17 @@ fun ChatGroupDetailComponent(
                         .background(Color.White)
                         .padding(paddingValues)
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Image(
-                            painter = painterResource(id = R.drawable.ic_logo_naukoteka),
-                            contentDescription = "Avatar",
-                            modifier = Modifier
-                                .size(100.dp)
-                                .clip(CircleShape),
-                            contentScale = ContentScale.Crop
-                        )
+                      Column(
+                          modifier = Modifier
+                              .fillMaxWidth()
+                              .padding(16.dp),
+                          horizontalAlignment = Alignment.CenterHorizontally
+                      ) {
+                          Avatar(
+                              state.image,
+                              state.name,
+                              size = 100.dp
+                          )
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
                             text = state.name,
@@ -274,13 +267,10 @@ fun ParticipantsContent(users: List<Participant>) {
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                AsyncImage(
-                    model = BuildConfig.IMAGE_SERVER_URL.plus(participant.user.image.orEmpty()),
-                    contentDescription = "Avatar",
-                    modifier = Modifier
-                        .size(40.dp)
-                        .clip(CircleShape),
-                    contentScale = ContentScale.Crop
+                Avatar(
+                    participant.user.image,
+                    participant.user.fullName,
+                    size = 40.dp
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Column(horizontalAlignment = Alignment.Start) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
@@ -1,6 +1,5 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -26,13 +25,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
-import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
 
 @Composable
@@ -57,50 +53,18 @@ fun ChatTopBar(
                 IconButton(onClick = { onBackPressed() }) {
                     Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color(0xFF2E83D9))
                 }
-                if (image.isNotEmpty()) {
-                    AsyncImage(
-                        model = BuildConfig.IMAGE_SERVER_URL.plus(image),
-                        contentDescription = "image",
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .clip(CircleShape)
-                            .size(36.dp)
-                            .clickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null
-                            ) {
-                                onDetailClick()
-                            }
-                    )
-                } else {
-                    if (isGroup) {
-                        Image(
-                            painter = painterResource(id = R.drawable.mock_avatar),
-                            contentDescription = "image",
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier
-                                .clip(CircleShape)
-                                .size(36.dp)
-                                .clickable(
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    indication = null
-                                ) {
-                                    onDetailClick()
-                                }
-                        )
-                    } else {
-                        Box(
-                            modifier = Modifier
-                                .clickable(
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    indication = null
-                                ) {
-                                    onDetailClick()
-                                }
+                Box(
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .size(36.dp)
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null
                         ) {
-                            Avatar(null, name, size = 36.dp)
+                            onDetailClick()
                         }
-                    }
+                ) {
+                    Avatar(image.takeIf { it.isNotEmpty() }, name, size = 36.dp)
                 }
                 Column(
                     modifier = Modifier


### PR DESCRIPTION
## Summary
- display initials avatar in chat dialogs when image missing
- add gradient avatar fallback in chat detail screens

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19df6ac6483278d35c3a55486fe61