### PR TITLE
Fix logout flow to clear caches and show login

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/fragments/profile/settings/ProfileSecurityFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/fragments/profile/settings/ProfileSecurityFragment.kt
@@ -33,6 +33,7 @@ import uddug.com.naukoteka.ui.fragments.profile.edit.ProfileAvatarEditActionBott
 import uddug.com.naukoteka.ui.fragments.profile.edit.ProfileAvatarEditActionBottomSheetFragment.Companion.DELETE_AVATAR_RESULT
 import uddug.com.naukoteka.ui.fragments.profile.edit.ProfileAvatarEditActionBottomSheetFragment.Companion.UPLOAD_AVATAR_RESULT
 import uddug.com.naukoteka.ui.fragments.profile.edit.ProfileEditPersonalInfoFragment.Companion.UPDATE_PROFILE_INFO
+import uddug.com.naukoteka.navigation.Screens
 import uddug.com.naukoteka.utils.getHashCodeToString
 import uddug.com.naukoteka.utils.text.isNotNullOrEmpty
 import uddug.com.naukoteka.utils.ui.load
@@ -100,7 +101,11 @@ class ProfileSecurityFragment : BaseFragment(R.layout.fragment_profile_security)
     override fun openLoginPage() {
         val activity = requireActivity()
         activity.finishAffinity()
-        activity.startActivity(Intent(activity, AuthActivity::class.java))
+        activity.startActivity(
+            Intent(activity, AuthActivity::class.java).apply {
+                putExtra(Screens.TO_LOGIN, true)
+            }
+        )
     }
 
     override fun openLogoutDialog() {

--- a/app/src/main/java/uddug/com/naukoteka/ui/fragments/profile/settings/ProfileSecurityPresenter.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/fragments/profile/settings/ProfileSecurityPresenter.kt
@@ -3,7 +3,9 @@ package uddug.com.naukoteka.ui.fragments.profile.settings
 import moxy.InjectViewState
 import toothpick.InjectConstructor
 import uddug.com.data.cache.cookies.CookiesCache
+import uddug.com.data.cache.system_settings.UserSystemSettingsCache
 import uddug.com.data.cache.user_id.UserIdCache
+import uddug.com.data.cache.user_uuid.UserUUIDCache
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.interactors.user_profile.UserProfileInteractor
 import uddug.com.naukoteka.global.base.BasePresenterImpl
@@ -13,7 +15,9 @@ import uddug.com.naukoteka.global.base.BasePresenterImpl
 class ProfileSecurityPresenter(
     private val userProfileInteractor: UserProfileInteractor,
     private val cookiesCache: CookiesCache,
-    private val userIdCache: UserIdCache
+    private val userIdCache: UserIdCache,
+    private val userUUIDCache: UserUUIDCache,
+    private val userSystemSettingsCache: UserSystemSettingsCache
 ) : BasePresenterImpl<ProfileSecurityView>() {
 
     var userProfileFullInfo: UserProfileFullInfo? = null
@@ -30,6 +34,8 @@ class ProfileSecurityPresenter(
     fun selectConfirmExit() {
         cookiesCache.clear()
         userIdCache.clear()
+        userUUIDCache.clear()
+        userSystemSettingsCache.clear()
         viewState.openLoginPage()
     }
 


### PR DESCRIPTION
## Summary
- clear the remaining user-related caches when confirming logout
- relaunch the auth flow directly on the login screen after finishing the current task stack

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf4e34a248327a3b97c1bfde45e89