### PR TITLE
Improve chat search UI and behavior

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -227,7 +227,7 @@ class ChatListViewModel @Inject constructor(
     }
 
     private companion object {
-        const val SEARCH_MIN_QUERY_LENGTH = 4
+        const val SEARCH_MIN_QUERY_LENGTH = 1
     }
 }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -83,7 +83,7 @@ fun ChatListComponent(
         }
 
         SearchField(
-            title = stringResource(R.string.find_chat_message),
+            title = stringResource(R.string.search_enter_query_full),
             query = query,
             onSearchChanged = {
                 query = it
@@ -96,7 +96,8 @@ fun ChatListComponent(
             onFocusChanged = { focused ->
                 isSearchFieldFocused = focused
                 viewModel.onSearchFocusChanged(focused || query.isNotEmpty())
-            }
+            },
+            placeholderCentered = true
         )
         if (!isSearchActive) {
             Box(modifier = Modifier.weight(1f)) {
@@ -197,7 +198,7 @@ private fun SearchResultsContent(
             when {
                 query.length < SEARCH_MIN_QUERY_LENGTH -> {
                     Text(
-                        text = stringResource(R.string.search_min_chars_hint, SEARCH_MIN_QUERY_LENGTH),
+                        text = stringResource(R.string.search_enter_query),
                         color = Color(0xFF8083A0),
                         modifier = Modifier
                             .align(Alignment.Center)
@@ -223,7 +224,11 @@ private fun SearchResultsContent(
                     } else {
                         LazyColumn(modifier = Modifier.fillMaxSize()) {
                             items(currentResults) { result ->
-                                SearchResultItem(result = result, onClick = onResultClick)
+                                SearchResultItem(
+                                    result = result,
+                                    query = query,
+                                    onClick = onResultClick
+                                )
                             }
                         }
                     }
@@ -238,4 +243,4 @@ private enum class SearchTab(@StringRes val titleRes: Int) {
     Messages(R.string.search_tab_messages)
 }
 
-private const val SEARCH_MIN_QUERY_LENGTH = 4
+private const val SEARCH_MIN_QUERY_LENGTH = 1

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
@@ -1,6 +1,7 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -16,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import uddug.com.naukoteka.R
 
@@ -25,6 +27,7 @@ fun SearchField(
     query: String,
     onSearchChanged: (String) -> Unit,
     onFocusChanged: (Boolean) -> Unit = {},
+    placeholderCentered: Boolean = false,
 ) {
     Row(
         modifier = Modifier
@@ -54,10 +57,25 @@ fun SearchField(
                 .onFocusChanged { onFocusChanged(it.isFocused) }
                 .padding(10.dp),
             decorationBox = { innerTextField ->
-                if (query.isEmpty()) {
-                    Text(text = title, color = Color.Gray)
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = if (placeholderCentered) Alignment.Center else Alignment.CenterStart
+                ) {
+                    if (query.isEmpty()) {
+                        Text(
+                            text = title,
+                            color = Color(0xFF8083A0),
+                            textAlign = if (placeholderCentered) TextAlign.Center else TextAlign.Start,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.CenterStart
+                    ) {
+                        innerTextField()
+                    }
                 }
-                innerTextField()
             }
         )
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchResultItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchResultItem.kt
@@ -2,36 +2,213 @@ package uddug.com.naukoteka.ui.chat.compose.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.domain.entities.chat.SearchDialog
+import uddug.com.domain.entities.chat.SearchMessage
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.core.deeplink.formatMessageTime as formatChatTime
 import uddug.com.naukoteka.mvvm.chat.SearchResult
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @Composable
 fun SearchResultItem(
     result: SearchResult,
+    query: String,
     onClick: (Long) -> Unit,
 ) {
-    val name = when (result) {
-        is SearchResult.Dialog -> result.data.fullName
-        is SearchResult.Message -> result.data.fullName
+    when (result) {
+        is SearchResult.Dialog -> SearchDialogResultCard(dialog = result.data, onClick = onClick)
+        is SearchResult.Message -> SearchMessageResultCard(result = result.data, query = query, onClick = onClick)
     }
-    val message = when (result) {
-        is SearchResult.Dialog -> ""
-        is SearchResult.Message -> result.data.text ?: ""
+}
+
+@Composable
+private fun SearchDialogResultCard(
+    dialog: SearchDialog,
+    onClick: (Long) -> Unit,
+) {
+    val context = LocalContext.current
+    val statusText = remember(dialog.createdAt) {
+        formatDialogStatus(context.resources, dialog.createdAt)
     }
+    val timeText = remember(dialog.createdAt) { formatChatTime(dialog.createdAt.toString()) }
+
+    ChatCard(
+        dialogId = dialog.dialogId,
+        avatarUrl = dialog.image,
+        name = dialog.fullName,
+        message = statusText,
+        time = timeText,
+        onChatClick = onClick,
+        onChatLongClick = {},
+    )
+}
+
+@Composable
+private fun SearchMessageResultCard(
+    result: SearchMessage,
+    query: String,
+    onClick: (Long) -> Unit,
+) {
+    val highlightColor = Color(0xFF2E83D9)
+    val timeText = remember(result.createdAt) { formatChatTime(result.createdAt.toString()) }
+    val messageText = result.text.orEmpty()
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick(result.dialogId) }
-            .padding(16.dp)
     ) {
-        Text(text = name)
-        if (message.isNotEmpty()) {
-            Text(text = message, modifier = Modifier.padding(top = 4.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Avatar(url = result.image, name = result.fullName, size = 40.dp)
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    HighlightedText(
+                        text = result.fullName,
+                        query = query,
+                        style = TextStyle(fontSize = 16.sp, color = Color.Black, fontWeight = FontWeight.SemiBold),
+                        highlightColor = highlightColor,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = timeText,
+                        color = Color(0xFF8083A0),
+                        fontSize = 12.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                }
+                if (messageText.isNotBlank()) {
+                    Text(
+                        text = buildHighlightedString(messageText, query, highlightColor),
+                        color = Color(0xFF4E5068),
+                        fontSize = 14.sp,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+            }
+        }
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 68.dp),
+            color = Color(0xFFEAEAF2),
+            thickness = 1.dp,
+        )
+    }
+}
+
+@Composable
+private fun HighlightedText(
+    text: String,
+    query: String,
+    style: TextStyle,
+    highlightColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = buildHighlightedString(text, query, highlightColor),
+        style = style,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier
+    )
+}
+
+private fun buildHighlightedString(
+    text: String,
+    query: String,
+    highlightColor: Color,
+): AnnotatedString {
+    if (query.isBlank()) {
+        return AnnotatedString(text)
+    }
+
+    val lowerText = text.lowercase(Locale.getDefault())
+    val lowerQuery = query.lowercase(Locale.getDefault())
+
+    if (!lowerText.contains(lowerQuery)) {
+        return AnnotatedString(text)
+    }
+
+    return buildAnnotatedString {
+        var currentIndex = 0
+        while (currentIndex < text.length) {
+            val index = lowerText.indexOf(lowerQuery, currentIndex)
+            if (index == -1) {
+                append(text.substring(currentIndex))
+                break
+            }
+            if (index > currentIndex) {
+                append(text.substring(currentIndex, index))
+            }
+            val end = index + lowerQuery.length
+            withStyle(SpanStyle(color = highlightColor, fontWeight = FontWeight.SemiBold)) {
+                append(text.substring(index, end))
+            }
+            currentIndex = end
+        }
+    }
+}
+
+private fun formatDialogStatus(resources: android.content.res.Resources, instant: Instant): String {
+    val zoneId = ZoneId.systemDefault()
+    val dialogTime = instant.atZone(zoneId)
+    val now = ZonedDateTime.now(zoneId)
+    val rawDuration = Duration.between(dialogTime, now)
+    val duration = if (rawDuration.isNegative) Duration.ZERO else rawDuration
+
+    return when {
+        duration <= Duration.ofMinutes(5) -> resources.getString(R.string.search_status_online)
+        duration < Duration.ofHours(1) -> resources.getString(
+            R.string.search_status_minutes_ago,
+            duration.toMinutes().toInt().coerceAtLeast(1)
+        )
+        duration < Duration.ofDays(1) -> resources.getString(
+            R.string.search_status_hours_ago,
+            duration.toHours().toInt().coerceAtLeast(1)
+        )
+        else -> {
+            val dateText = dialogTime.format(DateTimeFormatter.ofPattern("dd.MM.yy"))
+            resources.getString(R.string.search_status_date, dateText)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -372,6 +372,12 @@
     <string name="profile_shasre">Поделиться</string>
     <string name="profile_more">Еще</string>
     <string name="find_chat_message">Поиск чатов и сообщений</string>
+    <string name="search_enter_query_full">Введите текстовый запрос в поле поиска</string>
+    <string name="search_enter_query">Введите текстовый запрос</string>
+    <string name="search_status_online">Онлайн</string>
+    <string name="search_status_minutes_ago">Был(а) в сети %1$d минут назад</string>
+    <string name="search_status_hours_ago">Был(а) в сети %1$d часов назад</string>
+    <string name="search_status_date">Был(а) в сети %1$s</string>
     <string name="search_tab_chats">Чаты</string>
     <string name="search_tab_messages">Сообщения</string>
     <string name="search_min_chars_hint">Введите не менее %1$d символов</string>


### PR DESCRIPTION
## Summary
- allow chat search to run from a single character and update the empty state guidance
- center the search placeholder copy and reuse it in the chat search field
- render search results with the existing chat card and a new highlighted message card

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe03c0ca0832791f46e325cf108db