### PR TITLE
Integrate TedImagePicker for chat attachments

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,6 +172,7 @@ dependencies {
     implementation lib.domain
     implementation lib.data
     implementation("com.github.dhaval2404:imagepicker:2.1")
+    implementation "io.github.ParkSangGwon:tedimagepicker:1.4.2"
     debugImplementation "com.github.chuckerteam.chucker:library:4.0.0"
     releaseImplementation "com.github.chuckerteam.chucker:library-no-op:4.0.0"
     implementation("com.vanniktech:android-image-cropper:4.6.0")

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -3,11 +3,12 @@ package uddug.com.naukoteka.ui.chat.compose
 
 import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
 import android.media.MediaPlayer
 import android.net.Uri
+import android.os.Build
 import android.provider.ContactsContract
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -43,6 +44,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
+import com.gun0912.tedimagepicker.builder.TedImagePicker
 import kotlinx.coroutines.launch
 import uddug.com.naukoteka.mvvm.chat.ChatDialogUiState
 import uddug.com.naukoteka.mvvm.chat.ChatDialogViewModel
@@ -105,15 +108,6 @@ fun ChatDialogComponent(
         }
     }
 
-    val mediaPickerLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.PickMultipleVisualMedia()
-    ) { uris: List<Uri> ->
-        val files = uris.mapNotNull { uri -> uriToFile(context, uri) }
-        if (files.isNotEmpty()) {
-            viewModel.attachFiles(files)
-        }
-    }
-
     val filePickerLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenMultipleDocuments()
     ) { uris: List<Uri> ->
@@ -123,18 +117,48 @@ fun ChatDialogComponent(
         }
     }
 
+    val mediaPermissions = remember {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO
+            )
+        } else {
+            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+    }
+    val filePermissions = remember {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            emptyArray()
+        } else {
+            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+    }
+
+    fun attachMediaFiles(uris: List<Uri>) {
+        val files = uris.mapNotNull { uri -> uriToFile(context, uri) }
+        if (files.isNotEmpty()) {
+            viewModel.attachFiles(files)
+        }
+    }
+
+    fun openMediaPicker() {
+        TedImagePicker.with(context)
+            .showCameraTile(true)
+            .startMultiImage { uriList ->
+                attachMediaFiles(uriList)
+            }
+    }
+
     val permissionLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { granted: Boolean ->
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val granted = permissions.values.all { it }
         if (granted) {
             when (pendingPickerType) {
-                AttachmentPickerType.MEDIA ->
-                    mediaPickerLauncher.launch(
-                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageAndVideo)
-                    )
-                AttachmentPickerType.FILE ->
-                    filePickerLauncher.launch(arrayOf("*/*"))
-                null -> {}
+                AttachmentPickerType.MEDIA -> openMediaPicker()
+                AttachmentPickerType.FILE -> filePickerLauncher.launch(arrayOf("*/*"))
+                null -> Unit
             }
         }
         pendingPickerType = null
@@ -339,14 +363,28 @@ fun ChatDialogComponent(
             AttachOptionsBottomSheetDialog(
                 onDismissRequest = { showAttachmentSheet = false },
                 onMediaClick = {
-                    pendingPickerType = AttachmentPickerType.MEDIA
-                    permissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
                     showAttachmentSheet = false
+                    val hasPermissions = mediaPermissions.all { permission ->
+                        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+                    }
+                    if (hasPermissions) {
+                        openMediaPicker()
+                    } else {
+                        pendingPickerType = AttachmentPickerType.MEDIA
+                        permissionLauncher.launch(mediaPermissions)
+                    }
                 },
                 onFileClick = {
-                    pendingPickerType = AttachmentPickerType.FILE
-                    permissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
                     showAttachmentSheet = false
+                    val hasPermissions = filePermissions.all { permission ->
+                        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+                    }
+                    if (hasPermissions) {
+                        filePickerLauncher.launch(arrayOf("*/*"))
+                    } else {
+                        pendingPickerType = AttachmentPickerType.FILE
+                        permissionLauncher.launch(filePermissions)
+                    }
                 },
                 onPollClick = { showAttachmentSheet = false },
                 onContactClick = {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
@@ -1,20 +1,27 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.Person
-
+import androidx.compose.material.icons.filled.Poll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -22,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import uddug.com.naukoteka.R
 
@@ -46,17 +54,17 @@ fun AttachOptionsBottomSheetDialog(
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
             BottomSheetItem(
-                icon = Icons.Filled.Person,
+                icon = Icons.Filled.Image,
                 text = stringResource(R.string.chat_attach_photo_video),
                 onClick = onMediaClick
             )
             BottomSheetItem(
-                icon = Icons.Filled.Person,
+                icon = Icons.Filled.InsertDriveFile,
                 text = stringResource(R.string.chat_attach_file),
                 onClick = onFileClick
             )
             BottomSheetItem(
-                icon = Icons.Filled.Person,
+                icon = Icons.Filled.Poll,
                 text = stringResource(R.string.chat_attach_poll),
                 onClick = onPollClick
             )
@@ -81,13 +89,30 @@ private fun BottomSheetItem(
             .clickable { onClick() },
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = text,
-            modifier = Modifier.height(40.dp)
-        )
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.primary,
+                    shape = CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = text,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(24.dp)
+            )
+        }
         Spacer(modifier = Modifier.height(8.dp))
-        Text(text = text)
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            maxLines = 2
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- integrate the TedImagePicker library for the chat media attachment flow with runtime permission handling
- refresh the attachment options bottom sheet visuals to use circular icons and improved styling
- add the TedImagePicker dependency to the app module

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd11c3258832791b6d75585a70be4