### PR TITLE
Show edit group option for admins in chat detail

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
@@ -89,17 +89,23 @@ class ChatDialogDetailViewModel @Inject constructor(
                 .subscribe({
                     currentUser = it
                     viewModelScope.launch {
+                        val currentUserId = it.id
+                        val isAdmin = currentUserId?.let { id ->
+                            dialogInfo.users?.any { user -> user.userId == id && user.isAdmin }
+                        } ?: false
                         _uiState.value = ChatDetailUiState.Success(
                             profile = User(
                                 image = dialogInfo.interlocutor?.image.orEmpty(),
                                 fullName = dialogInfo.interlocutor?.fullName.orEmpty(),
-                                nickname = dialogInfo.interlocutor?.nickname.orEmpty()
+                                nickname = dialogInfo.interlocutor?.nickname.orEmpty(),
+                                isAdmin = dialogInfo.interlocutor?.isAdmin ?: false,
                             ),
                             media = emptyList(),
                             files = emptyList(),
                             voices = emptyList(),
                             notes = emptyList(),
-                            dialogId = dialogInfo.id
+                            dialogId = dialogInfo.id,
+                            isCurrentUserAdmin = isAdmin,
                         )
                         loadTabData(0)
                     }
@@ -244,6 +250,7 @@ sealed class ChatDetailUiState {
         val voices: List<MediaMessage>,
         val notes: List<MediaMessage>,
         val dialogId: Long,
+        val isCurrentUserAdmin: Boolean,
     ) : ChatDetailUiState()
 
     data class Error(val message: String) : ChatDetailUiState()

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
@@ -106,6 +106,17 @@ class ChatDetailDialogFragment : Fragment() {
                         },
                         onChatDeleted = {
                             findNavController().popBackStack(R.id.chatListFragment, false)
+                        },
+                        onEditGroup = {
+                            val dialogId = (viewModel.uiState.value as? ChatDetailUiState.Success)?.dialogId
+                                ?: arguments?.getLong(DIALOG_ID)
+                                ?: 0L
+                            if (dialogId != 0L) {
+                                findNavController().navigate(
+                                    R.id.chatGroupDetailFragment,
+                                    Bundle().apply { putLong(DIALOG_ID, dialogId) }
+                                )
+                            }
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -92,6 +92,7 @@ fun ChatDetailDialogComponent(
     onNavigateToProfile: () -> Unit,
     onSearchClick: () -> Unit,
     onChatDeleted: () -> Unit,
+    onEditGroup: () -> Unit,
 ) {
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope()
@@ -362,6 +363,8 @@ fun ChatDetailDialogComponent(
                             onNavigateToProfile = onNavigateToProfile,
                             onDismissRequest = { showMoreDialog = false },
                             onChatDeleted = onChatDeleted,
+                            onEditGroup = onEditGroup,
+                            isCurrentUserAdmin = state.isCurrentUserAdmin,
                         )
                     }
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.collectLatest
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatFunctionsEvent
 import uddug.com.naukoteka.mvvm.chat.ChatFunctionsViewModel
+import kotlin.collections.buildList
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,6 +32,8 @@ fun ChatDetailMoreSheetDialog(
     onNavigateToProfile: () -> Unit,
     onDismissRequest: () -> Unit,
     onChatDeleted: () -> Unit,
+    onEditGroup: () -> Unit,
+    isCurrentUserAdmin: Boolean,
     viewModel: ChatFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -55,19 +58,25 @@ fun ChatDetailMoreSheetDialog(
                 .fillMaxWidth()
                 .padding(20.dp)
         ) {
-            val items = listOf(
-                R.string.chat_go_to_profile to {
+            val items = buildList {
+                if (isCurrentUserAdmin) {
+                    add(R.string.chat_edit_group to {
+                        onEditGroup()
+                        onDismissRequest()
+                    })
+                }
+                add(R.string.chat_go_to_profile to {
                     onNavigateToProfile()
                     onDismissRequest()
-                },
-                R.string.chat_disable_notifications to {
+                })
+                add(R.string.chat_disable_notifications to {
                     viewModel.disableNotifications(dialogId)
                     onDismissRequest()
-                },
-                R.string.chat_delete_chat to {
+                })
+                add(R.string.chat_delete_chat to {
                     viewModel.deleteChat(dialogId)
-                }
-            )
+                })
+            }
             items.forEach { (textRes, action) ->
                 Row(
                     modifier = Modifier

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -178,4 +178,5 @@
     <item quantity="many">%d дней назад</item>
     <item quantity="other">%d дня назад</item>
   </plurals>
+  <string name="chat_edit_group">Редактировать группу</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -447,6 +447,7 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_pin">Закрепить в списке</string>
     <string name="chat_unpin">Открепить из списка</string>
     <string name="chat_go_to_profile">Перейти в профиль</string>
+    <string name="chat_edit_group">Редактировать группу</string>
     <string name="chat_disable_notifications">Отключить уведомления</string>
     <string name="chat_enable_notifications">Включить уведомления</string>
     <string name="chat_select_messages">Выделить сообщения</string>

--- a/data/src/main/java/uddug/com/data/mapper/mapChatDtoToDomain.kt
+++ b/data/src/main/java/uddug/com/data/mapper/mapChatDtoToDomain.kt
@@ -44,7 +44,9 @@ fun mapUserDtoToDomain(userDto: UserDto): User {
         image = userDto.image?.path,
         fullName = userDto.fullName,
         nickname = userDto.nickname,
-        userId = userDto.userId
+        userId = userDto.userId,
+        role = userDto.role,
+        isAdmin = userDto.isAdmin ?: false,
     )
 }
 

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/ChatDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/ChatDto.kt
@@ -37,7 +37,8 @@ data class UserDto(
     val fullName: String,
     val nickname: String,
     val userId: String,
-    val role: String,
+    val role: String? = null,
+    val isAdmin: Boolean? = null,
 )
 
 data class ImageDto(

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/mapDialogInfoDtoToDomain.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/mapDialogInfoDtoToDomain.kt
@@ -31,7 +31,8 @@ private fun mapUserDtoToDomain(dto: UserDto): User? {
             fullName = dto.fullName ?: "",
             nickname = dto.nickname ?: "",
             userId = dto.userId ?: return null,
-            role = dto.role ?: ""
+            role = dto.role ?: "",
+            isAdmin = dto.isAdmin ?: false,
         )
     } catch (e: Exception) {
         null

--- a/domain/src/main/java/uddug/com/domain/entities/chat/Chat.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/Chat.kt
@@ -27,6 +27,7 @@ data class User(
     val nickname: String? = null,
     val userId: String? = null,
     val role: String? = null,
+    val isAdmin: Boolean = false,
 ) : Parcelable
 
 data class Image(
@@ -61,6 +62,6 @@ fun MessageChat.updateOwnerInfoFromDialog(dialogInfo: DialogInfo): MessageChat {
     return this.copy(
         ownerName = name,
         ownerAvatarUrl = avatarUrl,
-        ownerIsAdmin = ownerUser?.role == "admin"
+        ownerIsAdmin = ownerUser?.isAdmin == true || ownerUser?.role == "admin"
     )
 }


### PR DESCRIPTION
## Summary
- map the `isAdmin` flag from chat API DTOs into domain models and view state
- expose the current user admin status in chat detail and gate the “Edit group” option
- add navigation to the group detail screen from the new menu item and localize the label

## Testing
- ./gradlew :app:lint *(fails: Android SDK not configured in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfc0d09148327af613ba706f712f5