### PR TITLE
Fix chat actions to reflect current state

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
@@ -38,6 +38,16 @@ class ChatFunctionsViewModel @Inject constructor(
         }
     }
 
+    fun unpinChat(dialogId: Long) {
+        viewModelScope.launch {
+            try {
+                chatRepository.unpinDialog(dialogId)
+            } catch (e: Exception) {
+                // handle error if needed
+            }
+        }
+    }
+
     fun disableNotifications(dialogId: Long) {
         viewModelScope.launch {
             try {

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -112,6 +112,25 @@ class ChatListViewModel @Inject constructor(
         }
     }
 
+    fun updateDialogPin(dialogId: Long, pinned: Boolean) {
+        viewModelScope.launch {
+            try {
+                chatRepository.getDialogInfo(dialogId)
+                _uiState.update { state ->
+                    if (state is ChatListUiState.Success) {
+                        val updatedChats = state.chats.map { chat ->
+                            if (chat.dialogId == dialogId) {
+                                chat.copy(isPinned = pinned)
+                            } else chat
+                        }
+                        ChatListUiState.Success(updatedChats)
+                    } else state
+                }
+            } catch (_: Exception) {
+            }
+        }
+    }
+
     fun onFolderSelected(folderId: Long) {
         loadChats(folderId)
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -90,15 +90,23 @@ fun ChatListComponent(
     }
 
     selectedDialogId?.let { id ->
-        val isBlocked = (uiState as? ChatListUiState.Success)?.chats?.firstOrNull { it.dialogId == id }?.isBlocked ?: false
+        val chat = (uiState as? ChatListUiState.Success)?.chats?.firstOrNull { it.dialogId == id }
+        val isBlocked = chat?.isBlocked ?: false
+        val isPinned = chat?.isPinned ?: false
+        val notificationsDisabled = chat?.notificationsDisable ?: false
         ChatFunctionsBottomSheetDialog(
             dialogId = id,
             isBlocked = isBlocked,
+            isPinned = isPinned,
+            notificationsDisabled = notificationsDisabled,
             onDismissRequest = { selectedDialogId = null },
             onShowAttachments = onShowAttachments,
             onSelectMessages = {
                 viewModel.startSelection(id)
                 selectedDialogId = null
+            },
+            onPinChange = { dialogId, pinned ->
+                viewModel.updateDialogPin(dialogId, pinned)
             },
             onNotificationsChange = { dialogId, disabled ->
                 viewModel.updateDialogNotifications(dialogId, disabled)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -28,9 +28,12 @@ import uddug.com.naukoteka.mvvm.chat.ChatFunctionsViewModel
 fun ChatFunctionsBottomSheetDialog(
     dialogId: Long,
     isBlocked: Boolean = false,
+    isPinned: Boolean = false,
+    notificationsDisabled: Boolean = false,
     onDismissRequest: () -> Unit,
     onShowAttachments: (Long) -> Unit,
     onSelectMessages: () -> Unit,
+    onPinChange: (Long, Boolean) -> Unit = { _, _ -> },
     onNotificationsChange: (Long, Boolean) -> Unit = { _, _ -> },
     viewModel: ChatFunctionsViewModel = hiltViewModel(),
 ) {
@@ -57,14 +60,33 @@ fun ChatFunctionsBottomSheetDialog(
             } else {
                 R.string.chat_block_chat to { viewModel.blockChat(dialogId) }
             }
-            val items = listOf(
-                R.string.chat_mark_unread to { viewModel.markUnread(dialogId) },
-                R.string.chat_show_attachments to { onShowAttachments(dialogId) },
-                R.string.chat_pin to { viewModel.pinChat(dialogId) },
+            val pinItem = if (isPinned) {
+                R.string.chat_unpin to {
+                    viewModel.unpinChat(dialogId)
+                    onPinChange(dialogId, false)
+                }
+            } else {
+                R.string.chat_pin to {
+                    viewModel.pinChat(dialogId)
+                    onPinChange(dialogId, true)
+                }
+            }
+            val notificationsItem = if (notificationsDisabled) {
+                R.string.chat_enable_notifications to {
+                    viewModel.enableNotifications(dialogId)
+                    onNotificationsChange(dialogId, false)
+                }
+            } else {
                 R.string.chat_disable_notifications to {
                     viewModel.disableNotifications(dialogId)
                     onNotificationsChange(dialogId, true)
-                },
+                }
+            }
+            val items = listOf(
+                R.string.chat_mark_unread to { viewModel.markUnread(dialogId) },
+                R.string.chat_show_attachments to { onShowAttachments(dialogId) },
+                pinItem,
+                notificationsItem,
                 R.string.chat_select_messages to {
                     viewModel.selectMessages(dialogId)
                     onSelectMessages()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -376,8 +376,10 @@
     <string name="chat_mark_unread">Отметить непрочитанным</string>
     <string name="chat_show_attachments">Показать вложения</string>
     <string name="chat_pin">Закрепить в списке</string>
+    <string name="chat_unpin">Открепить из списка</string>
     <string name="chat_go_to_profile">Перейти в профиль</string>
     <string name="chat_disable_notifications">Отключить уведомления</string>
+    <string name="chat_enable_notifications">Включить уведомления</string>
     <string name="chat_select_messages">Выделить сообщения</string>
     <string name="chat_block_chat">Заблокировать чат</string>
     <string name="chat_unblock_chat">Разблокировать чат</string>


### PR DESCRIPTION
## Summary
- switch chat options between pin/unpin and enable/disable notifications
- update view models to handle pin state changes
- add missing string resources for chat actions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a226e4e08327b3dc75ffad844df1