### PR TITLE
Fix socket file descriptor mapping

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -604,13 +604,7 @@ class ChatDialogViewModel @Inject constructor(
                 }
             } else emptyList()
 
-            val fileDescriptors = uploaded.mapIndexed { index, uploadedFile ->
-                val type = attachedFiles.getOrNull(index)?.let { determineFileType(it) } ?: DOCUMENT_FILE_TYPE
-                FileDescriptor(
-                    id = uploadedFile.id,
-                    fileType = type
-                )
-            }
+            val fileDescriptors = uploaded.map { it.toFileDescriptor() }
 
             val cType = if (fileDescriptors.isEmpty()) 1 else 3
 
@@ -654,12 +648,7 @@ class ChatDialogViewModel @Inject constructor(
                 e.printStackTrace()
                 emptyList()
             }
-            val descriptor = uploaded.firstOrNull()?.let { uploadedFile ->
-                FileDescriptor(
-                    id = uploadedFile.id,
-                    fileType = determineFileType(file)
-                )
-            }
+            val descriptor = uploaded.firstOrNull()?.toFileDescriptor()
             val message = if (dialog.id != 0L) {
                 ChatSocketMessage(
                     dialog = dialog.id,


### PR DESCRIPTION
## Summary
- reuse ChatFile.toFileDescriptor() for uploaded attachments to honour backend file type expectations
- ensure voice message payloads reuse the server-provided descriptor metadata

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcfaa6ee048327ba69f1989dc5fc71