### PR TITLE
Filter group chats from search and subscriptions

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -69,9 +69,12 @@ class ChatListViewModel @Inject constructor(
         loadChatsJob = viewModelScope.launch {
             try {
                 val chats = chatRepository.getChats(folderId)
+                val filteredChats = chats.filter { chat ->
+                    chat.users.size <= 2
+                }
                 val elapsed = System.currentTimeMillis() - startTime
                 if (elapsed < 500L) delay(500L - elapsed)
-                _uiState.value = ChatListUiState.Success(chats)
+                _uiState.value = ChatListUiState.Success(filteredChats)
             } catch (e: Exception) {
                 _uiState.value = ChatListUiState.Error(e.message ?: "Unknown error")
             }
@@ -170,7 +173,14 @@ class ChatListViewModel @Inject constructor(
             _isSearchLoading.value = true
             try {
                 val dialogs = chatRepository.searchDialogs(query)
+                    .filter { it.dialogType == 1 }
                 val messages = chatRepository.searchMessages(query)
+                    .mapNotNull { message ->
+                        val info = runCatching {
+                            chatRepository.getDialogInfo(message.dialogId)
+                        }.getOrNull()
+                        if (info?.users.orEmpty().size <= 2) message else null
+                    }
                 val results = dialogs.map { SearchResult.Dialog(it) } +
                         messages.map { SearchResult.Message(it) }
                 _searchResults.value = results


### PR DESCRIPTION
## Summary
- exclude chats with more than two members from chat list and search results

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a11e19e883279c7f597092096358