### PR TITLE
Fix chat search time parsing crash

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/core/deeplink/Extensions.kt
+++ b/app/src/main/java/uddug/com/naukoteka/core/deeplink/Extensions.kt
@@ -47,19 +47,20 @@ fun Context.launchCustomTabsByUrl(
 
 
 fun formatMessageTime(time: String): String {
-    val messageDate = ZonedDateTime.parse(time, DateTimeFormatter.ISO_DATE_TIME)
-        .withZoneSameInstant(ZoneId.systemDefault())
-    val currentDate = ZonedDateTime.now(ZoneId.systemDefault())
+    return runCatching {
+        val messageDate = ZonedDateTime.parse(time, DateTimeFormatter.ISO_DATE_TIME)
+            .withZoneSameInstant(ZoneId.systemDefault())
+        val currentDate = ZonedDateTime.now(ZoneId.systemDefault())
 
-    return when {
-        messageDate.toLocalDate().isEqual(currentDate.toLocalDate()) -> {
-            messageDate.format(DateTimeFormatter.ofPattern("HH:mm"))
+        when {
+            messageDate.toLocalDate().isEqual(currentDate.toLocalDate()) -> {
+                messageDate.format(DateTimeFormatter.ofPattern("HH:mm"))
+            }
+            messageDate.isAfter(currentDate.minusDays(7)) -> {
+                val dayOfWeek = messageDate.dayOfWeek
+                dayOfWeek.getDisplayName(java.time.format.TextStyle.SHORT, java.util.Locale("ru"))
+            }
+            else -> messageDate.format(DateTimeFormatter.ofPattern("dd.MM.yy"))
         }
-        messageDate.isAfter(currentDate.minusDays(7)) -> {
-            val dayOfWeek = messageDate.dayOfWeek
-            val shortDay = dayOfWeek.getDisplayName(java.time.format.TextStyle.SHORT, java.util.Locale("ru"))
-            shortDay
-        }
-        else -> messageDate.format(DateTimeFormatter.ofPattern("dd.MM.yy"))
-    }
+    }.getOrElse { time }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchResultItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchResultItem.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.sp
 import uddug.com.domain.entities.chat.SearchDialog
 import uddug.com.domain.entities.chat.SearchMessage
 import uddug.com.naukoteka.R
-import uddug.com.naukoteka.core.deeplink.formatMessageTime as formatChatTime
+import uddug.com.naukoteka.core.deeplink.formatMessageTime
 import uddug.com.naukoteka.mvvm.chat.SearchResult
 import java.time.Duration
 import java.time.Instant
@@ -57,14 +57,14 @@ private fun SearchDialogResultCard(
     val statusText = remember(dialog.createdAt) {
         formatDialogStatus(context.resources, dialog.createdAt)
     }
-    val timeText = remember(dialog.createdAt) { formatChatTime(dialog.createdAt.toString()) }
+    val createdAtIso = remember(dialog.createdAt) { dialog.createdAt.toString() }
 
     ChatCard(
         dialogId = dialog.dialogId,
         avatarUrl = dialog.image,
         name = dialog.fullName,
         message = statusText,
-        time = timeText,
+        time = createdAtIso,
         onChatClick = onClick,
         onChatLongClick = {},
     )
@@ -77,7 +77,7 @@ private fun SearchMessageResultCard(
     onClick: (Long) -> Unit,
 ) {
     val highlightColor = Color(0xFF2E83D9)
-    val timeText = remember(result.createdAt) { formatChatTime(result.createdAt.toString()) }
+    val createdAtIso = remember(result.createdAt) { result.createdAt.toString() }
     val messageText = result.text.orEmpty()
 
     Column(
@@ -106,7 +106,7 @@ private fun SearchMessageResultCard(
                         modifier = Modifier.weight(1f)
                     )
                     Text(
-                        text = timeText,
+                        text = formatMessageTime(createdAtIso),
                         color = Color(0xFF8083A0),
                         fontSize = 12.sp,
                         maxLines = 1,


### PR DESCRIPTION
## Summary
- guard chat time formatting against invalid or pre-formatted values to avoid runtime crashes
- pass raw ISO timestamps from chat search results so they are formatted consistently in the card UI
- reuse the shared formatter when rendering message search rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbed581564832784a4bc1dd8d5f1eb