### PR TITLE
Scroll chat dialog to newest message on load

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -203,6 +203,12 @@ fun ChatDialogComponent(
 
                 is ChatDialogUiState.Success -> {
                     val messages = state.chats
+
+                    LaunchedEffect(messages.size) {
+                        if (messages.isNotEmpty()) {
+                            scrollState.scrollToItem(messages.size - 1)
+                        }
+                    }
                     if (isSelectionMode) {
                         Surface(elevation = 4.dp) {
                             Column {


### PR DESCRIPTION
## Summary
- automatically scroll the chat dialog message list to the latest message when content loads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbfa823fe48327864a8ef554fa2405