### PR TITLE
Hide bottom navigation in ChatList when keyboard is open

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
+import net.yslibrary.android.keyboardvisibilityevent.KeyboardVisibilityEvent
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -40,6 +41,10 @@ class ChatListFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        KeyboardVisibilityEvent.setEventListener(requireActivity(), viewLifecycleOwner) { isOpen ->
+            navigationView?.showNavigationBottomBar(!isOpen)
+        }
 
         setupObservers()
         viewModel.loadFolders()


### PR DESCRIPTION
## Summary
- Hide bottom navigation in ChatList when keyboard appears using KeyboardVisibilityEvent

## Testing
- `./gradlew app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a23854d0832792d878c1f5d6d037