### PR TITLE
Reuse search result item in chat detail search

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
@@ -5,15 +5,24 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,8 +35,9 @@ import androidx.compose.ui.unit.sp
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatDetailUiState
 import uddug.com.naukoteka.mvvm.chat.ChatDialogDetailViewModel
+import uddug.com.naukoteka.mvvm.chat.SearchResult
 import uddug.com.naukoteka.ui.chat.compose.components.SearchField
-import uddug.com.naukoteka.ui.chat.compose.components.ChatMessagesList
+import uddug.com.naukoteka.ui.chat.compose.components.SearchResultItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -113,7 +123,15 @@ fun ChatDetailDialogSearchComponent(
                 0 -> if (searchMessages.isEmpty()) {
                     NoResults()
                 } else {
-                    ChatMessagesList(searchMessages)
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(searchMessages) { message ->
+                            SearchResultItem(
+                                result = SearchResult.Message(message),
+                                query = searchQuery,
+                                onClick = { _ -> }
+                            )
+                        }
+                    }
                 }
 
                 1 -> if (searchMedia.isEmpty()) {


### PR DESCRIPTION
## Summary
- reuse the shared SearchResultItem when rendering message matches in the chat detail search screen
- expose dialog search results as SearchMessage instances so they can be displayed consistently

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dbf4c6e7008327af1fda6e01090659