### PR TITLE
Improve chat attachment upload pipeline

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -8,6 +8,7 @@ import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Build
 import android.provider.ContactsContract
+import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -437,17 +438,57 @@ fun ChatDialogComponent(
 
 private fun uriToFile(context: Context, uri: Uri): File? {
     return try {
-        val input = context.contentResolver.openInputStream(uri) ?: return null
-        val file = File.createTempFile("chat_attach_", null, context.cacheDir)
-        input.use { inputStream ->
-            file.outputStream().use { outputStream ->
-                inputStream.copyTo(outputStream)
+        val contentResolver = context.contentResolver
+        val displayName = contentResolver.query(
+            uri,
+            arrayOf(OpenableColumns.DISPLAY_NAME),
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (nameIndex != -1 && cursor.moveToFirst()) {
+                cursor.getString(nameIndex)
+            } else {
+                null
             }
         }
-        file
+
+        val sanitizedName = displayName?.takeIf { it.isNotBlank() }
+            ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+            ?: "chat_attach_${'$'}{System.currentTimeMillis()}"
+        val targetFile = createUniqueFile(context.cacheDir, sanitizedName)
+
+        contentResolver.openInputStream(uri)?.use { inputStream ->
+            targetFile.outputStream().use { outputStream ->
+                inputStream.copyTo(outputStream)
+            }
+        } ?: return null
+
+        targetFile
     } catch (e: Exception) {
         null
     }
+}
+
+private fun createUniqueFile(directory: File, fileName: String): File {
+    val dotIndex = fileName.lastIndexOf('.')
+    val baseName = when {
+        dotIndex > 0 -> fileName.substring(0, dotIndex)
+        else -> fileName
+    }.ifBlank { "chat_attach" }
+    val extension = when {
+        dotIndex > 0 -> fileName.substring(dotIndex)
+        else -> ""
+    }
+
+    var candidate = File(directory, baseName + extension)
+    var index = 1
+    while (candidate.exists()) {
+        candidate = File(directory, "$baseName($index)$extension")
+        index++
+    }
+    return candidate
 }
 
 private fun getContactInfo(context: Context, uri: Uri): ContactInfo? {


### PR DESCRIPTION
## Summary
- derive chat attachment types so non-image files trigger raw uploads before sending messages
- preserve picked attachment filenames when copying content URIs to cache
- send chat file uploads with accurate MIME types in the repository layer

## Testing
- `./gradlew :data:compileDebugKotlin` *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfdc15d6c8327bb502cc20c355c39