### PR TITLE
Add message editing option to chat dialog

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -254,6 +254,7 @@ fun ChatDialogComponent(
                         currentMessage = state.currentMessage,
                         attachedFiles = state.attachedFiles,
                         replyMessage = state.replyMessage,
+                        editingMessage = state.editingMessage,
                         isRecording = isRecording,
                         recordedAudio = recordedAudio,
                         recordingTime = String.format("%02d:%02d", recordingTime / 60000, (recordingTime / 1000) % 60),
@@ -290,6 +291,9 @@ fun ChatDialogComponent(
                         },
                         onCancelReply = {
                             viewModel.clearReplyMessage()
+                        },
+                        onCancelEditing = {
+                            viewModel.clearEditingMessage()
                         },
                         onDeleteRecording = {
                             recordedAudio?.delete()
@@ -365,6 +369,10 @@ fun ChatDialogComponent(
                 },
                 onReply = { msg ->
                     viewModel.setReplyMessage(msg)
+                },
+                onEdit = { msg ->
+                    viewModel.startEditingMessage(msg)
+                    selectedMessage = null
                 }
             )
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -16,8 +16,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.PlayArrow
-
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -42,8 +40,8 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.material.icons.filled.ThumbUp
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
 import coil.compose.AsyncImage
 import uddug.com.naukoteka.R
 import uddug.com.domain.entities.chat.MessageChat
@@ -55,6 +53,7 @@ fun ChatInputBar(
     currentMessage: String,
     attachedFiles: List<File>,
     replyMessage: MessageChat?,
+    editingMessage: MessageChat?,
     isRecording: Boolean,
     recordedAudio: File?,
     recordingTime: String,
@@ -65,6 +64,7 @@ fun ChatInputBar(
     onAttachClick: () -> Unit,
     onRemoveFile: (File) -> Unit,
     onCancelReply: () -> Unit,
+    onCancelEditing: () -> Unit,
     onDeleteRecording: () -> Unit,
     onSendRecording: () -> Unit,
     onPlayRecording: () -> Unit,
@@ -83,35 +83,11 @@ fun ChatInputBar(
         )
 
         replyMessage?.let { reply ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Color.White)
-                    .padding(horizontal = 8.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = reply.ownerName ?: "",
-                        color = Color(0XFF8083A0),
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 12.sp
-                    )
-                    Text(
-                        text = reply.text.orEmpty(),
-                        color = Color(0XFF8083A0),
-                        fontSize = 12.sp,
-                        maxLines = 1
-                    )
-                }
-                IconButton(onClick = onCancelReply) {
-                    Icon(
-                        imageVector = Icons.Filled.Close,
-                        contentDescription = "Cancel reply",
-                        tint = Color(0XFF8083A0)
-                    )
-                }
-            }
+            ReplyInfoBlock(reply = reply, onCancelReply = onCancelReply)
+        }
+
+        editingMessage?.let { message ->
+            EditInfoBlock(message = message, onCancelEdit = onCancelEditing)
         }
 
         if (attachedFiles.isNotEmpty()) {
@@ -310,6 +286,78 @@ fun ChatInputBar(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun ReplyInfoBlock(reply: MessageChat, onCancelReply: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = reply.ownerName ?: "",
+                color = Color(0XFF8083A0),
+                fontWeight = FontWeight.Bold,
+                fontSize = 12.sp
+            )
+            Text(
+                text = reply.text.orEmpty(),
+                color = Color(0XFF8083A0),
+                fontSize = 12.sp,
+                maxLines = 1
+            )
+        }
+        IconButton(onClick = onCancelReply) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = stringResource(id = R.string.cancel_button),
+                tint = Color(0XFF8083A0)
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditInfoBlock(message: MessageChat, onCancelEdit: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Create,
+            contentDescription = null,
+            tint = Color(0XFF8083A0),
+            modifier = Modifier.padding(end = 8.dp)
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(id = R.string.chat_editing_title),
+                color = Color(0XFF8083A0),
+                fontWeight = FontWeight.Bold,
+                fontSize = 12.sp
+            )
+            Text(
+                text = message.text.orEmpty(),
+                color = Color(0XFF8083A0),
+                fontSize = 12.sp,
+                maxLines = 1
+            )
+        }
+        IconButton(onClick = onCancelEdit) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = stringResource(id = R.string.cancel_button),
+                tint = Color(0XFF8083A0)
+            )
         }
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import android.widget.Toast
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.domain.entities.chat.MessageType
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.MessageFunctionsViewModel
 import uddug.com.naukoteka.utils.copyToClipboard
@@ -34,6 +35,7 @@ fun MessageFunctionsBottomSheetDialog(
     onDismissRequest: () -> Unit,
     onSelectMessage: () -> Unit,
     onReply: (MessageChat) -> Unit,
+    onEdit: (MessageChat) -> Unit,
     viewModel: MessageFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -55,10 +57,13 @@ fun MessageFunctionsBottomSheetDialog(
                 )
             )
             Spacer(modifier = Modifier.height(10.dp))
-            val items = listOf(
-                R.string.chat_message_reply to { onReply(message) },
-                R.string.chat_message_forward to { viewModel.forward(message.id) },
-                R.string.chat_message_copy to {
+            val items = buildList<Pair<Int, () -> Unit>> {
+                add(R.string.chat_message_reply to { onReply(message) })
+                if (message.isMine && message.type == MessageType.TEXT) {
+                    add(R.string.chat_message_edit to { onEdit(message) })
+                }
+                add(R.string.chat_message_forward to { viewModel.forward(message.id) })
+                add(R.string.chat_message_copy to {
                     message.text?.let {
                         context.copyToClipboard(it)
                         Toast.makeText(
@@ -68,14 +73,14 @@ fun MessageFunctionsBottomSheetDialog(
                         ).show()
                     }
                     viewModel.copy(message.id)
-                },
-                R.string.chat_message_select to {
+                })
+                add(R.string.chat_message_select to {
                     viewModel.select(message.id)
                     onSelectMessage()
-                },
-                R.string.chat_message_show_original to { viewModel.showOriginal(message.id) },
-                R.string.chat_message_delete to { viewModel.delete(message.id) }
-            )
+                })
+                add(R.string.chat_message_show_original to { viewModel.showOriginal(message.id) })
+                add(R.string.chat_message_delete to { viewModel.delete(message.id) })
+            }
             items.forEach { (textRes, action) ->
                 Row(
                     modifier = Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -390,12 +390,14 @@
     <string name="chat_delete_chat">Удалить чат</string>
     <string name="message_functions_title">Действия с сообщением</string>
     <string name="chat_message_reply">Ответить</string>
+    <string name="chat_message_edit">Редактировать</string>
     <string name="chat_message_forward">Переслать</string>
     <string name="chat_message_copy">Скопировать</string>
     <string name="chat_message_copied">Сообщение скопировано</string>
     <string name="chat_message_select">Выбрать сообщение</string>
     <string name="chat_message_show_original">Показать оригинал в чате</string>
     <string name="chat_message_delete">Удалить сообщение</string>
+    <string name="chat_editing_title">Редактирование</string>
     <string name="create_group_chat">Создать групповой чат</string>
     <string name="subs">Подписки</string>
 


### PR DESCRIPTION
## Summary
- enable editing of own text messages by wiring the update API in the chat dialog view model
- surface an "Edit" action in the message functions sheet and show an editing banner above the input field with cancel support
- keep UI strings in sync for the new editing flow

## Testing
- ./gradlew :app:lintVitalRelease *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbce79a1108327a25b2c2ab76a2426