### PR TITLE
Add send contact screen to chat

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -59,6 +59,8 @@ class ChatDialogViewModel @Inject constructor(
 
     private var attachedContact: ContactInfo? = null
 
+    private var selectedUser: UserProfileFullInfo? = null
+
     private var currentUser: UserProfileFullInfo? = null
 
     init {
@@ -290,6 +292,14 @@ class ChatDialogViewModel @Inject constructor(
         val currentState = _uiState.value
         if (currentState is ChatDialogUiState.Success) {
             _uiState.value = currentState.copy(attachedContact = contact)
+        }
+    }
+
+    fun attachUserContact(user: UserProfileFullInfo) {
+        selectedUser = user
+        val currentState = _uiState.value
+        if (currentState is ChatDialogUiState.Success) {
+            _uiState.value = currentState.copy(selectedContact = user)
         }
     }
 
@@ -601,6 +611,7 @@ sealed class ChatDialogUiState {
         val status: String? = null,
         val replyMessage: MessageChat? = null,
         val attachedContact: ContactInfo? = null,
+        val selectedContact: UserProfileFullInfo? = null,
     ) : ChatDialogUiState()
 
     data class Error(val message: String) : ChatDialogUiState()

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/SendContactViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/SendContactViewModel.kt
@@ -1,0 +1,47 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.domain.interactors.chat.ChatInteractor
+import javax.inject.Inject
+
+data class SendContactUiState(
+    val query: String = "",
+    val contacts: List<UserProfileFullInfo> = emptyList()
+)
+
+@HiltViewModel
+class SendContactViewModel @Inject constructor(
+    private val chatInteractor: ChatInteractor
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SendContactUiState())
+    val uiState: StateFlow<SendContactUiState> = _uiState
+
+    init {
+        loadContacts("")
+    }
+
+    fun onQueryChange(query: String) {
+        _uiState.update { it.copy(query = query) }
+        loadContacts(query)
+    }
+
+    private fun loadContacts(query: String) {
+        viewModelScope.launch {
+            val users = try {
+                chatInteractor.searchUsers(query)
+            } catch (e: Exception) {
+                emptyList()
+            }
+            _uiState.update { it.copy(contacts = users) }
+        }
+    }
+}
+

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -16,6 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import uddug.com.domain.entities.chat.Chat
+import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatDialogEvents
 import uddug.com.naukoteka.mvvm.chat.ChatDialogUiState
@@ -93,6 +94,12 @@ class ChatDialogFragment : Fragment() {
                 }
             }
         }
+
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<UserProfileFullInfo>("selectedUser")
+            ?.observe(viewLifecycleOwner) { user ->
+                user?.let { viewModel.attachUserContact(it) }
+            }
     }
 
     override fun onCreateView(
@@ -115,6 +122,9 @@ class ChatDialogFragment : Fragment() {
                                 R.id.chatDetailSearchFragment,
                                 Bundle().apply { putLong(ChatDetailDialogFragment.DIALOG_ID, dialogId) }
                             )
+                        },
+                        onContactClick = {
+                            findNavController().navigate(R.id.sendContactFragment)
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/SendContactFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/SendContactFragment.kt
@@ -1,0 +1,47 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.naukoteka.mvvm.chat.SendContactViewModel
+import uddug.com.naukoteka.ui.chat.compose.SendContactComponent
+
+@AndroidEntryPoint
+class SendContactFragment : Fragment() {
+
+    private val viewModel: SendContactViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    SendContactComponent(
+                        viewModel = viewModel,
+                        onBack = { requireActivity().onBackPressed() },
+                        onSelect = { user ->
+                            onContactSelected(user)
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun onContactSelected(user: UserProfileFullInfo) {
+        findNavController().previousBackStackEntry?.savedStateHandle?.set("selectedUser", user)
+        findNavController().popBackStack()
+    }
+}
+

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -3,9 +3,8 @@ package uddug.com.naukoteka.ui.chat.compose
 
 import android.Manifest
 import android.content.Context
-import android.net.Uri
 import android.media.MediaPlayer
-import android.provider.ContactsContract
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -56,10 +55,9 @@ import uddug.com.naukoteka.ui.chat.compose.components.AttachOptionsBottomSheetDi
 import uddug.com.naukoteka.ui.chat.compose.components.ChatTopBar
 import uddug.com.naukoteka.ui.chat.compose.components.MessageListShimmer
 import uddug.com.domain.entities.chat.MessageChat
-import java.io.File
 import uddug.com.naukoteka.ui.chat.AudioRecorder
 
-private enum class AttachmentPickerType { MEDIA, FILE, CONTACT }
+private enum class AttachmentPickerType { MEDIA, FILE }
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -67,6 +65,7 @@ fun ChatDialogComponent(
     viewModel: ChatDialogViewModel,
     onBackPressed: () -> Unit,
     onSearchClick: () -> Unit,
+    onContactClick: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val scrollState = rememberLazyListState()
@@ -122,16 +121,6 @@ fun ChatDialogComponent(
         }
     }
 
-    val contactPickerLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.PickContact()
-    ) { uri: Uri? ->
-        uri?.let {
-            getContactInfo(context, it)?.let { info ->
-                viewModel.attachContact(info)
-            }
-        }
-    }
-
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted: Boolean ->
@@ -143,8 +132,6 @@ fun ChatDialogComponent(
                     )
                 AttachmentPickerType.FILE ->
                     filePickerLauncher.launch(arrayOf("*/*"))
-                AttachmentPickerType.CONTACT ->
-                    contactPickerLauncher.launch(null)
                 null -> {}
             }
         }
@@ -337,9 +324,8 @@ fun ChatDialogComponent(
                 },
                 onPollClick = { showAttachmentSheet = false },
                 onContactClick = {
-                    pendingPickerType = AttachmentPickerType.CONTACT
-                    permissionLauncher.launch(Manifest.permission.READ_CONTACTS)
                     showAttachmentSheet = false
+                    onContactClick()
                 }
             )
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/SendContactComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/SendContactComponent.kt
@@ -1,0 +1,67 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.SendContactViewModel
+
+@Composable
+fun SendContactComponent(
+    viewModel: SendContactViewModel,
+    onBack: () -> Unit,
+    onSelect: (UserProfileFullInfo) -> Unit
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text(text = stringResource(R.string.send_contact_title)) },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_back),
+                        contentDescription = null
+                    )
+                }
+            }
+        )
+        TextField(
+            value = state.query,
+            onValueChange = { viewModel.onQueryChange(it) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            placeholder = { Text(text = stringResource(R.string.search_contacts_hint)) }
+        )
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(state.contacts) { user ->
+                Text(
+                    text = user.fullName ?: "",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onSelect(user) }
+                        .padding(16.dp)
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -56,4 +56,8 @@
 
     </fragment>
 
+    <fragment
+        android:id="@+id/sendContactFragment"
+        android:name="uddug.com.naukoteka.ui.chat.SendContactFragment"/>
+
 </navigation>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -110,5 +110,7 @@
   <string name="change_photo">Изменить фотографию</string>
   <string name="open_photo">Открыть фотографию</string>
   <string name="amount_followers_following">%s подписчиков ∙ %s подписок</string>
+  <string name="send_contact_title">Отправить контакт</string>
+  <string name="search_contacts_hint">Поиск по контактам</string>
   <string name="labor_activity_name">%s в <font color="#2E83D9">%s</font></string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -112,5 +112,7 @@
   <string name="change_photo">Изменить фотографию</string>
   <string name="open_photo">Открыть фотографию</string>
   <string name="amount_followers_following">%s подписчиков ∙ %s подписок</string>
+  <string name="send_contact_title">Отправить контакт</string>
+  <string name="search_contacts_hint">Поиск по контактам</string>
   <string name="labor_activity_name">%s в <font color="##2E83D9">%s</font></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -400,5 +400,7 @@
     <string name="chat_attach_file">Файлы</string>
     <string name="chat_attach_poll">Опросы</string>
     <string name="chat_attach_contact">Контакты</string>
+    <string name="send_contact_title">Отправить контакт</string>
+    <string name="search_contacts_hint">Поиск по контактам</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- allow opening send-contact picker from chat attachments
- add send-contact screen to search followers and return selection
- handle selected user in chat view model

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a4fac74883278e681044d68ae362