### PR TITLE
Fix manifest provider conflict and format string placeholders

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,10 +106,12 @@
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
-            android:grantUriPermissions="true">
+            android:grantUriPermissions="true"
+            tools:replace="android:authorities">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/image_path" />
+                android:resource="@xml/image_path"
+                tools:replace="android:resource" />
         </provider>
 
         <meta-data

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -109,8 +109,8 @@
   <string name="delete_photo">Удалить фотографию</string>
   <string name="change_photo">Изменить фотографию</string>
   <string name="open_photo">Открыть фотографию</string>
-  <string name="amount_followers_following">%s подписчиков ∙ %s подписок</string>
+  <string name="amount_followers_following">%1$s подписчиков ∙ %2$s подписок</string>
   <string name="send_contact_title">Отправить контакт</string>
   <string name="search_contacts_hint">Поиск по контактам</string>
-  <string name="labor_activity_name">%s в <font color="#2E83D9">%s</font></string>
+  <string name="labor_activity_name">%1$s в <font color="#2E83D9">%2$s</font></string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -111,8 +111,8 @@
   <string name="delete_photo">Удалить фотографию</string>
   <string name="change_photo">Изменить фотографию</string>
   <string name="open_photo">Открыть фотографию</string>
-  <string name="amount_followers_following">%s подписчиков ∙ %s подписок</string>
+  <string name="amount_followers_following">%1$s подписчиков ∙ %2$s подписок</string>
   <string name="send_contact_title">Отправить контакт</string>
   <string name="search_contacts_hint">Поиск по контактам</string>
-  <string name="labor_activity_name">%s в <font color="##2E83D9">%s</font></string>
+  <string name="labor_activity_name">%1$s в <font color="##2E83D9">%2$s</font></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,7 +110,7 @@
     <string name="delete_photo">Удалить фотографию</string>
     <string name="change_photo">Изменить фотографию</string>
     <string name="open_photo">Открыть фотографию</string>
-    <string name="amount_followers_following">%s подписчиков ∙ %s подписок</string>
+    <string name="amount_followers_following">%1$s подписчиков ∙ %2$s подписок</string>
     <string name="edit_photo">Изменить фотографию</string>
     <string name="Фотография">Фотография</string>
     <string name="profile">Профиль</string>
@@ -126,7 +126,7 @@
     <string name="place_birthday">Место рождения</string>
     <string name="place_live">Место проживания</string>
     <string name="personal_info">Контактная информация</string>
-    <string name="labor_activity_name">%s в %s</string>
+    <string name="labor_activity_name">%1$s в %2$s</string>
     <string name="profile_full_subs">Подписчика</string>
     <string name="profile_full_subr">Подписок</string>
     <string name="naukotheka_ru_link">naukotheka.ru/%1$s</string>


### PR DESCRIPTION
## Summary
- add tools:replace attributes to the app FileProvider declaration to resolve manifest merge conflicts with tedimagepicker
- update follower and labor activity strings to use positional parameters across locales to satisfy resource formatting requirements

## Testing
- ./gradlew :app:processDebugMainManifest *(fails: repository downloads blocked with HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd7b6081c8327bcf5db208d005b49