### PR TITLE
Reduce top padding in dialog layouts

### DIFF
--- a/app/src/main/res/layout/dialog_delete_account.xml
+++ b/app/src/main/res/layout/dialog_delete_account.xml
@@ -5,7 +5,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@drawable/main_background_rounded"
     android:orientation="vertical"
-    android:padding="24dp">
+    android:paddingStart="24dp"
+    android:paddingTop="16dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="24dp">
 
     <TextView
         style="@style/NauTextAppearance.AppCompat.Title"

--- a/app/src/main/res/layout/dialog_exit_profile.xml
+++ b/app/src/main/res/layout/dialog_exit_profile.xml
@@ -4,7 +4,10 @@
     android:layout_height="wrap_content"
     android:background="@drawable/main_background_rounded"
     android:orientation="vertical"
-    android:padding="24dp">
+    android:paddingStart="24dp"
+    android:paddingTop="16dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="24dp">
 
     <TextView
         style="@style/NauTextAppearance.AppCompat.Title"

--- a/app/src/main/res/layout/dialog_remove_banner.xml
+++ b/app/src/main/res/layout/dialog_remove_banner.xml
@@ -4,7 +4,10 @@
     android:layout_height="wrap_content"
     android:background="@drawable/main_background_rounded"
     android:orientation="vertical"
-    android:padding="24dp">
+    android:paddingStart="24dp"
+    android:paddingTop="16dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="24dp">
 
     <TextView
         style="@style/NauTextAppearance.AppCompat.Title"

--- a/app/src/main/res/layout/dialog_remove_education.xml
+++ b/app/src/main/res/layout/dialog_remove_education.xml
@@ -4,7 +4,10 @@
     android:layout_height="wrap_content"
     android:background="@drawable/main_background_rounded"
     android:orientation="vertical"
-    android:padding="24dp">
+    android:paddingStart="24dp"
+    android:paddingTop="16dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="24dp">
 
     <TextView
         style="@style/NauTextAppearance.AppCompat.Title"

--- a/app/src/main/res/layout/dialog_remove_labor.xml
+++ b/app/src/main/res/layout/dialog_remove_labor.xml
@@ -4,7 +4,10 @@
     android:layout_height="wrap_content"
     android:background="@drawable/main_background_rounded"
     android:orientation="vertical"
-    android:padding="24dp">
+    android:paddingStart="24dp"
+    android:paddingTop="16dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="24dp">
 
     <TextView
         style="@style/NauTextAppearance.AppCompat.Title"

--- a/app/src/main/res/layout/dialog_remove_photo.xml
+++ b/app/src/main/res/layout/dialog_remove_photo.xml
@@ -4,7 +4,10 @@
     android:layout_height="wrap_content"
     android:background="@drawable/main_background_rounded"
     android:orientation="vertical"
-    android:padding="24dp">
+    android:paddingStart="24dp"
+    android:paddingTop="16dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="24dp">
 
     <TextView
         style="@style/NauTextAppearance.AppCompat.Title"

--- a/app/src/main/res/layout/dialog_visibility_settings_type.xml
+++ b/app/src/main/res/layout/dialog_visibility_settings_type.xml
@@ -4,7 +4,10 @@
     android:layout_height="wrap_content"
     android:background="@drawable/main_background_rounded"
     android:orientation="vertical"
-    android:padding="24dp">
+    android:paddingStart="24dp"
+    android:paddingTop="16dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="24dp">
 
     <RadioGroup
         android:id="@+id/radioGroup"

--- a/app/src/main/res/layout/view_custom_alert_dialog_photo.xml
+++ b/app/src/main/res/layout/view_custom_alert_dialog_photo.xml
@@ -6,7 +6,10 @@
         android:layout_height="wrap_content"
         android:background="@drawable/main_background_rounded"
         android:orientation="vertical"
-        android:padding="20dp">
+        android:paddingStart="20dp"
+        android:paddingTop="16dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="20dp">
 
         <LinearLayout
             android:id="@+id/functionsContainer"


### PR DESCRIPTION
## Summary
- Reduce top padding in dialog layouts for a tighter spacing below the top divider
- Adjust custom photo alert dialog padding to match new spacing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a29cc73c8327a9932b6ea33cd142