### PR TITLE
Fix duplicate search hint visibility in chat list

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -111,13 +111,6 @@ fun ChatListComponent(
             }
         )
         if (!isSearchActive) {
-            Text(
-                text = stringResource(R.string.search_enter_query),
-                color = Color(0xFF8083A0),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-            )
             Box(modifier = Modifier.weight(1f)) {
                 ChatTabBar(
                     viewModel = viewModel,
@@ -130,15 +123,6 @@ fun ChatListComponent(
                 )
             }
         } else {
-            if (query.length < SEARCH_MIN_QUERY_LENGTH) {
-                Text(
-                    text = stringResource(R.string.search_enter_query_min_length),
-                    color = Color(0xFF8083A0),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                )
-            }
             SearchResultsContent(
                 modifier = Modifier.weight(1f),
                 query = query,
@@ -223,7 +207,25 @@ private fun SearchResultsContent(
                 .background(Color.White)
         ) {
             when {
-                query.length < SEARCH_MIN_QUERY_LENGTH -> {}
+                query.isEmpty() -> {
+                    Text(
+                        text = stringResource(R.string.search_enter_query),
+                        color = Color(0xFF8083A0),
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(horizontal = 32.dp)
+                    )
+                }
+
+                query.length < SEARCH_MIN_QUERY_LENGTH -> {
+                    Text(
+                        text = stringResource(R.string.search_enter_query_min_length),
+                        color = Color(0xFF8083A0),
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(horizontal = 32.dp)
+                    )
+                }
 
                 isLoading -> ChatListShimmer()
 


### PR DESCRIPTION
## Summary
- remove the redundant search hint shown above the chat tabs when search is inactive
- show the search instructions centered below the search tabs only when the field is focused or the query is too short

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbfa3ae1b48327ac66c758eba6f9bf