### PR TITLE
Refine reply preview visuals in chat detail

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -90,20 +90,15 @@ fun ChatInputBar(
                     .padding(horizontal = 8.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = reply.ownerName ?: "",
-                        color = Color(0XFF8083A0),
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 12.sp
-                    )
-                    Text(
-                        text = reply.text.orEmpty(),
-                        color = Color(0XFF8083A0),
-                        fontSize = 12.sp,
-                        maxLines = 1
-                    )
-                }
+                ReplyBlock(
+                    reply = reply,
+                    isMine = false,
+                    backgroundColor = Color(0xFFF5F5F9),
+                    modifier = Modifier.weight(1f)
+                )
+
+                Spacer(modifier = Modifier.width(8.dp))
+
                 IconButton(onClick = onCancelReply) {
                     Icon(
                         imageVector = Icons.Filled.Close,

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -146,7 +146,10 @@ fun ChatMessageItem(
                 }
 
                 if (message.replyTo != null) {
-                    ReplyBlock(message.replyTo!!)
+                    ReplyBlock(
+                        reply = message.replyTo!!,
+                        isMine = isMine
+                    )
                     Spacer(modifier = Modifier.height(4.dp))
                 }
                 if (!message.text.isNullOrBlank()) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ReplyBlock.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ReplyBlock.kt
@@ -1,44 +1,98 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-
+import androidx.compose.material.icons.filled.Reply
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
 import uddug.com.domain.entities.chat.MessageChat
-import java.time.format.DateTimeFormatter
 
 @Composable
-fun ReplyBlock(reply: MessageChat) {
-    Column(
-        modifier = Modifier
+fun ReplyBlock(
+    reply: MessageChat,
+    isMine: Boolean,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color? = null,
+) {
+    val resolvedBackgroundColor = backgroundColor ?: if (isMine) {
+        Color.White.copy(alpha = 0.1f)
+    } else {
+        Color.White
+    }
+
+    Row(
+        modifier = modifier
             .fillMaxWidth()
-            .background(Color.White.copy(alpha = 0.3f), shape = RoundedCornerShape(8.dp))
-            .padding(6.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(resolvedBackgroundColor)
+            .height(IntrinsicSize.Min)
+            .padding(horizontal = 8.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = reply.ownerName ?: "Ответ",
-            color = Color.White,
-            fontWeight = FontWeight.Bold,
-            fontSize = 12.sp
+        Icon(
+            imageVector = Icons.Filled.Reply,
+            contentDescription = null,
+            tint = Color(0xFF2E83D9),
+            modifier = Modifier.size(16.dp)
         )
-        Text(
-            text = reply.text.orEmpty().take(50) + "...",
-            color = Color.White,
-            fontSize = 12.sp
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .width(2.dp)
+                .clip(RoundedCornerShape(1.dp))
+                .background(Color(0xFF2E83D9))
         )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = reply.ownerName?.takeIf { it.isNotBlank() } ?: "Ответ",
+                color = Color(0xFF2E83D9),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 12.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            val previewText = when {
+                !reply.text.isNullOrBlank() -> reply.text
+                else -> reply.files.firstOrNull()?.fileName
+            }?.takeIf { it.isNotBlank() }
+
+            if (previewText != null) {
+                Text(
+                    text = previewText,
+                    color = if (isMine) Color.White else Color.Black,
+                    fontSize = 12.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- restyle the reply/forward preview with a reply icon, blue divider, and updated text colors
- reuse the same preview component inside the composer reply banner so visuals match the design

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcd7f8bc08327bca3801d0442f127