### PR TITLE
Include file type descriptors when updating chat messages

### DIFF
--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -8,6 +8,7 @@ import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
 import uddug.com.data.services.models.request.chat.DialogImageRequestDto
 import uddug.com.data.services.models.request.chat.PinMessageRequestDto
 import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
+import uddug.com.data.services.models.request.chat.UpdateMessageFileDto
 import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
 import uddug.com.data.services.models.request.chat.UsersStatusRequestDto
 import uddug.com.data.services.models.response.chat.FileDto
@@ -23,6 +24,7 @@ import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.domain.entities.chat.SearchDialog
 import uddug.com.domain.entities.chat.SearchMessage
 import uddug.com.domain.entities.chat.UserStatus
+import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.updateOwnerInfoFromDialog
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.repositories.chat.ChatRepository
@@ -253,14 +255,19 @@ class ChatRepositoryImpl @Inject constructor(
         dialogId: Long,
         messageId: Long,
         text: String,
-        fileIds: List<String> = emptyList(),
+        files: List<FileDescriptor> = emptyList(),
     ): MessageChat {
         val dto = apiService.updateMessage(
             UpdateMessageRequestDto(
                 dialogId = dialogId,
                 messageId = messageId,
                 updatedText = text,
-                files = fileIds,
+                files = files.map { file ->
+                    UpdateMessageFileDto(
+                        id = file.id,
+                        fileType = file.fileType,
+                    )
+                },
             )
         )
         return dto.toDomain(dto.ownerId)

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateMessageRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateMessageRequestDto.kt
@@ -6,5 +6,10 @@ data class UpdateMessageRequestDto(
     @SerializedName("dialogId") val dialogId: Long,
     @SerializedName("messageId") val messageId: Long,
     @SerializedName("updatedText") val updatedText: String?,
-    @SerializedName("files") val files: List<String> = emptyList(),
+    @SerializedName("files") val files: List<UpdateMessageFileDto> = emptyList(),
+)
+
+data class UpdateMessageFileDto(
+    @SerializedName("id") val id: String,
+    @SerializedName("fileType") val fileType: Int,
 )

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -5,6 +5,7 @@ import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.SearchDialog
 import uddug.com.domain.entities.chat.SearchMessage
 import uddug.com.domain.entities.chat.UserStatus
@@ -89,8 +90,8 @@ class ChatInteractor @Inject constructor(
         dialogId: Long,
         messageId: Long,
         text: String,
-        fileIds: List<String> = emptyList(),
-    ): MessageChat = chatRepository.updateMessage(dialogId, messageId, text, fileIds)
+        files: List<FileDescriptor> = emptyList(),
+    ): MessageChat = chatRepository.updateMessage(dialogId, messageId, text, files)
 
     suspend fun deleteMessage(messageId: Long, forMe: Boolean = false) =
         chatRepository.deleteMessage(messageId, forMe)

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -3,6 +3,7 @@ package uddug.com.domain.repositories.chat
 import uddug.com.domain.entities.chat.Chat
 import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.DialogInfo
+import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.domain.entities.chat.SearchDialog
@@ -99,7 +100,7 @@ interface ChatRepository {
         dialogId: Long,
         messageId: Long,
         text: String,
-        fileIds: List<String> = emptyList(),
+        files: List<FileDescriptor> = emptyList(),
     ): MessageChat
 
     suspend fun deleteMessage(messageId: Long, forMe: Boolean = false)


### PR DESCRIPTION
## Summary
- derive file descriptors with the proper file type when re-sending edited chat messages
- send id/fileType pairs through the repository and request DTO when calling the message update API

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc072b0bdc832789fb07fe7b22dcfa