### PR TITLE
Add chat message forwarding flow

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ForwardMessageViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ForwardMessageViewModel.kt
@@ -1,0 +1,101 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uddug.com.domain.entities.chat.Chat
+import uddug.com.domain.entities.chat.ChatSocketMessage
+import uddug.com.domain.interactors.chat.ChatInteractor
+import uddug.com.naukoteka.ui.chat.di.SocketService
+
+@HiltViewModel
+class ForwardMessageViewModel @Inject constructor(
+    private val chatInteractor: ChatInteractor,
+    private val socketService: SocketService,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ForwardMessageUiState())
+    val uiState: StateFlow<ForwardMessageUiState> = _uiState
+
+    private val _events = MutableSharedFlow<ForwardMessageEvent>()
+    val events: SharedFlow<ForwardMessageEvent> = _events.asSharedFlow()
+
+    init {
+        socketService.connect()
+        loadDialogs()
+    }
+
+    fun onQueryChange(query: String) {
+        _uiState.update { it.copy(query = query) }
+    }
+
+    private fun loadDialogs() {
+        viewModelScope.launch {
+            val dialogs = try {
+                chatInteractor.getDialogs()
+            } catch (e: Exception) {
+                emptyList()
+            }
+            val items = dialogs.map { it.toForwardMessageItem() }
+                .distinctBy { it.dialogId }
+            _uiState.update { state ->
+                state.copy(dialogs = items)
+            }
+        }
+    }
+
+    fun forwardMessage(messageId: Long, dialogId: Long) {
+        viewModelScope.launch {
+            try {
+                val message = ChatSocketMessage(
+                    dialog = dialogId,
+                    text = "",
+                    forwarded = messageId
+                )
+                socketService.sendMessage("message", message)
+                _events.emit(ForwardMessageEvent.ForwardSuccess(dialogId))
+            } catch (e: Exception) {
+                _events.emit(ForwardMessageEvent.ForwardError)
+            }
+        }
+    }
+
+    private fun Chat.toForwardMessageItem(): ForwardMessageItem {
+        val title = dialogName.takeIf { it.isNotBlank() }
+            ?: interlocutor.fullName
+            ?: interlocutor.nickname
+            ?: ""
+        val subtitle = lastMessage.text?.takeIf { it.isNotBlank() }
+        return ForwardMessageItem(
+            dialogId = dialogId,
+            title = title,
+            subtitle = subtitle,
+            avatarUrl = interlocutor.image
+        )
+    }
+}
+
+data class ForwardMessageUiState(
+    val query: String = "",
+    val dialogs: List<ForwardMessageItem> = emptyList(),
+)
+
+data class ForwardMessageItem(
+    val dialogId: Long,
+    val title: String,
+    val subtitle: String?,
+    val avatarUrl: String?,
+)
+
+sealed class ForwardMessageEvent {
+    data class ForwardSuccess(val dialogId: Long) : ForwardMessageEvent()
+    object ForwardError : ForwardMessageEvent()
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -26,6 +26,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatListUiState
 import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.ChatDetailDialogFragment.Companion.DIALOG_DETAIL
+import uddug.com.naukoteka.ui.chat.ForwardMessageFragment.Companion.ARG_MESSAGE_ID
 import uddug.com.naukoteka.ui.chat.compose.ChatDialogComponent
 import uddug.com.naukoteka.ui.chat.compose.ChatListComponent
 
@@ -125,6 +126,12 @@ class ChatDialogFragment : Fragment() {
                         },
                         onContactClick = {
                             findNavController().navigate(R.id.sendContactFragment)
+                        },
+                        onForwardMessage = { message ->
+                            val args = Bundle().apply {
+                                putLong(ARG_MESSAGE_ID, message.id)
+                            }
+                            findNavController().navigate(R.id.forwardMessageFragment, args)
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ForwardMessageFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ForwardMessageFragment.kt
@@ -1,0 +1,96 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ForwardMessageEvent
+import uddug.com.naukoteka.mvvm.chat.ForwardMessageItem
+import uddug.com.naukoteka.mvvm.chat.ForwardMessageViewModel
+import uddug.com.naukoteka.ui.chat.compose.ForwardMessageComponent
+
+@AndroidEntryPoint
+class ForwardMessageFragment : Fragment() {
+
+    private val viewModel: ForwardMessageViewModel by viewModels()
+
+    private var messageId: Long = 0L
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        messageId = requireArguments().getLong(ARG_MESSAGE_ID)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ForwardMessageComponent(
+                        viewModel = viewModel,
+                        onBack = { requireActivity().onBackPressed() },
+                        onSelect = { item -> onDialogSelected(item) }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.events.collectLatest { event ->
+                    when (event) {
+                        is ForwardMessageEvent.ForwardSuccess -> navigateToDialog(event.dialogId)
+                        ForwardMessageEvent.ForwardError -> showError()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onDialogSelected(item: ForwardMessageItem) {
+        viewModel.forwardMessage(messageId, item.dialogId)
+    }
+
+    private fun navigateToDialog(dialogId: Long) {
+        val navOptions = NavOptions.Builder()
+            .setPopUpTo(R.id.chatDialogFragment, true)
+            .build()
+        findNavController().navigate(
+            R.id.chatDialogFragment,
+            Bundle().apply { putLong(ChatDialogFragment.DIALOG_ID, dialogId) },
+            navOptions
+        )
+    }
+
+    private fun showError() {
+        Toast.makeText(
+            requireContext(),
+            getString(R.string.forward_message_error),
+            Toast.LENGTH_SHORT
+        ).show()
+    }
+
+    companion object {
+        const val ARG_MESSAGE_ID = "forward_message_id"
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -70,6 +70,7 @@ fun ChatDialogComponent(
     onBackPressed: () -> Unit,
     onSearchClick: () -> Unit,
     onContactClick: () -> Unit,
+    onForwardMessage: (MessageChat) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val scrollState = rememberLazyListState()
@@ -419,6 +420,9 @@ fun ChatDialogComponent(
                 onEdit = { msg ->
                     viewModel.startEditingMessage(msg)
                     selectedMessage = null
+                },
+                onForward = { msg ->
+                    onForwardMessage(msg)
                 }
             )
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ForwardMessageComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ForwardMessageComponent.kt
@@ -1,0 +1,193 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ForwardMessageItem
+import uddug.com.naukoteka.mvvm.chat.ForwardMessageViewModel
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
+
+@Composable
+fun ForwardMessageComponent(
+    viewModel: ForwardMessageViewModel,
+    onBack: () -> Unit,
+    onSelect: (ForwardMessageItem) -> Unit,
+) {
+    val state by viewModel.uiState.collectAsState()
+    val scaffoldState = rememberScaffoldState()
+
+    val dialogs = remember(state.query, state.dialogs) {
+        val query = state.query.trim().lowercase()
+        if (query.isEmpty()) {
+            state.dialogs
+        } else {
+            state.dialogs.filter { item ->
+                val title = item.title.lowercase()
+                val subtitle = item.subtitle?.lowercase().orEmpty()
+                title.contains(query) || subtitle.contains(query)
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        scaffoldState = scaffoldState,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.forward_message_title),
+                        color = Color(0xFF1F1F1F),
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_back),
+                            contentDescription = null,
+                            tint = Color(0xFF1F1F1F)
+                        )
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp,
+            )
+        },
+        backgroundColor = Color(0xFFF5F5F9),
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            TextField(
+                value = state.query,
+                onValueChange = viewModel::onQueryChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                placeholder = { Text(text = stringResource(R.string.search_dialogs_hint)) },
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_search),
+                        contentDescription = null,
+                    )
+                },
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                colors = TextFieldDefaults.textFieldColors(
+                    backgroundColor = Color.White,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                    cursorColor = Color(0xFF2E83D9),
+                    textColor = Color(0xFF1F1F1F),
+                    placeholderColor = Color(0xFF8F8FA0),
+                    leadingIconColor = Color(0xFF8F8FA0),
+                ),
+            )
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(0.dp)
+            ) {
+                items(
+                    items = dialogs,
+                    key = { item -> item.dialogId }
+                ) { item ->
+                    ForwardMessageListItem(
+                        item = item,
+                        onClick = { onSelect(item) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ForwardMessageListItem(
+    item: ForwardMessageItem,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .background(Color.White)
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Avatar(
+                url = item.avatarUrl,
+                name = item.title,
+                size = 48.dp,
+            )
+            Spacer(modifier = Modifier.size(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.title,
+                    color = Color(0xFF1F1F1F),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                item.subtitle?.let {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = it,
+                        color = Color(0xFF6F6F7B),
+                        fontSize = 13.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+        Divider(
+            color = Color(0xFFE7E8EC),
+            thickness = 1.dp,
+            modifier = Modifier.padding(start = 76.dp)
+        )
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -36,6 +36,7 @@ fun MessageFunctionsBottomSheetDialog(
     onSelectMessage: () -> Unit,
     onReply: (MessageChat) -> Unit,
     onEdit: (MessageChat) -> Unit,
+    onForward: (MessageChat) -> Unit,
     viewModel: MessageFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -62,7 +63,7 @@ fun MessageFunctionsBottomSheetDialog(
                 if (message.isMine && message.type == MessageType.TEXT) {
                     add(R.string.chat_message_edit to { onEdit(message) })
                 }
-                add(R.string.chat_message_forward to { viewModel.forward(message.id) })
+                add(R.string.chat_message_forward to { onForward(message) })
                 add(R.string.chat_message_copy to {
                     message.text?.let {
                         context.copyToClipboard(it)

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -60,4 +60,8 @@
         android:id="@+id/sendContactFragment"
         android:name="uddug.com.naukoteka.ui.chat.SendContactFragment"/>
 
+    <fragment
+        android:id="@+id/forwardMessageFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ForwardMessageFragment"/>
+
 </navigation>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -111,6 +111,9 @@
   <string name="open_photo">Открыть фотографию</string>
   <string name="amount_followers_following">%1$s подписчиков ∙ %2$s подписок</string>
   <string name="send_contact_title">Отправить контакт</string>
+  <string name="forward_message_title">Переслать сообщение</string>
+  <string name="forward_message_error">Не удалось переслать сообщение</string>
+  <string name="search_dialogs_hint">Поиск по диалогам</string>
   <string name="search_contacts_hint">Поиск по контактам</string>
   <string name="labor_activity_name">%1$s в <font color="#2E83D9">%2$s</font></string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -113,6 +113,9 @@
   <string name="open_photo">Открыть фотографию</string>
   <string name="amount_followers_following">%1$s подписчиков ∙ %2$s подписок</string>
   <string name="send_contact_title">Отправить контакт</string>
+  <string name="forward_message_title">Переслать сообщение</string>
+  <string name="forward_message_error">Не удалось переслать сообщение</string>
+  <string name="search_dialogs_hint">Поиск по диалогам</string>
   <string name="search_contacts_hint">Поиск по контактам</string>
   <string name="labor_activity_name">%1$s в <font color="##2E83D9">%2$s</font></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,6 +413,9 @@
     <string name="chat_attach_poll">Опросы</string>
     <string name="chat_attach_contact">Контакты</string>
     <string name="send_contact_title">Отправить контакт</string>
+    <string name="forward_message_title">Переслать сообщение</string>
+    <string name="forward_message_error">Не удалось переслать сообщение</string>
+    <string name="search_dialogs_hint">Поиск по диалогам</string>
     <string name="search_contacts_hint">Поиск по контактам</string>
 
 </resources>

--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
@@ -9,6 +9,9 @@ data class ChatSocketMessage(
     val files: List<FileDescriptor>? = null,
     val answered: Long? = null,
     val ansPreview: AnswerPreview? = null,
+    val forwarded: Long? = null,
+    val forwardedn: List<Long>? = null,
+    val dialogs: List<Long>? = null,
 )
 
 public data class FileDescriptor(


### PR DESCRIPTION
## Summary
- add a dedicated forwarding screen that lists available dialogs and sends the selected message via the socket
- hook the message action bottom sheet to open the new screen and navigate to the chosen chat after forwarding
- extend ChatSocketMessage and string resources to support the new flow

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbeb99596c8327aee2c8467fa8697f