### PR TITLE
Redesign chat file message

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -1,14 +1,22 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
+import android.app.DownloadManager
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -26,23 +34,32 @@ import androidx.compose.material.CheckboxDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.domain.entities.chat.MessageType
 import uddug.com.naukoteka.BuildConfig
+import uddug.com.naukoteka.R
+import uddug.com.domain.entities.chat.File as ChatFile
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -183,11 +200,12 @@ fun ChatMessageItem(
                             }
                         }
                     } else {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(Icons.Default.Menu, contentDescription = "PDF", tint = Color.White)
-                            Spacer(Modifier.width(8.dp))
-                            Text("Медиа Сообщение", fontSize = 12.sp, color = Color.White)
-                        }
+                        FileAttachmentCard(
+                            file = file,
+                            isMine = isMine,
+                            selectionMode = selectionMode,
+                            onSelectChange = onSelectChange
+                        )
                     }
                 }
 
@@ -205,6 +223,127 @@ fun ChatMessageItem(
 
         }
     }
+}
+
+@Composable
+private fun FileAttachmentCard(
+    file: ChatFile,
+    isMine: Boolean,
+    selectionMode: Boolean,
+    onSelectChange: () -> Unit,
+) {
+    val context = LocalContext.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val backgroundColor = if (isMine) Color.White.copy(alpha = 0.1f) else Color.White
+    val accentColor = if (isMine) Color.White else Color(0xFF2E83D9)
+    val supportingColor = if (isMine) Color.White.copy(alpha = 0.75f) else Color(0xFF6F7A90)
+    val fileTypeLabel = file.fileName?.substringAfterLast('.', "")?.takeIf { it.isNotBlank() }?.uppercase(Locale.getDefault())
+        ?: file.contentType?.substringAfterLast('/', "")?.takeIf { it.isNotBlank() }?.uppercase(Locale.getDefault())
+        ?: stringResource(id = R.string.chat_file_attachment_unknown_type)
+    val fileSizeText = formatFileSize(file.fileSize)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(backgroundColor)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) {
+                if (selectionMode) {
+                    onSelectChange()
+                } else {
+                    downloadChatFile(context, file)
+                }
+            }
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(
+                    if (isMine) Color.White.copy(alpha = 0.12f) else Color(0xFFE4E8F1)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_file_placeholder),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(accentColor),
+                modifier = Modifier.size(28.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = fileTypeLabel,
+                color = supportingColor,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = file.fileName.orEmpty(),
+                color = if (isMine) Color.White else Color(0xFF111827),
+                fontSize = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Filled.Download,
+                    contentDescription = null,
+                    tint = supportingColor,
+                    modifier = Modifier.size(16.dp)
+                )
+                if (!fileSizeText.isNullOrEmpty()) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = fileSizeText,
+                        color = supportingColor,
+                        fontSize = 12.sp
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatFileSize(sizeInBytes: Int?): String? {
+    if (sizeInBytes == null || sizeInBytes <= 0) return null
+    val kiloBytes = sizeInBytes / 1024.0
+    if (kiloBytes < 1) {
+        return String.format(Locale.getDefault(), "%d B", sizeInBytes)
+    }
+    val megaBytes = kiloBytes / 1024.0
+    if (megaBytes < 1) {
+        return String.format(Locale.getDefault(), "%.1f KB", kiloBytes)
+    }
+    val gigaBytes = megaBytes / 1024.0
+    if (gigaBytes < 1) {
+        return String.format(Locale.getDefault(), "%.1f MB", megaBytes)
+    }
+    return String.format(Locale.getDefault(), "%.2f GB", gigaBytes)
+}
+
+private fun downloadChatFile(context: Context, file: ChatFile) {
+    val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as? DownloadManager ?: return
+    val fileName = file.fileName?.takeIf { it.isNotBlank() } ?: "chat_file_${file.id}"
+    val request = DownloadManager.Request(Uri.parse(BuildConfig.IMAGE_SERVER_URL + file.path))
+        .setTitle(fileName)
+        .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+        .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS, fileName)
+        .setAllowedOverMetered(true)
+        .setAllowedOverRoaming(true)
+    file.contentType?.let { request.setMimeType(it) }
+    downloadManager.enqueue(request)
+    Toast.makeText(context, context.getString(R.string.chat_file_download_started), Toast.LENGTH_SHORT).show()
 }
 
 

--- a/app/src/main/res/drawable/ic_file_placeholder.xml
+++ b/app/src/main/res/drawable/ic_file_placeholder.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="#2E83D9"
+        android:pathData="M12,4h16l8,8v24a4,4 0,0 1,-4 4H12a4,4 0,0 1,-4 -4V8a4,4 0,0 1,4 -4z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillAlpha="0.4"
+        android:pathData="M28,4v8h8" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillAlpha="0.9"
+        android:pathData="M16,24h16v4H16z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillAlpha="0.9"
+        android:pathData="M16,30h16v4H16z" />
+</vector>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -115,5 +115,7 @@
   <string name="forward_message_error">Не удалось переслать сообщение</string>
   <string name="search_dialogs_hint">Поиск по диалогам</string>
   <string name="search_contacts_hint">Поиск по контактам</string>
+  <string name="chat_file_attachment_unknown_type">ملف</string>
+  <string name="chat_file_download_started">جاري تنزيل الملف…</string>
   <string name="labor_activity_name">%1$s в <font color="#2E83D9">%2$s</font></string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -117,5 +117,7 @@
   <string name="forward_message_error">Не удалось переслать сообщение</string>
   <string name="search_dialogs_hint">Поиск по диалогам</string>
   <string name="search_contacts_hint">Поиск по контактам</string>
+  <string name="chat_file_attachment_unknown_type">ФАЙЛ</string>
+  <string name="chat_file_download_started">Загрузка файла…</string>
   <string name="labor_activity_name">%1$s в <font color="##2E83D9">%2$s</font></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,4 +419,7 @@
     <string name="search_dialogs_hint">Поиск по диалогам</string>
     <string name="search_contacts_hint">Поиск по контактам</string>
 
+    <string name="chat_file_attachment_unknown_type">FILE</string>
+    <string name="chat_file_download_started">Downloading file…</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- restyle chat message file attachments to match the desired card layout and trigger downloads on tap
- add placeholder drawable and localized strings for the new file card presentation and download feedback

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfbeb1c308327b37cd379d72d3b1e