### PR TITLE
Redesign contact picker and enable contact message sending

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/SendContactViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/SendContactViewModel.kt
@@ -3,17 +3,26 @@ package uddug.com.naukoteka.mvvm.chat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.Duration
+import java.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import uddug.com.domain.entities.chat.UserStatus
+import uddug.com.domain.entities.profile.Image
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.interactors.chat.ChatInteractor
 import javax.inject.Inject
 
 data class SendContactUiState(
     val query: String = "",
-    val contacts: List<UserProfileFullInfo> = emptyList()
+    val contacts: List<SendContactItem> = emptyList()
+)
+
+data class SendContactItem(
+    val user: UserProfileFullInfo,
+    val status: String?
 )
 
 @HiltViewModel
@@ -25,22 +34,75 @@ class SendContactViewModel @Inject constructor(
     val uiState: StateFlow<SendContactUiState> = _uiState
 
     init {
-        loadContacts("")
+        loadContacts()
     }
 
     fun onQueryChange(query: String) {
         _uiState.update { it.copy(query = query) }
-        loadContacts(query)
     }
 
-    private fun loadContacts(query: String) {
+    private fun loadContacts() {
         viewModelScope.launch {
-            val users = try {
-                chatInteractor.searchUsers(query)
+            val contacts = try {
+                val dialogs = chatInteractor.getDialogs()
+                    .filter { it.dialogType == 1 }
+
+                val userIds = dialogs.mapNotNull { it.interlocutor.userId }.distinct()
+                val statuses = if (userIds.isNotEmpty()) {
+                    try {
+                        chatInteractor.getUsersStatus(userIds)
+                    } catch (e: Exception) {
+                        emptyList()
+                    }
+                } else {
+                    emptyList()
+                }
+                val statusMap = statuses.associateBy { it.userId }
+
+                dialogs.mapNotNull { chat ->
+                    val interlocutor = chat.interlocutor
+                    val userId = interlocutor.userId ?: return@mapNotNull null
+                    val fullName = interlocutor.fullName ?: interlocutor.nickname
+                    val profile = UserProfileFullInfo(
+                        id = userId,
+                        fullName = fullName,
+                        nickname = interlocutor.nickname,
+                        image = Image(path = interlocutor.image)
+                    )
+                    SendContactItem(
+                        user = profile,
+                        status = formatStatus(statusMap[userId])
+                    )
+                }.distinctBy { it.user.id }
             } catch (e: Exception) {
                 emptyList()
             }
-            _uiState.update { it.copy(contacts = users) }
+            _uiState.update { it.copy(contacts = contacts) }
+        }
+    }
+
+    private fun formatStatus(status: UserStatus?): String? {
+        status ?: return null
+        if (status.isOnline) {
+            return "Сейчас онлайн"
+        }
+        val lastSeen = status.lastSeen ?: return null
+        return try {
+            val instant = Instant.parse(lastSeen)
+            val duration = Duration.between(instant, Instant.now())
+            val minutes = duration.toMinutes().coerceAtLeast(1)
+            val hours = duration.toHours().coerceAtLeast(1)
+            val days = duration.toDays().coerceAtLeast(1)
+            val weeks = (days / 7).coerceAtLeast(1)
+            when {
+                minutes < 60 -> "Был(а) в сети ${minutes} мин. назад"
+                hours < 24 -> "Был(а) в сети ${hours} ч. назад"
+                days == 1L -> "Был(а) в сети вчера"
+                days < 7 -> "Был(а) в сети ${days} д. назад"
+                else -> "Был(а) в сети ${weeks} нед. назад"
+            }
+        } catch (e: Exception) {
+            null
         }
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -257,7 +257,8 @@ fun ChatDialogComponent(
                         isRecording = isRecording,
                         recordedAudio = recordedAudio,
                         recordingTime = String.format("%02d:%02d", recordingTime / 60000, (recordingTime / 1000) % 60),
-                        isRecordingPlaying = isRecordingPlaying,
+                        selectedContact = state.selectedContact,
+                        attachedContact = state.attachedContact,
                         onMessageChange = { newMessage ->
                             viewModel.updateCurrentMessage(newMessage)
                         },
@@ -290,6 +291,12 @@ fun ChatDialogComponent(
                         },
                         onCancelReply = {
                             viewModel.clearReplyMessage()
+                        },
+                        onRemoveSelectedContact = {
+                            viewModel.clearSelectedContact()
+                        },
+                        onRemoveAttachedContact = {
+                            viewModel.clearAttachedContact()
                         },
                         onDeleteRecording = {
                             recordedAudio?.delete()
@@ -330,7 +337,8 @@ fun ChatDialogComponent(
                                     }
                                 }
                             }
-                        }
+                        },
+                        isRecordingPlaying = isRecordingPlaying
                     )
                 }
             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/SendContactComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/SendContactComponent.kt
@@ -1,27 +1,46 @@
 package uddug.com.naukoteka.ui.chat.compose
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.SendContactItem
 import uddug.com.naukoteka.mvvm.chat.SendContactViewModel
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
 
 @Composable
 fun SendContactComponent(
@@ -30,38 +49,146 @@ fun SendContactComponent(
     onSelect: (UserProfileFullInfo) -> Unit
 ) {
     val state by viewModel.uiState.collectAsState()
+    val scaffoldState = rememberScaffoldState()
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        TopAppBar(
-            title = { Text(text = stringResource(R.string.send_contact_title)) },
-            navigationIcon = {
-                IconButton(onClick = onBack) {
+    val contacts = remember(state.query, state.contacts) {
+        val query = state.query.trim().lowercase()
+        if (query.isEmpty()) {
+            state.contacts
+        } else {
+            state.contacts.filter { item ->
+                val fullName = item.user.fullName?.lowercase().orEmpty()
+                val nickname = item.user.nickname?.lowercase().orEmpty()
+                fullName.contains(query) || nickname.contains(query)
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        scaffoldState = scaffoldState,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.send_contact_title),
+                        color = Color(0xFF1F1F1F),
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_back),
+                            contentDescription = null,
+                            tint = Color(0xFF1F1F1F)
+                        )
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp
+            )
+        },
+        backgroundColor = Color(0xFFF5F5F9)
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            TextField(
+                value = state.query,
+                onValueChange = { viewModel.onQueryChange(it) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                placeholder = { Text(text = stringResource(R.string.search_contacts_hint)) },
+                leadingIcon = {
                     Icon(
-                        painter = painterResource(id = R.drawable.ic_back),
+                        painter = painterResource(id = R.drawable.ic_search),
                         contentDescription = null
                     )
-                }
-            }
-        )
-        TextField(
-            value = state.query,
-            onValueChange = { viewModel.onQueryChange(it) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            placeholder = { Text(text = stringResource(R.string.search_contacts_hint)) }
-        )
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
-            items(state.contacts) { user ->
-                Text(
-                    text = user.fullName ?: "",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onSelect(user) }
-                        .padding(16.dp)
+                },
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                colors = TextFieldDefaults.textFieldColors(
+                    backgroundColor = Color.White,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                    cursorColor = Color(0xFF2E83D9),
+                    textColor = Color(0xFF1F1F1F),
+                    placeholderColor = Color(0xFF8F8FA0),
+                    leadingIconColor = Color(0xFF8F8FA0)
                 )
+            )
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(0.dp)
+            ) {
+                items(
+                    items = contacts,
+                    key = { item -> item.user.id ?: item.user.fullName ?: item.hashCode().toString() }
+                ) { item ->
+                    ContactListItem(
+                        contact = item,
+                        onClick = { onSelect(item.user) }
+                    )
+                }
             }
         }
     }
 }
 
+@Composable
+private fun ContactListItem(
+    contact: SendContactItem,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .background(Color.White)
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Avatar(
+                url = contact.user.image?.path,
+                name = contact.user.fullName,
+                size = 48.dp
+            )
+            Spacer(modifier = Modifier.size(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = contact.user.fullName.orEmpty(),
+                    color = Color(0xFF1F1F1F),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                contact.status?.let {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = it,
+                        color = Color(0xFF6F6F7B),
+                        fontSize = 13.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+        Divider(
+            color = Color(0xFFE7E8EC),
+            thickness = 1.dp,
+            modifier = Modifier.padding(start = 76.dp)
+        )
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.res.colorResource
 import coil.compose.AsyncImage
 import uddug.com.naukoteka.R
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.naukoteka.mvvm.chat.ContactInfo
 import java.io.File
 
 @Composable
@@ -58,6 +60,8 @@ fun ChatInputBar(
     isRecording: Boolean,
     recordedAudio: File?,
     recordingTime: String,
+    selectedContact: UserProfileFullInfo?,
+    attachedContact: ContactInfo?,
     onMessageChange: (String) -> Unit,
     onSendClick: () -> Unit,
     onVoiceClick: () -> Unit,
@@ -65,6 +69,8 @@ fun ChatInputBar(
     onAttachClick: () -> Unit,
     onRemoveFile: (File) -> Unit,
     onCancelReply: () -> Unit,
+    onRemoveSelectedContact: () -> Unit,
+    onRemoveAttachedContact: () -> Unit,
     onDeleteRecording: () -> Unit,
     onSendRecording: () -> Unit,
     onPlayRecording: () -> Unit,
@@ -153,6 +159,85 @@ fun ChatInputBar(
                             )
                         }
                     }
+                }
+            }
+        }
+
+        selectedContact?.let { contact ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.White)
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Avatar(
+                    url = contact.image?.path,
+                    name = contact.fullName,
+                    size = 40.dp
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = contact.fullName.orEmpty(),
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 14.sp,
+                        color = Color(0xFF1F1F1F)
+                    )
+                    val phone = contact.phone ?: contact.phone2 ?: contact.phone3
+                    phone?.takeIf { it.isNotBlank() }?.let {
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = it,
+                            fontSize = 12.sp,
+                            color = Color(0xFF8083A0)
+                        )
+                    }
+                }
+                IconButton(onClick = onRemoveSelectedContact) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Remove contact",
+                        tint = Color(0xFF8083A0)
+                    )
+                }
+            }
+        }
+
+        attachedContact?.let { contact ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.White)
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Avatar(
+                    url = null,
+                    name = contact.name,
+                    size = 40.dp
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = contact.name,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 14.sp,
+                        color = Color(0xFF1F1F1F)
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = contact.phone,
+                        fontSize = 12.sp,
+                        color = Color(0xFF8083A0)
+                    )
+                }
+                IconButton(onClick = onRemoveAttachedContact) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Remove contact",
+                        tint = Color(0xFF8083A0)
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace the send contact screen with a scaffolded layout that filters personal dialogs and shows contact statuses
- fetch personal dialogs and user presence data for the picker through the chat interactor
- surface selected contacts in the chat input bar and send them through the socket as cType 7 messages

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK location not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcf3ee7fc832799cf8bd4ec4279f4