### PR TITLE
Adjust chat search hints

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -99,7 +99,7 @@ fun ChatListComponent(
                 isSearchFieldFocused = focused
                 viewModel.onSearchFocusChanged(focused || query.isNotEmpty())
             },
-            placeholderCentered = true,
+            placeholderCentered = false,
             showClearIcon = isSearchActive,
             onClearClick = {
                 query = ""
@@ -111,6 +111,13 @@ fun ChatListComponent(
             }
         )
         if (!isSearchActive) {
+            Text(
+                text = stringResource(R.string.search_enter_query),
+                color = Color(0xFF8083A0),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            )
             Box(modifier = Modifier.weight(1f)) {
                 ChatTabBar(
                     viewModel = viewModel,
@@ -123,6 +130,15 @@ fun ChatListComponent(
                 )
             }
         } else {
+            if (query.length < SEARCH_MIN_QUERY_LENGTH) {
+                Text(
+                    text = stringResource(R.string.search_enter_query_min_length),
+                    color = Color(0xFF8083A0),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                )
+            }
             SearchResultsContent(
                 modifier = Modifier.weight(1f),
                 query = query,
@@ -207,15 +223,7 @@ private fun SearchResultsContent(
                 .background(Color.White)
         ) {
             when {
-                query.length < SEARCH_MIN_QUERY_LENGTH -> {
-                    Text(
-                        text = stringResource(R.string.search_enter_query),
-                        color = Color(0xFF8083A0),
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .padding(horizontal = 32.dp)
-                    )
-                }
+                query.length < SEARCH_MIN_QUERY_LENGTH -> {}
 
                 isLoading -> ChatListShimmer()
 
@@ -254,4 +262,4 @@ private enum class SearchTab(@StringRes val titleRes: Int) {
     Messages(R.string.search_tab_messages)
 }
 
-private const val SEARCH_MIN_QUERY_LENGTH = 1
+private const val SEARCH_MIN_QUERY_LENGTH = 3

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -374,6 +374,7 @@
     <string name="find_chat_message">Поиск чатов и сообщений</string>
     <string name="search_enter_query_full">Введите текстовый запрос в поле поиска</string>
     <string name="search_enter_query">Введите текстовый запрос</string>
+    <string name="search_enter_query_min_length">Введите текстовый запрос минимум 3 символа</string>
     <string name="search_status_online">Онлайн</string>
     <string name="search_status_minutes_ago">Был(а) в сети %1$d минут назад</string>
     <string name="search_status_hours_ago">Был(а) в сети %1$d часов назад</string>


### PR DESCRIPTION
## Summary
- show the "Введите текстовый запрос" hint when the search field is inactive and align the placeholder to the left
- display a minimum length helper message while the search field is focused and raise the threshold to three characters
- add a dedicated string resource for the new helper text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbedd7f40083279c54c1cd39932159