### PR TITLE
Remove chat participant limit in chat list

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -69,12 +69,9 @@ class ChatListViewModel @Inject constructor(
         loadChatsJob = viewModelScope.launch {
             try {
                 val chats = chatRepository.getChats(folderId)
-                val filteredChats = chats.filter { chat ->
-                    chat.users.size <= 2
-                }
                 val elapsed = System.currentTimeMillis() - startTime
                 if (elapsed < 500L) delay(500L - elapsed)
-                _uiState.value = ChatListUiState.Success(filteredChats)
+                _uiState.value = ChatListUiState.Success(chats)
             } catch (e: Exception) {
                 _uiState.value = ChatListUiState.Error(e.message ?: "Unknown error")
             }
@@ -194,12 +191,6 @@ class ChatListViewModel @Inject constructor(
                 val dialogs = chatRepository.searchDialogs(query)
                     .filter { it.dialogType == 1 }
                 val messages = chatRepository.searchMessages(query)
-                    .mapNotNull { message ->
-                        val info = runCatching {
-                            chatRepository.getDialogInfo(message.dialogId)
-                        }.getOrNull()
-                        if (info?.users.orEmpty().size <= 2) message else null
-                    }
                 val results = dialogs.map { SearchResult.Dialog(it) } +
                         messages.map { SearchResult.Message(it) }
                 _searchResults.value = results


### PR DESCRIPTION
## Summary
- show all chats from backend without filtering by participant count
- include group chats in search results

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a7e57df883278190263ebb871785