### PR TITLE
Add swipe gesture to cancel voice recording

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -286,6 +286,12 @@ fun ChatDialogComponent(
                                 audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                             }
                         },
+                        onCancelRecording = {
+                            audioRecorder.stop()?.delete()
+                            recordedAudio = null
+                            recordingTime = 0L
+                            isRecording = false
+                        },
                         onAttachClick = {
                             showAttachmentSheet = true
                         },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
@@ -19,7 +20,9 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -54,6 +58,7 @@ fun ChatInputBar(
     onMessageChange: (String) -> Unit,
     onSendClick: () -> Unit,
     onVoiceClick: () -> Unit,
+    onCancelRecording: () -> Unit,
     onAttachClick: () -> Unit,
     onRemoveFile: (File) -> Unit,
     onCancelReply: () -> Unit,
@@ -177,11 +182,25 @@ fun ChatInputBar(
                 }
             }
             isRecording -> {
+                var dragAmount by remember { mutableStateOf(0f) }
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(Color.White)
-                        .padding(horizontal = 8.dp, vertical = 8.dp),
+                        .padding(horizontal = 8.dp, vertical = 8.dp)
+                        .pointerInput(Unit) {
+                            detectHorizontalDragGestures(
+                                onDragEnd = { dragAmount = 0f },
+                                onDragCancel = { dragAmount = 0f },
+                                onHorizontalDrag = { _, amount ->
+                                    dragAmount += amount
+                                    if (dragAmount < -100f) {
+                                        dragAmount = 0f
+                                        onCancelRecording()
+                                    }
+                                }
+                            )
+                        },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
## Summary
- allow ChatInputBar to cancel recording on left swipe
- reset recorder state when swipe-to-cancel is triggered

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a3f7faf88327ad7062a7f3d80479