### PR TITLE
Fix edit message UI and handle empty update response

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -29,6 +29,7 @@ import uddug.com.naukoteka.ui.chat.di.SocketService
 import java.time.Instant
 import java.time.Duration
 import java.io.File
+import java.io.EOFException
 import uddug.com.naukoteka.mvvm.chat.ContactInfo
 import javax.inject.Inject
 
@@ -492,36 +493,45 @@ class ChatDialogViewModel @Inject constructor(
             val editingMessage = successState?.editingMessage
 
             if (editingMessage != null) {
-                try {
-                    val updated = chatInteractor.updateMessage(
+                val updatedMessage = try {
+                    chatInteractor.updateMessage(
                         dialogId = dialog.id,
                         messageId = editingMessage.id,
                         text = text,
                         fileIds = editingMessage.files.map { it.id },
                     )
-                    val updatedChats = successState.chats.map { existing ->
-                        if (existing.id == updated.id) {
-                            existing.copy(
-                                text = updated.text,
-                                type = updated.type,
-                                files = updated.files,
-                                readCount = updated.readCount,
-                                createdAt = updated.createdAt,
-                                ownerId = updated.ownerId,
-                                isMine = updated.isMine
-                            )
-                        } else {
-                            existing
-                        }
-                    }
-                    _uiState.value = successState.copy(
-                        chats = updatedChats,
-                        currentMessage = "",
-                        editingMessage = null
+                } catch (e: EOFException) {
+                    Log.w(
+                        "ChatViewModel",
+                        "Empty response received when updating message, using local data",
+                        e
                     )
+                    editingMessage.copy(text = text)
                 } catch (e: Exception) {
                     Log.e("ChatViewModel", "Failed to update message", e)
+                    return@launch
                 }
+
+                val updatedChats = successState.chats.map { existing ->
+                    if (existing.id == updatedMessage.id) {
+                        existing.copy(
+                            text = updatedMessage.text,
+                            type = updatedMessage.type,
+                            files = updatedMessage.files,
+                            readCount = updatedMessage.readCount,
+                            createdAt = updatedMessage.createdAt,
+                            ownerId = updatedMessage.ownerId,
+                            isMine = updatedMessage.isMine
+                        )
+                    } else {
+                        existing
+                    }
+                }
+                _uiState.value = successState.copy(
+                    chats = updatedChats,
+                    currentMessage = "",
+                    editingMessage = null
+                )
                 return@launch
             }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -410,6 +410,7 @@ private fun ReplyInfoBlock(reply: MessageChat, onCancelReply: () -> Unit) {
 
 @Composable
 private fun EditInfoBlock(message: MessageChat, onCancelEdit: () -> Unit) {
+    val accentColor = colorResource(id = R.color.object_main)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -420,13 +421,19 @@ private fun EditInfoBlock(message: MessageChat, onCancelEdit: () -> Unit) {
         Icon(
             imageVector = Icons.Filled.Create,
             contentDescription = null,
-            tint = Color(0XFF8083A0),
-            modifier = Modifier.padding(end = 8.dp)
+            tint = accentColor
+        )
+        Box(
+            modifier = Modifier
+                .padding(horizontal = 12.dp)
+                .width(2.dp)
+                .height(24.dp)
+                .background(accentColor)
         )
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = stringResource(id = R.string.chat_editing_title),
-                color = Color(0XFF8083A0),
+                color = accentColor,
                 fontWeight = FontWeight.Bold,
                 fontSize = 12.sp
             )


### PR DESCRIPTION
## Summary
- update the edit message indicator styling to use the primary blue color and add a vertical separator between the icon and text
- handle empty responses from the message update API by falling back to local data so the UI clears edit mode without errors

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfe6227a88327b03ecf391a6f2c25