### PR TITLE
Fix chat message update payload

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -409,7 +409,12 @@ class ChatDialogViewModel @Inject constructor(
 
             if (editingMessage != null) {
                 try {
-                    val updated = chatInteractor.updateMessage(editingMessage.id, text)
+                    val updated = chatInteractor.updateMessage(
+                        dialogId = dialog.id,
+                        messageId = editingMessage.id,
+                        text = text,
+                        fileIds = editingMessage.files.map { it.id },
+                    )
                     val updatedChats = successState.chats.map { existing ->
                         if (existing.id == updated.id) {
                             existing.copy(

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -246,8 +246,20 @@ class ChatRepositoryImpl @Inject constructor(
         apiService.unpinMessage(PinMessageRequestDto(dialogId, messageId))
     }
 
-    override suspend fun updateMessage(messageId: Long, text: String): MessageChat {
-        val dto = apiService.updateMessage(UpdateMessageRequestDto(messageId, text))
+    override suspend fun updateMessage(
+        dialogId: Long,
+        messageId: Long,
+        text: String,
+        fileIds: List<String> = emptyList(),
+    ): MessageChat {
+        val dto = apiService.updateMessage(
+            UpdateMessageRequestDto(
+                dialogId = dialogId,
+                messageId = messageId,
+                updatedText = text,
+                files = fileIds,
+            )
+        )
         return dto.toDomain(dto.ownerId)
     }
 

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateMessageRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateMessageRequestDto.kt
@@ -1,6 +1,10 @@
 package uddug.com.data.services.models.request.chat
 
+import com.google.gson.annotations.SerializedName
+
 data class UpdateMessageRequestDto(
-    val messageId: Long,
-    val text: String?,
+    @SerializedName("dialogId") val dialogId: Long,
+    @SerializedName("messageId") val messageId: Long,
+    @SerializedName("updatedText") val updatedText: String?,
+    @SerializedName("files") val files: List<String> = emptyList(),
 )

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -85,8 +85,12 @@ class ChatInteractor @Inject constructor(
     suspend fun unpinMessage(dialogId: Long, messageId: Long) =
         chatRepository.unpinMessage(dialogId, messageId)
 
-    suspend fun updateMessage(messageId: Long, text: String): MessageChat =
-        chatRepository.updateMessage(messageId, text)
+    suspend fun updateMessage(
+        dialogId: Long,
+        messageId: Long,
+        text: String,
+        fileIds: List<String> = emptyList(),
+    ): MessageChat = chatRepository.updateMessage(dialogId, messageId, text, fileIds)
 
     suspend fun deleteMessage(messageId: Long, forMe: Boolean = false) =
         chatRepository.deleteMessage(messageId, forMe)

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -95,7 +95,12 @@ interface ChatRepository {
 
     suspend fun unpinMessage(dialogId: Long, messageId: Long)
 
-    suspend fun updateMessage(messageId: Long, text: String): MessageChat
+    suspend fun updateMessage(
+        dialogId: Long,
+        messageId: Long,
+        text: String,
+        fileIds: List<String> = emptyList(),
+    ): MessageChat
 
     suspend fun deleteMessage(messageId: Long, forMe: Boolean = false)
 


### PR DESCRIPTION
## Summary
- align the chat message update request body with the backend API by sending dialog id, updated text, and file identifiers
- propagate the new parameters through the data and domain layers
- update the chat dialog view model to supply the dialog id and existing attachment ids when editing messages

## Testing
- ./gradlew :data:compileDebugKotlin *(fails in CI sandbox: Android SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd33187d48327b5552d17e32fcf86