### PR TITLE
Fix group ChatDialog avatar gradient

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
@@ -106,9 +106,10 @@ fun ChatGroupDetailComponent(
                           horizontalAlignment = Alignment.CenterHorizontally
                       ) {
                           Avatar(
-                              state.image,
-                              state.name,
-                              size = 100.dp
+                              url = null,
+                              name = null,
+                              size = 100.dp,
+                              overrideInitials = "Г",
                           )
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/Avatar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/Avatar.kt
@@ -19,7 +19,12 @@ import coil.compose.AsyncImage
 import uddug.com.naukoteka.BuildConfig
 
 @Composable
-fun Avatar(url: String?, name: String?, size: Dp = 36.dp) {
+fun Avatar(
+    url: String?,
+    name: String?,
+    size: Dp = 36.dp,
+    overrideInitials: String? = null,
+) {
     if (!url.isNullOrEmpty()) {
         AsyncImage(
             model = BuildConfig.IMAGE_SERVER_URL.plus(url),
@@ -29,12 +34,12 @@ fun Avatar(url: String?, name: String?, size: Dp = 36.dp) {
                 .clip(CircleShape)
         )
     } else {
-        val initials = name.orEmpty()
+        val initials = overrideInitials ?: name.orEmpty()
             .split(" ")
             .mapNotNull { it.firstOrNull()?.uppercase() }
             .take(2)
             .joinToString("")
-        val gradient = getGradientForName(name.orEmpty())
+        val gradient = getGradientForName(overrideInitials ?: name.orEmpty())
         Box(
             modifier = Modifier
                 .size(size)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
@@ -64,7 +64,12 @@ fun ChatTopBar(
                             onDetailClick()
                         }
                 ) {
-                    Avatar(image.takeIf { it.isNotEmpty() }, name, size = 36.dp)
+                    Avatar(
+                        url = image.takeIf { !isGroup && it.isNotEmpty() },
+                        name = if (isGroup) null else name,
+                        size = 36.dp,
+                        overrideInitials = if (isGroup) "Г" else null,
+                    )
                 }
                 Column(
                     modifier = Modifier


### PR DESCRIPTION
## Summary
- show gradient avatar with letter `Г` for group chats
- support overriding initials in shared Avatar component

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a09eb6048327a7299b727d49c3d8