### PR TITLE
Add folder management API endpoints and folder long-press actions

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -130,6 +130,16 @@
   <string name="chat_folder_settings_add_folder">Добавить новую папку</string>
   <string name="chat_folder_menu_configure">Настроить папки</string>
   <string name="chat_folder_menu_change_order">Изменить порядок</string>
+  <string name="chat_folder_action_rename">Переименовать папку</string>
+  <string name="chat_folder_action_mark_read">Отметить как прочитанное</string>
+  <string name="chat_folder_action_delete">Удалить папку</string>
+  <string name="chat_folder_action_rename_title">Переименовать папку</string>
+  <string name="chat_folder_action_rename_placeholder">Название папки</string>
+  <string name="chat_folder_action_rename_confirm">Сохранить</string>
+  <string name="chat_folder_action_delete_confirm_title">Удалить папку?</string>
+  <string name="chat_folder_action_delete_confirm_message">Вы уверены, что хотите удалить папку "%1$s"?</string>
+  <string name="chat_folder_action_delete_confirm_positive">Удалить</string>
+  <string name="chat_folder_action_delete_confirm_negative">Отмена</string>
   <string name="chat_unknown_user">Неизвестный</string>
   <string name="chat_no_messages">Нет сообщений</string>
   <string name="chat_unknown_time">Неизвестно</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,6 +208,16 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_folder_settings_add_folder">Add new folder</string>
     <string name="chat_folder_menu_configure">Configure folders</string>
     <string name="chat_folder_menu_change_order">Change order</string>
+    <string name="chat_folder_action_rename">Rename folder</string>
+    <string name="chat_folder_action_mark_read">Mark as read</string>
+    <string name="chat_folder_action_delete">Delete folder</string>
+    <string name="chat_folder_action_rename_title">Rename folder</string>
+    <string name="chat_folder_action_rename_placeholder">Folder name</string>
+    <string name="chat_folder_action_rename_confirm">Save</string>
+    <string name="chat_folder_action_delete_confirm_title">Delete folder?</string>
+    <string name="chat_folder_action_delete_confirm_message">Are you sure you want to delete the folder "%1$s"?</string>
+    <string name="chat_folder_action_delete_confirm_positive">Delete</string>
+    <string name="chat_folder_action_delete_confirm_negative">Cancel</string>
     <string name="chat_unknown_user">Unknown</string>
     <string name="chat_no_messages">No messages</string>
     <string name="chat_unknown_time">Unknown</string>

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -11,6 +11,7 @@ import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
+import uddug.com.data.services.models.request.chat.ChatFolderRequestDto
 import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
 import uddug.com.data.services.models.request.chat.PinMessageRequestDto
@@ -18,6 +19,9 @@ import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
 import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
 import uddug.com.data.services.models.response.chat.ChatDto
 import uddug.com.data.services.models.response.chat.DialogInfoDto
+import uddug.com.data.services.models.response.chat.FolderDetailsDto
+import uddug.com.data.services.models.response.chat.FolderDialogsDto
+import uddug.com.data.services.models.response.chat.FolderDto
 import uddug.com.data.services.models.response.chat.FoldersDto
 import uddug.com.data.services.models.request.chat.UsersStatusRequestDto
 import uddug.com.data.services.models.response.chat.UserStatusDto
@@ -36,6 +40,31 @@ interface ChatApiService {
 
     @GET("chat/v1/dialogs/folder")
     suspend fun getFolders(): FoldersDto
+
+    @POST("chat/v1/dialogs/folder")
+    suspend fun createFolder(@Body request: ChatFolderRequestDto): FolderDto
+
+    @PATCH("chat/v1/dialogs/folder/{folderId}")
+    suspend fun updateFolder(
+        @Path("folderId") folderId: Long,
+        @Body request: ChatFolderRequestDto,
+    ): FolderDto
+
+    @DELETE("chat/v1/dialogs/folder/{folderId}")
+    suspend fun deleteFolder(@Path("folderId") folderId: Long)
+
+    @GET("chat/v1/dialogs/folder/{folderId}")
+    suspend fun getFolder(@Path("folderId") folderId: Long): FolderDetailsDto
+
+    @GET("chat/v1/dialogs/folder/{folderId}/dialogs")
+    suspend fun getFolderDialogs(
+        @Path("folderId") folderId: Long,
+        @Query("limit") limit: Int,
+        @Query("page") page: Int,
+    ): FolderDialogsDto
+
+    @PATCH("chat/v1/dialogs/folder/{folderId}/set-read")
+    suspend fun markFolderAsRead(@Path("folderId") folderId: Long)
 
     @GET("chat/v1/dialogs/{dialogId}")
     suspend fun getMessages(

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/ChatFolderRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/ChatFolderRequestDto.kt
@@ -1,0 +1,7 @@
+package uddug.com.data.services.models.request.chat
+
+data class ChatFolderRequestDto(
+    val name: String? = null,
+    val dialogIds: List<Long>? = null,
+    val ord: Int? = null,
+)

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/FolderDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/FolderDto.kt
@@ -11,3 +11,21 @@ data class FolderDto(
     val ord: Int,
     val unreadCount: Int
 )
+
+data class FolderDetailsDto(
+    val id: Long,
+    val name: String,
+    val ord: Int,
+    val unreadCount: Int,
+    val dialogIds: List<Long>,
+    val dialogs: List<SearchDialogDto>
+)
+
+data class FolderDialogsDto(
+    val dialogs: List<FolderDialogItemDto>
+)
+
+data class FolderDialogItemDto(
+    val dialog: SearchDialogDto,
+    val folderNames: List<String>
+)

--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatFolderDetails.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatFolderDetails.kt
@@ -1,0 +1,16 @@
+package uddug.com.domain.entities.chat
+
+data class ChatFolderDetails(
+    val folder: ChatFolder,
+    val dialogIds: List<Long>,
+    val dialogs: List<SearchDialog>,
+)
+
+data class ChatFolderDialog(
+    val dialog: SearchDialog,
+    val folderNames: List<String>,
+)
+
+data class ChatFolderDialogsPage(
+    val dialogs: List<ChatFolderDialog>,
+)

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -2,10 +2,12 @@ package uddug.com.domain.interactors.chat
 
 import uddug.com.domain.entities.chat.Chat
 import uddug.com.domain.entities.chat.ChatFolder
+import uddug.com.domain.entities.chat.ChatFolderDetails
+import uddug.com.domain.entities.chat.ChatFolderDialogsPage
 import uddug.com.domain.entities.chat.DialogInfo
+import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
-import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.SearchDialog
 import uddug.com.domain.entities.chat.SearchMessage
 import uddug.com.domain.entities.chat.UserStatus
@@ -22,6 +24,31 @@ class ChatInteractor @Inject constructor(
     suspend fun getDialogs(folderId: Long? = null): List<Chat> = chatRepository.getChats(folderId)
 
     suspend fun getFolders(): List<ChatFolder> = chatRepository.getFolders()
+
+    suspend fun createFolder(
+        name: String,
+        dialogIds: List<Long> = emptyList(),
+        ord: Int? = null,
+    ): ChatFolder = chatRepository.createFolder(name, dialogIds, ord)
+
+    suspend fun updateFolder(
+        folderId: Long,
+        name: String? = null,
+        dialogIds: List<Long>? = null,
+        ord: Int? = null,
+    ): ChatFolder = chatRepository.updateFolder(folderId, name, dialogIds, ord)
+
+    suspend fun deleteFolder(folderId: Long) = chatRepository.deleteFolder(folderId)
+
+    suspend fun getFolder(folderId: Long): ChatFolderDetails = chatRepository.getFolder(folderId)
+
+    suspend fun getFolderDialogs(
+        folderId: Long,
+        limit: Int,
+        page: Int,
+    ): ChatFolderDialogsPage = chatRepository.getFolderDialogs(folderId, limit, page)
+
+    suspend fun markFolderAsRead(folderId: Long) = chatRepository.markFolderAsRead(folderId)
 
     suspend fun getMessages(
         currentUserId: String,

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -2,6 +2,8 @@ package uddug.com.domain.repositories.chat
 
 import uddug.com.domain.entities.chat.Chat
 import uddug.com.domain.entities.chat.ChatFolder
+import uddug.com.domain.entities.chat.ChatFolderDetails
+import uddug.com.domain.entities.chat.ChatFolderDialogsPage
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.MediaMessage
@@ -17,6 +19,31 @@ interface ChatRepository {
     suspend fun getChats(folderId: Long? = null): List<Chat>
 
     suspend fun getFolders(): List<ChatFolder>
+
+    suspend fun createFolder(
+        name: String,
+        dialogIds: List<Long> = emptyList(),
+        ord: Int? = null,
+    ): ChatFolder
+
+    suspend fun updateFolder(
+        folderId: Long,
+        name: String? = null,
+        dialogIds: List<Long>? = null,
+        ord: Int? = null,
+    ): ChatFolder
+
+    suspend fun deleteFolder(folderId: Long)
+
+    suspend fun getFolder(folderId: Long): ChatFolderDetails
+
+    suspend fun getFolderDialogs(
+        folderId: Long,
+        limit: Int,
+        page: Int,
+    ): ChatFolderDialogsPage
+
+    suspend fun markFolderAsRead(folderId: Long)
 
     suspend fun getMessages(
         currentUserId: String,


### PR DESCRIPTION
## Summary
- add chat folder CRUD endpoints and pagination helpers to the API layer with domain mappings
- expose folder management operations in the repository, interactor, and view model to support mark-as-read, rename, and delete actions
- implement a bottom sheet for folder long-press actions in the chat list UI with updated localized strings

## Testing
- ./gradlew app:compileDebugKotlin *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd02a3c7308327b29e2635abf6f9a3