### PR TITLE
Restore chat folder switching

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -37,8 +37,21 @@ fun ChatTabBar(
     var showFolderMenu by remember { mutableStateOf(false) }
 
     val folders by viewModel.folders.collectAsState()
+    val currentFolderId by viewModel.currentFolderId.collectAsState()
 
     val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(folders, currentFolderId) {
+        if (folders.isEmpty()) {
+            selectedTabIndex = 0
+        } else {
+            val newIndex = folders.indexOfFirst { it.id == currentFolderId }
+            val resolvedIndex = if (newIndex >= 0) newIndex else 0
+            if (selectedTabIndex != resolvedIndex) {
+                selectedTabIndex = resolvedIndex
+            }
+        }
+    }
 
     Box {
         Column(


### PR DESCRIPTION
## Summary
- remember the currently selected chat folder in the view model when loading data
- synchronize the tab selection with the active folder so users can switch between folders again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbc7a953d083279c14d9a0f819fb4d