### PR TITLE
Clear edit state when switching to reply mode

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -314,7 +314,11 @@ class ChatDialogViewModel @Inject constructor(
     fun setReplyMessage(message: MessageChat) {
         val currentState = _uiState.value
         if (currentState is ChatDialogUiState.Success) {
-            _uiState.value = currentState.copy(replyMessage = message)
+            _uiState.value = currentState.copy(
+                replyMessage = message,
+                editingMessage = null,
+                currentMessage = if (currentState.editingMessage != null) "" else currentState.currentMessage,
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- clear the current editing state when a reply is initiated so only one mode is active at a time

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbd364035c8327927cce5164eb5907