### PR TITLE
Enable copy-to-clipboard for chat messages

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -17,12 +17,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import android.widget.Toast
 import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.MessageFunctionsViewModel
+import uddug.com.naukoteka.utils.copyToClipboard
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -34,6 +37,7 @@ fun MessageFunctionsBottomSheetDialog(
     viewModel: MessageFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val context = LocalContext.current
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
@@ -54,7 +58,17 @@ fun MessageFunctionsBottomSheetDialog(
             val items = listOf(
                 R.string.chat_message_reply to { onReply(message) },
                 R.string.chat_message_forward to { viewModel.forward(message.id) },
-                R.string.chat_message_copy to { viewModel.copy(message.id) },
+                R.string.chat_message_copy to {
+                    message.text?.let {
+                        context.copyToClipboard(it)
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.chat_message_copied),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                    viewModel.copy(message.id)
+                },
                 R.string.chat_message_select to {
                     viewModel.select(message.id)
                     onSelectMessage()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,6 +386,7 @@
     <string name="chat_message_reply">Ответить</string>
     <string name="chat_message_forward">Переслать</string>
     <string name="chat_message_copy">Скопировать</string>
+    <string name="chat_message_copied">Сообщение скопировано</string>
     <string name="chat_message_select">Выбрать сообщение</string>
     <string name="chat_message_show_original">Показать оригинал в чате</string>
     <string name="chat_message_delete">Удалить сообщение</string>


### PR DESCRIPTION
## Summary
- copy message text to clipboard and show a toast when selecting **Copy** in chat
- add string resource for clipboard confirmation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19e3ed8548327800e319ee7d48458