### PR TITLE
Add chat search tabs for dialogs and messages

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -20,9 +21,10 @@ import uddug.com.naukoteka.R
 
 @Composable
 fun SearchField(
-     title: String,
-     query: String,
-     onSearchChanged: (String) -> Unit
+    title: String,
+    query: String,
+    onSearchChanged: (String) -> Unit,
+    onFocusChanged: (Boolean) -> Unit = {},
 ) {
     Row(
         modifier = Modifier
@@ -49,6 +51,7 @@ fun SearchField(
             textStyle = LocalTextStyle.current.copy(color = Color.Black),
             modifier = Modifier
                 .fillMaxWidth()
+                .onFocusChanged { onFocusChanged(it.isFocused) }
                 .padding(10.dp),
             decorationBox = { innerTextField ->
                 if (query.isEmpty()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -372,6 +372,10 @@
     <string name="profile_shasre">Поделиться</string>
     <string name="profile_more">Еще</string>
     <string name="find_chat_message">Поиск чатов и сообщений</string>
+    <string name="search_tab_chats">Чаты</string>
+    <string name="search_tab_messages">Сообщения</string>
+    <string name="search_min_chars_hint">Введите не менее %1$d символов</string>
+    <string name="search_empty_result">Ничего не найдено</string>
     <string name="chat_functions_title">Функции чата</string>
     <string name="chat_mark_unread">Отметить непрочитанным</string>
     <string name="chat_show_attachments">Показать вложения</string>


### PR DESCRIPTION
## Summary
- split search results into dialogs and messages with dedicated state in ChatListViewModel
- add search focus handling and UI tabs for chats and messages in the chat list screen
- extend the search field to expose focus changes and provide localized text for the new search UI

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcaad2dfc8327876d9f359f2a52c6