### PR TITLE
Handle chat deletion refresh in chat list

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -155,6 +155,9 @@ fun ChatListComponent(
             },
             onNotificationsChange = { dialogId, disabled ->
                 viewModel.updateDialogNotifications(dialogId, disabled)
+            },
+            onChatDeleted = {
+                viewModel.refreshChats()
             }
         )
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -14,13 +14,16 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.flow.collectLatest
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatFunctionsEvent
 import uddug.com.naukoteka.mvvm.chat.ChatFunctionsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -35,9 +38,21 @@ fun ChatFunctionsBottomSheetDialog(
     onSelectMessages: () -> Unit,
     onPinChange: (Long, Boolean) -> Unit = { _, _ -> },
     onNotificationsChange: (Long, Boolean) -> Unit = { _, _ -> },
+    onChatDeleted: () -> Unit = {},
     viewModel: ChatFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collectLatest { event ->
+            when (event) {
+                ChatFunctionsEvent.ChatDeleted -> {
+                    onDismissRequest()
+                    onChatDeleted()
+                }
+            }
+        }
+    }
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,


### PR DESCRIPTION
## Summary
- collect chat deletion events from the chat actions bottom sheet
- refresh the chat list when a dialog is removed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0997c5308327be83ffe37282a101