### PR TITLE
feat(chat): add group creation flow with compose screen

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateGroupViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateGroupViewModel.kt
@@ -1,0 +1,199 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.domain.interactors.chat.ChatInteractor
+import uddug.com.domain.repositories.user_profile.UserProfileRepository
+import java.io.File
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatCreateGroupViewModel @Inject constructor(
+    private val chatInteractor: ChatInteractor,
+    private val userProfileRepository: UserProfileRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    companion object {
+        const val SELECTED_USERS_KEY = "selected_users"
+        private const val MAX_GROUP_NAME_LENGTH = 100
+        private const val ADMIN_ROLE = "37:202"
+    }
+
+    private val initialParticipants: List<UserProfileFullInfo> =
+        savedStateHandle.get<ArrayList<UserProfileFullInfo>>(SELECTED_USERS_KEY)?.toList().orEmpty()
+
+    private val _uiState = MutableStateFlow<ChatCreateGroupUiState>(ChatCreateGroupUiState.Loading)
+    val uiState: StateFlow<ChatCreateGroupUiState> = _uiState
+
+    private val _events = MutableSharedFlow<ChatCreateGroupEvent>()
+    val events: SharedFlow<ChatCreateGroupEvent> = _events.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            try {
+                val currentUser = withContext(Dispatchers.IO) {
+                    userProfileRepository.getProfileInfo().await()
+                }
+                val distinctParticipants = initialParticipants
+                    .filter { participant -> participant.id != currentUser.id }
+                    .distinctBy { it.id }
+                val members = buildList {
+                    add(GroupMember(user = currentUser, isCreator = true, isAdmin = true))
+                    distinctParticipants.forEach { participant ->
+                        add(GroupMember(user = participant, isCreator = false, isAdmin = false))
+                    }
+                }
+                val defaultName = distinctParticipants
+                    .mapNotNull { it.fullName }
+                    .joinToString(separator = ", ")
+                    .take(MAX_GROUP_NAME_LENGTH)
+                _uiState.value = ChatCreateGroupUiState.Success(
+                    groupName = defaultName,
+                    members = members,
+                    avatarPath = null,
+                    avatarId = null,
+                    isSaving = false,
+                    isAvatarUploading = false
+                )
+            } catch (e: Exception) {
+                _uiState.value = ChatCreateGroupUiState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    fun onGroupNameChanged(name: String) {
+        val current = _uiState.value
+        if (current is ChatCreateGroupUiState.Success) {
+            val trimmed = name.take(MAX_GROUP_NAME_LENGTH)
+            _uiState.value = current.copy(groupName = trimmed)
+        }
+    }
+
+    fun onAvatarSelected(file: File) {
+        val current = _uiState.value
+        if (current is ChatCreateGroupUiState.Success && !current.isAvatarUploading) {
+            _uiState.value = current.copy(isAvatarUploading = true)
+            viewModelScope.launch {
+                try {
+                    val uploaded = withContext(Dispatchers.IO) {
+                        chatInteractor.uploadFiles(listOf(file), raw = false)
+                    }
+                    val uploadedFile = uploaded.firstOrNull()
+                    if (uploadedFile != null) {
+                        val latestState = _uiState.value as? ChatCreateGroupUiState.Success
+                        if (latestState != null) {
+                            _uiState.value = latestState.copy(
+                                avatarPath = uploadedFile.path,
+                                avatarId = uploadedFile.id,
+                                isAvatarUploading = false
+                            )
+                        } else {
+                            _uiState.value = current.copy(
+                                avatarPath = uploadedFile.path,
+                                avatarId = uploadedFile.id,
+                                isAvatarUploading = false
+                            )
+                        }
+                    } else {
+                        val latestState = _uiState.value as? ChatCreateGroupUiState.Success
+                        _uiState.value = latestState?.copy(isAvatarUploading = false)
+                            ?: current.copy(isAvatarUploading = false)
+                        _events.emit(ChatCreateGroupEvent.ShowImageUploadError)
+                    }
+                } catch (e: Exception) {
+                    val latestState = _uiState.value as? ChatCreateGroupUiState.Success
+                    _uiState.value = latestState?.copy(isAvatarUploading = false)
+                        ?: current.copy(isAvatarUploading = false)
+                    _events.emit(ChatCreateGroupEvent.ShowError(e.message))
+                }
+            }
+        }
+    }
+
+    fun onCreateGroupClick() {
+        val current = _uiState.value
+        if (current is ChatCreateGroupUiState.Success) {
+            val participants = current.members.filterNot { it.isCreator }
+            if (participants.isEmpty()) {
+                viewModelScope.launch {
+                    _events.emit(ChatCreateGroupEvent.ShowMissingParticipantsError)
+                }
+                return
+            }
+
+            if (current.isSaving || current.isAvatarUploading) return
+
+            val groupName = current.groupName.takeIf { it.isNotBlank() }
+                ?: participants.mapNotNull { it.user.fullName }
+                    .joinToString(separator = ", ")
+                    .take(MAX_GROUP_NAME_LENGTH)
+
+            val userRoles = participants
+                .mapNotNull { member ->
+                    member.user.id?.let { id -> id to if (member.isAdmin) ADMIN_ROLE else null }
+                }
+                .toMap()
+
+            if (userRoles.isEmpty()) {
+                _uiState.value = current.copy(isSaving = false)
+                viewModelScope.launch {
+                    _events.emit(ChatCreateGroupEvent.ShowError(null))
+                }
+                return
+            }
+
+            _uiState.value = current.copy(isSaving = true)
+
+            viewModelScope.launch {
+                try {
+                    val dialogId = withContext(Dispatchers.IO) {
+                        chatInteractor.createGroupDialog(groupName, userRoles, current.avatarId)
+                    }
+                    _events.emit(ChatCreateGroupEvent.GroupCreated(dialogId))
+                } catch (e: Exception) {
+                    _uiState.value = current.copy(isSaving = false)
+                    _events.emit(ChatCreateGroupEvent.ShowError(e.message))
+                }
+            }
+        }
+    }
+}
+
+data class GroupMember(
+    val user: UserProfileFullInfo,
+    val isCreator: Boolean,
+    val isAdmin: Boolean,
+)
+
+sealed class ChatCreateGroupUiState {
+    object Loading : ChatCreateGroupUiState()
+    data class Success(
+        val groupName: String,
+        val members: List<GroupMember>,
+        val avatarPath: String?,
+        val avatarId: String?,
+        val isSaving: Boolean,
+        val isAvatarUploading: Boolean,
+    ) : ChatCreateGroupUiState()
+
+    data class Error(val message: String) : ChatCreateGroupUiState()
+}
+
+sealed class ChatCreateGroupEvent {
+    data class GroupCreated(val dialogId: Long) : ChatCreateGroupEvent()
+    data class ShowError(val message: String?) : ChatCreateGroupEvent()
+    object ShowImageUploadError : ChatCreateGroupEvent()
+    object ShowMissingParticipantsError : ChatCreateGroupEvent()
+}

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateSingleViewModel.kt
@@ -18,11 +18,8 @@ import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.interactors.chat.ChatInteractor
 import uddug.com.domain.repositories.user_profile.UserProfileRepository
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.await
 import javax.inject.Inject
-import io.reactivex.Single
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 @HiltViewModel
 class ChatCreateSingleViewModel @Inject constructor(
@@ -142,19 +139,6 @@ class ChatCreateSingleViewModel @Inject constructor(
         }
     }
 }
-
-/**
- * Простая корутинная обёртка для RxJava Single<T>,
- * чтобы не использовать blockingGet() и не блокировать поток.
- */
-private suspend fun <T> Single<T>.await(): T =
-    suspendCancellableCoroutine { cont ->
-        val d = this.subscribe(
-            { value -> if (cont.isActive) cont.resume(value) },
-            { error -> if (cont.isActive) cont.resumeWithException(error) }
-        )
-        cont.invokeOnCancellation { d.dispose() }
-    }
 
 sealed class ChatCreateSingleEvent {
     data class OpenDialogDetail(val interlocutorId: String) : ChatCreateSingleEvent()

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/RxExtensions.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/RxExtensions.kt
@@ -1,0 +1,14 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import io.reactivex.Single
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+suspend fun <T> Single<T>.await(): T = suspendCancellableCoroutine { cont ->
+    val disposable = this.subscribe(
+        { value -> if (cont.isActive) cont.resume(value) },
+        { error -> if (cont.isActive) cont.resumeWithException(error) }
+    )
+    cont.invokeOnCancellation { disposable.dispose() }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateGroupFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateGroupFragment.kt
@@ -1,0 +1,107 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatCreateGroupEvent
+import uddug.com.naukoteka.mvvm.chat.ChatCreateGroupViewModel
+import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
+import uddug.com.naukoteka.ui.chat.compose.ChatCreateGroupScreen
+
+@AndroidEntryPoint
+class ChatCreateGroupFragment : Fragment() {
+
+    private val viewModel: ChatCreateGroupViewModel by viewModels()
+
+    private var navigationView: ContainerNavigationView? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        navigationView = requireActivity() as? ContainerNavigationView
+    }
+
+    override fun onResume() {
+        super.onResume()
+        navigationView?.showNavigationBottomBar(true)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.events.collectLatest { event ->
+                when (event) {
+                    is ChatCreateGroupEvent.GroupCreated -> {
+                        findNavController().getBackStackEntry(R.id.chatListFragment)
+                            .savedStateHandle["refreshChats"] = true
+                        findNavController().popBackStack(R.id.chatListFragment, false)
+                    }
+
+                    ChatCreateGroupEvent.ShowImageUploadError -> {
+                        Toast.makeText(
+                            requireContext(),
+                            R.string.chat_create_group_image_upload_error,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+
+                    ChatCreateGroupEvent.ShowMissingParticipantsError -> {
+                        Toast.makeText(
+                            requireContext(),
+                            R.string.chat_create_group_missing_participants_error,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+
+                    is ChatCreateGroupEvent.ShowError -> {
+                        val message = event.message ?: getString(R.string.chat_create_group_generic_error)
+                        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatCreateGroupScreen(
+                        viewModel = viewModel,
+                        onBackPressed = { findNavController().popBackStack() },
+                        onAddParticipantsClick = { findNavController().popBackStack() }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        navigationView = null
+    }
+
+    companion object {
+        const val SELECTED_USERS_ARG = ChatCreateGroupViewModel.SELECTED_USERS_KEY
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.core.os.bundleOf
+import android.widget.Toast
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -19,6 +21,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatCreateMultiEvent
 import uddug.com.naukoteka.mvvm.chat.ChatCreateMultiViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatCreateMultiScreen
+import uddug.com.naukoteka.ui.chat.ChatCreateGroupFragment
 
 @AndroidEntryPoint
 class ChatCreateMultiFragment : Fragment() {
@@ -46,10 +49,18 @@ class ChatCreateMultiFragment : Fragment() {
         lifecycleScope.launch {
             viewModel.events.collectLatest { event ->
                 when (event) {
-                    is ChatCreateMultiEvent.GroupCreated -> {
-                        findNavController().getBackStackEntry(R.id.chatListFragment)
-                            .savedStateHandle["refreshChats"] = true
-                        findNavController().popBackStack(R.id.chatListFragment, false)
+                    is ChatCreateMultiEvent.OpenGroupDetails -> {
+                        val args = bundleOf(
+                            ChatCreateGroupFragment.SELECTED_USERS_ARG to ArrayList(event.selectedUsers)
+                        )
+                        findNavController().navigate(R.id.chatCreateGroupFragment, args)
+                    }
+                    ChatCreateMultiEvent.ShowMinimumMembersError -> {
+                        Toast.makeText(
+                            requireContext(),
+                            R.string.chat_create_group_min_members_error,
+                            Toast.LENGTH_SHORT
+                        ).show()
                     }
                 }
             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateGroupScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateGroupScreen.kt
@@ -1,0 +1,361 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.PhotoCamera
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import uddug.com.naukoteka.BuildConfig
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatCreateGroupUiState
+import uddug.com.naukoteka.mvvm.chat.ChatCreateGroupViewModel
+import uddug.com.naukoteka.mvvm.chat.GroupMember
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
+import uddug.com.naukoteka.ui.chat.compose.util.uriToFile
+
+@Composable
+fun ChatCreateGroupScreen(
+    viewModel: ChatCreateGroupViewModel,
+    onBackPressed: () -> Unit,
+    onAddParticipantsClick: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null) {
+            val file = uriToFile(context, uri)
+            if (file != null) {
+                viewModel.onAvatarSelected(file)
+            } else {
+                Toast.makeText(context, R.string.chat_create_group_image_upload_error, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    val confirmEnabled = (uiState as? ChatCreateGroupUiState.Success)?.let { state ->
+        state.members.count { !it.isCreator } >= 2 && !state.isSaving && !state.isAvatarUploading
+    } ?: false
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.chat_create_group_title),
+                        fontSize = 20.sp,
+                        color = Color.Black
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chat_back),
+                            contentDescription = null,
+                            tint = Color(0xFF2E83D9)
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { viewModel.onCreateGroupClick() },
+                        enabled = confirmEnabled
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chat_create_apply),
+                            contentDescription = null,
+                            tint = if (confirmEnabled) Color(0xFF2E83D9) else Color(0x4D2E83D9)
+                        )
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp
+            )
+        },
+        backgroundColor = Color.White
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+        ) {
+            when (val state = uiState) {
+                ChatCreateGroupUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                is ChatCreateGroupUiState.Error -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(text = state.message, color = Color.Red)
+                    }
+                }
+
+                is ChatCreateGroupUiState.Success -> {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp)
+                    ) {
+                        item {
+                            GroupHeader(
+                                state = state,
+                                onAvatarClick = { imagePickerLauncher.launch("image/*") },
+                                onNameChanged = viewModel::onGroupNameChanged,
+                                onAddParticipantsClick = onAddParticipantsClick
+                            )
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Text(
+                                text = stringResource(
+                                    R.string.chat_create_group_members,
+                                    state.members.size
+                                ),
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 16.sp,
+                                color = Color.Black
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                        }
+
+                        itemsIndexed(state.members) { index, member ->
+                            GroupMemberRow(member = member)
+                            if (index < state.members.lastIndex) {
+                                Divider(color = Color(0xFFEAEAF2))
+                            }
+                        }
+                    }
+
+                    if (state.isSaving) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(Color.White.copy(alpha = 0.6f)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+@Composable
+private fun GroupHeader(
+    state: ChatCreateGroupUiState.Success,
+    onAvatarClick: () -> Unit,
+    onNameChanged: (String) -> Unit,
+    onAddParticipantsClick: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            GroupAvatarPicker(
+                avatarPath = state.avatarPath,
+                isUploading = state.isAvatarUploading,
+                onClick = onAvatarClick
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                OutlinedTextField(
+                    value = state.groupName,
+                    onValueChange = onNameChanged,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = {
+                        Text(
+                            text = stringResource(R.string.chat_create_group_name_placeholder),
+                            color = Color(0xFFB0B2C3)
+                        )
+                    },
+                    singleLine = true,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        backgroundColor = Color.White,
+                        focusedBorderColor = Color(0xFF2E83D9),
+                        unfocusedBorderColor = Color(0xFFE0E0E8),
+                        cursorColor = Color(0xFF2E83D9),
+                        textColor = Color.Black
+                    )
+                )
+                Text(
+                    text = stringResource(
+                        R.string.chat_create_group_name_counter,
+                        state.groupName.length
+                    ),
+                    fontSize = 12.sp,
+                    color = Color(0xFF8083A0),
+                    modifier = Modifier.align(Alignment.End)
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .clickable { onAddParticipantsClick() }
+                .background(Color(0xFFF5F5F9))
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = Color(0xFF2E83D9)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = stringResource(R.string.chat_create_group_add_participant),
+                color = Color(0xFF2E83D9),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}
+
+@Composable
+private fun GroupAvatarPicker(
+    avatarPath: String?,
+    isUploading: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(72.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(Color(0xFFF5F5F9))
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        if (!avatarPath.isNullOrEmpty()) {
+            AsyncImage(
+                model = BuildConfig.IMAGE_SERVER_URL + avatarPath,
+                contentDescription = stringResource(R.string.chat_create_group_avatar_description),
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Outlined.PhotoCamera,
+                contentDescription = stringResource(R.string.chat_create_group_avatar_description),
+                tint = Color(0xFF2E83D9),
+                modifier = Modifier.size(32.dp)
+            )
+        }
+
+        if (isUploading) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(Color.White.copy(alpha = 0.6f)),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupMemberRow(member: GroupMember) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Avatar(
+            url = member.user.image?.path,
+            name = member.user.fullName,
+            size = 40.dp
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = member.user.fullName.orEmpty(),
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp,
+                color = Color.Black
+            )
+            member.user.placeOfResidence?.takeIf { it.isNotBlank() }?.let { residence ->
+                Text(
+                    text = residence,
+                    fontSize = 12.sp,
+                    color = Color(0xFF8083A0)
+                )
+            }
+        }
+        if (member.isCreator || member.isAdmin) {
+            Text(
+                text = stringResource(R.string.chat_create_group_admin_label),
+                color = Color(0xFF2E83D9),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp
+            )
+        } else {
+            IconButton(onClick = { }) {
+                Icon(
+                    imageVector = Icons.Filled.MoreVert,
+                    contentDescription = null,
+                    tint = Color(0xFFB0B2C3)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
@@ -31,6 +31,9 @@ fun ChatCreateMultiScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
+    val successState = uiState as? ChatCreateMultiUiState.Success
+    val isActionEnabled = (successState?.selected?.size ?: 0) >= 2
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -38,14 +41,15 @@ fun ChatCreateMultiScreen(
     ) {
         ChatToolbarCreateSingleComponent(
             onBackPressed = onBackPressed,
-            onActionClick = { viewModel.onCreateGroupClick() }
+            onActionClick = { viewModel.onCreateGroupClick() },
+            isActionEnabled = isActionEnabled
         )
 
         when (uiState) {
             is ChatCreateMultiUiState.Error -> Unit
             ChatCreateMultiUiState.Loading -> Unit
             is ChatCreateMultiUiState.Success -> {
-                val state = uiState as ChatCreateMultiUiState.Success
+                val state = successState ?: return
                 SearchField(
                     title = stringResource(R.string.find_chat_message),
                     query = state.query,

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
@@ -24,6 +24,7 @@ fun ChatToolbarCreateSingleComponent(
     modifier: Modifier = Modifier,
     onBackPressed: () -> Unit,
     onActionClick: (() -> Unit)? = null,
+    isActionEnabled: Boolean = true,
 ) {
     TopAppBar(
         title = {
@@ -33,10 +34,11 @@ fun ChatToolbarCreateSingleComponent(
         },
         actions = {
             if (onActionClick != null) {
-                IconButton(onClick = { onActionClick() }) {
+                IconButton(onClick = { onActionClick() }, enabled = isActionEnabled) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_chat_create_apply),
                         contentDescription = "Edit Icon",
+                        tint = if (isActionEnabled) Color(0xFF2E83D9) else Color(0x4D2E83D9)
                     )
                 }
             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/util/FileUtils.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/util/FileUtils.kt
@@ -1,0 +1,61 @@
+package uddug.com.naukoteka.ui.chat.compose.util
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import java.io.File
+
+fun uriToFile(context: Context, uri: Uri): File? {
+    return try {
+        val contentResolver = context.contentResolver
+        val displayName = contentResolver.query(
+            uri,
+            arrayOf(OpenableColumns.DISPLAY_NAME),
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (nameIndex != -1 && cursor.moveToFirst()) {
+                cursor.getString(nameIndex)
+            } else {
+                null
+            }
+        }
+
+        val sanitizedName = displayName?.takeIf { it.isNotBlank() }
+            ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+            ?: "chat_attach_${System.currentTimeMillis()}"
+        val targetFile = createUniqueFile(context.cacheDir, sanitizedName)
+
+        contentResolver.openInputStream(uri)?.use { inputStream ->
+            targetFile.outputStream().use { outputStream ->
+                inputStream.copyTo(outputStream)
+            }
+        } ?: return null
+
+        targetFile
+    } catch (e: Exception) {
+        null
+    }
+}
+
+fun createUniqueFile(directory: File, fileName: String): File {
+    val dotIndex = fileName.lastIndexOf('.')
+    val baseName = when {
+        dotIndex > 0 -> fileName.substring(0, dotIndex)
+        else -> fileName
+    }.ifBlank { "chat_attach" }
+    val extension = when {
+        dotIndex > 0 -> fileName.substring(dotIndex)
+        else -> ""
+    }
+
+    var candidate = File(directory, baseName + extension)
+    var index = 1
+    while (candidate.exists()) {
+        candidate = File(directory, "$baseName($index)$extension")
+        index++
+    }
+    return candidate
+}

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -51,6 +51,12 @@
     </fragment>
 
     <fragment
+        android:id="@+id/chatCreateGroupFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatCreateGroupFragment">
+
+    </fragment>
+
+    <fragment
         android:id="@+id/chatFolderSettingsFragment"
         android:name="uddug.com.naukoteka.ui.chat.ChatFolderSettingsFragment">
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -165,6 +165,17 @@
   <string name="chat_status_contact_last_seen_weeks">Был(а) в сети %1$d нед. назад</string>
   <string name="chat_status_contact_last_seen_yesterday">Был(а) в сети вчера</string>
   <string name="chat_private_dialog_permission_error">Нет разрешения на личный диалог</string>
+  <string name="chat_create_group_title">Создать группу</string>
+  <string name="chat_create_group_name_placeholder">Укажите название группы</string>
+  <string name="chat_create_group_name_counter">%1$d/100</string>
+  <string name="chat_create_group_add_participant">Добавить еще участника</string>
+  <string name="chat_create_group_members">Участники %1$d</string>
+  <string name="chat_create_group_admin_label">Админ.</string>
+  <string name="chat_create_group_avatar_description">Аватар группы</string>
+  <string name="chat_create_group_image_upload_error">Не удалось загрузить изображение</string>
+  <string name="chat_create_group_missing_participants_error">Добавьте участников</string>
+  <string name="chat_create_group_generic_error">Произошла ошибка. Попробуйте еще раз</string>
+  <string name="chat_create_group_min_members_error">Выберите минимум двух участников</string>
   <string name="settlement_no_selection">Без выбора</string>
   <string name="language_english">Английский</string>
   <string name="language_russian">Русский</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,6 +464,17 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_message_delete">Удалить сообщение</string>
     <string name="chat_editing_title">Редактирование</string>
     <string name="create_group_chat">Создать групповой чат</string>
+    <string name="chat_create_group_title">Создать группу</string>
+    <string name="chat_create_group_name_placeholder">Укажите название группы</string>
+    <string name="chat_create_group_name_counter">%1$d/100</string>
+    <string name="chat_create_group_add_participant">Добавить еще участника</string>
+    <string name="chat_create_group_members">Участники %1$d</string>
+    <string name="chat_create_group_admin_label">Админ.</string>
+    <string name="chat_create_group_avatar_description">Аватар группы</string>
+    <string name="chat_create_group_image_upload_error">Не удалось загрузить изображение</string>
+    <string name="chat_create_group_missing_participants_error">Добавьте участников</string>
+    <string name="chat_create_group_generic_error">Произошла ошибка. Попробуйте еще раз</string>
+    <string name="chat_create_group_min_members_error">Выберите минимум двух участников</string>
     <string name="subs">Подписки</string>
 
     <!-- Chat attachment options -->

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -67,8 +67,12 @@ class ChatInteractor @Inject constructor(
     suspend fun createDialog(dialogName: String?, userRoles: Map<String, String?>): Long =
         chatRepository.createDialog(dialogName = dialogName, userRoles = userRoles)
 
-    suspend fun createGroupDialog(dialogName: String, userRoles: Map<String, String?>): Long =
-        chatRepository.createGroupDialog(dialogName = dialogName, userRoles = userRoles)
+    suspend fun createGroupDialog(
+        dialogName: String?,
+        userRoles: Map<String, String?>,
+        imageId: String? = null,
+    ): Long =
+        chatRepository.createGroupDialog(dialogName = dialogName, userRoles = userRoles, imageId = imageId)
 
     suspend fun searchUsers(query: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo> =
         chatRepository.searchUsers(query, limit, page)


### PR DESCRIPTION
## Summary
- add a dedicated Compose-driven group creation screen with view model, fragment, navigation entry, and related strings
- update the multi-selection flow to open the new screen, enforce the minimum participant count, and gate the confirmation icon
- extract shared Rx and file helper utilities and adjust existing components, including the chat dialog and interactor, to use them

## Testing
- `./gradlew lint` *(fails: Android SDK path is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf4dbb3448327bee5fc8cf033a5a1