### PR TITLE
Add clear button to chat list search

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import uddug.com.naukoteka.R
@@ -59,6 +60,7 @@ fun ChatListComponent(
             .fillMaxSize()
             .background(color = Color.White)
     ) {
+        val focusManager = LocalFocusManager.current
         ChatToolbarComponent(
             viewModel = viewModel,
             onCreateChatClick = { onCreateChatClick() },
@@ -97,7 +99,16 @@ fun ChatListComponent(
                 isSearchFieldFocused = focused
                 viewModel.onSearchFocusChanged(focused || query.isNotEmpty())
             },
-            placeholderCentered = true
+            placeholderCentered = true,
+            showClearIcon = isSearchActive,
+            onClearClick = {
+                query = ""
+                selectedSearchTab = SearchTab.Dialogs
+                focusManager.clearFocus()
+                isSearchFieldFocused = false
+                viewModel.search("")
+                viewModel.onSearchFocusChanged(false)
+            }
         )
         if (!isSearchActive) {
             Box(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -28,6 +30,8 @@ fun SearchField(
     onSearchChanged: (String) -> Unit,
     onFocusChanged: (Boolean) -> Unit = {},
     placeholderCentered: Boolean = false,
+    showClearIcon: Boolean = false,
+    onClearClick: () -> Unit = {},
 ) {
     Row(
         modifier = Modifier
@@ -37,15 +41,14 @@ fun SearchField(
                 shape = RoundedCornerShape(16.dp),
                 color = Color(0xFFEAEAF2)
             )
-            .padding(start = 16.dp)
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             painter = painterResource(id = R.drawable.ic_search),
             contentDescription = "Search",
             tint = Color.Gray,
-            modifier = Modifier
-                .size(18.dp)
-                .align(Alignment.CenterVertically)
+            modifier = Modifier.size(18.dp)
         )
 
         BasicTextField(
@@ -53,9 +56,9 @@ fun SearchField(
             onValueChange = { onSearchChanged(it) },
             textStyle = LocalTextStyle.current.copy(color = Color.Black),
             modifier = Modifier
-                .fillMaxWidth()
+                .weight(1f)
                 .onFocusChanged { onFocusChanged(it.isFocused) }
-                .padding(10.dp),
+                .padding(horizontal = 12.dp, vertical = 10.dp),
             decorationBox = { innerTextField ->
                 Box(
                     modifier = Modifier.fillMaxWidth(),
@@ -78,5 +81,19 @@ fun SearchField(
                 }
             }
         )
+
+        if (showClearIcon) {
+            IconButton(
+                onClick = onClearClick,
+                modifier = Modifier.size(24.dp)
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_close),
+                    contentDescription = "Clear search",
+                    tint = Color.Gray,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add optional clear button support to the shared SearchField component
- show the clear button in the chat list search bar and reset the search state when pressed

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not configured in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe8eb9d0c8327b2fb2faae68dcdda