### PR TITLE
Add chat message date separators

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -20,7 +20,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
@@ -52,6 +52,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatDialogViewModel
 import uddug.com.naukoteka.mvvm.chat.ContactInfo
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.ui.chat.compose.components.ChatInputBar
+import uddug.com.naukoteka.ui.chat.compose.components.ChatMessageDateBadge
 import uddug.com.naukoteka.ui.chat.compose.components.ChatMessageItem
 import uddug.com.naukoteka.ui.chat.compose.components.MessageFunctionsBottomSheetDialog
 import uddug.com.naukoteka.ui.chat.compose.components.AttachOptionsBottomSheetDialog
@@ -59,7 +60,11 @@ import uddug.com.naukoteka.ui.chat.compose.components.ChatTopBar
 import uddug.com.naukoteka.ui.chat.compose.components.MessageListShimmer
 import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.naukoteka.ui.chat.AudioRecorder
+import uddug.com.naukoteka.ui.chat.compose.formatMessageDate
+import uddug.com.naukoteka.ui.chat.compose.messageDate
+import uddug.com.naukoteka.ui.chat.compose.shouldShowDateBadge
 import java.io.File
+import java.time.ZoneId
 
 private enum class AttachmentPickerType { MEDIA, FILE }
 
@@ -77,6 +82,7 @@ fun ChatDialogComponent(
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
     val context = LocalContext.current
+    val zoneId = remember { ZoneId.systemDefault() }
     var selectedMessage by remember { mutableStateOf<MessageChat?>(null) }
     val isSelectionMode by viewModel.isSelectionMode.collectAsState()
     val selectedMessages by viewModel.selectedMessages.collectAsState()
@@ -262,13 +268,23 @@ fun ChatDialogComponent(
                             .fillMaxWidth()
                             .padding(vertical = 10.dp)
                     ) {
-                        items(messages) { message ->
+                        itemsIndexed(messages) { index, message ->
+                            val previousMessage = messages.getOrNull(index - 1)
+                            if (shouldShowDateBadge(previousMessage, message, zoneId)) {
+                                ChatMessageDateBadge(
+                                    text = formatMessageDate(
+                                        context = context,
+                                        date = message.messageDate(zoneId),
+                                        zoneId = zoneId
+                                    )
+                                )
+                            }
                             ChatMessageItem(
                                 message = message,
                                 isMine = message.isMine,
-                                    selectionMode = isSelectionMode,
-                                    isSelected = selectedMessages.contains(message.id),
-                                    onSelectChange = { viewModel.toggleMessageSelection(message.id) },
+                                selectionMode = isSelectionMode,
+                                isSelected = selectedMessages.contains(message.id),
+                                onSelectChange = { viewModel.toggleMessageSelection(message.id) },
                                 onLongPress = { selectedMessage = it }
                             )
                         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/MessageDateUtils.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/MessageDateUtils.kt
@@ -1,0 +1,61 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import android.content.Context
+import android.os.Build
+import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.naukoteka.R
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+internal fun MessageChat.messageDate(zoneId: ZoneId): LocalDate =
+    createdAt.atZone(zoneId).toLocalDate()
+
+internal fun shouldShowDateBadge(
+    previousMessage: MessageChat?,
+    currentMessage: MessageChat,
+    zoneId: ZoneId
+): Boolean {
+    val previousDate = previousMessage?.messageDate(zoneId)
+    val currentDate = currentMessage.messageDate(zoneId)
+    return previousDate != currentDate
+}
+
+internal fun formatMessageDate(
+    context: Context,
+    date: LocalDate,
+    zoneId: ZoneId
+): String {
+    val today = LocalDate.now(zoneId)
+    val daysDifference = ChronoUnit.DAYS.between(date, today)
+
+    return when {
+        daysDifference <= -1L -> date.format(createFormatter(context))
+        daysDifference == 0L -> context.getString(R.string.chat_message_date_today)
+        daysDifference == 1L -> context.getString(R.string.chat_message_date_yesterday)
+        daysDifference in 2..6 -> context.resources.getQuantityString(
+            R.plurals.chat_message_date_days_ago,
+            daysDifference.toInt(),
+            daysDifference.toInt()
+        )
+        daysDifference == 7L -> context.getString(R.string.chat_message_date_week_ago)
+        else -> date.format(createFormatter(context))
+    }
+}
+
+private fun createFormatter(context: Context): DateTimeFormatter {
+    val locale = currentLocale(context)
+    return DateTimeFormatter.ofPattern("d MMMM yyyy", locale)
+}
+
+@Suppress("DEPRECATION")
+private fun currentLocale(context: Context): Locale {
+    val configuration = context.resources.configuration
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        configuration.locales[0]
+    } else {
+        configuration.locale
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageDateBadge.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageDateBadge.kt
@@ -1,0 +1,41 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.shape.RoundedCornerShape
+
+@Composable
+fun ChatMessageDateBadge(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            color = Color(0xFF5E6273),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier
+                .background(
+                    color = Color(0xFFE6E8F0),
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .padding(horizontal = 12.dp, vertical = 4.dp)
+        )
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessagesList.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessagesList.kt
@@ -5,22 +5,40 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.Text
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.naukoteka.ui.chat.compose.formatMessageDate
+import uddug.com.naukoteka.ui.chat.compose.messageDate
+import uddug.com.naukoteka.ui.chat.compose.shouldShowDateBadge
+import java.time.ZoneId
 
 @Composable
 fun ChatMessagesList(messages: List<MessageChat>) {
+    val context = LocalContext.current
+    val zoneId = remember { ZoneId.systemDefault() }
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .padding(8.dp),
         contentPadding = PaddingValues(bottom = 16.dp)
     ) {
-        items(messages) { message ->
+        itemsIndexed(messages) { index, message ->
+            val previousMessage = messages.getOrNull(index - 1)
+            if (shouldShowDateBadge(previousMessage, message, zoneId)) {
+                ChatMessageDateBadge(
+                    text = formatMessageDate(
+                        context = context,
+                        date = message.messageDate(zoneId),
+                        zoneId = zoneId
+                    )
+                )
+            }
             Text(
                 text = message.text.orEmpty(),
                 modifier = Modifier

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -118,4 +118,13 @@
   <string name="search_dialogs_hint">Поиск по диалогам</string>
   <string name="search_contacts_hint">Поиск по контактам</string>
   <string name="labor_activity_name">%1$s в <font color="##2E83D9">%2$s</font></string>
+  <string name="chat_message_date_today">Сегодня</string>
+  <string name="chat_message_date_yesterday">Вчера</string>
+  <string name="chat_message_date_week_ago">Неделю назад</string>
+  <plurals name="chat_message_date_days_ago">
+    <item quantity="one">%d день назад</item>
+    <item quantity="few">%d дня назад</item>
+    <item quantity="many">%d дней назад</item>
+    <item quantity="other">%d дня назад</item>
+  </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,6 +335,15 @@
     <string name="today_daye">Сегодня</string>
     <string name="one_day_before">1 день назад</string>
     <string name="few_days_before">%1$s дней назад</string>
+    <string name="chat_message_date_today">Сегодня</string>
+    <string name="chat_message_date_yesterday">Вчера</string>
+    <string name="chat_message_date_week_ago">Неделю назад</string>
+    <plurals name="chat_message_date_days_ago">
+        <item quantity="one">%d день назад</item>
+        <item quantity="few">%d дня назад</item>
+        <item quantity="many">%d дней назад</item>
+        <item quantity="other">%d дня назад</item>
+    </plurals>
     <string name="wall_detail">Запись</string>
     <string name="user_post_comment">Комментарий</string>
     <string name="share">Поделиться</string>


### PR DESCRIPTION
## Summary
- show localized date separators in chat conversations and message search results
- add reusable utilities and UI badge for rendering day dividers
- extend string resources with relative date labels used by the separators

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf98a4628832797d86222fa0c2de9