### PR TITLE
Ensure group creator is included as admin when creating group dialogs

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateGroupViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateGroupViewModel.kt
@@ -140,9 +140,12 @@ class ChatCreateGroupViewModel @Inject constructor(
                     .joinToString(separator = ", ")
                     .take(MAX_GROUP_NAME_LENGTH)
 
-            val userRoles = participants
+            val userRoles = current.members
                 .mapNotNull { member ->
-                    member.user.id?.let { id -> id to if (member.isAdmin) ADMIN_ROLE else null }
+                    member.user.id?.let { id ->
+                        val role = if (member.isCreator || member.isAdmin) ADMIN_ROLE else null
+                        id to role
+                    }
                 }
                 .toMap()
 


### PR DESCRIPTION
## Summary
- ensure the creator remains in the userRoles payload when a group chat is created
- always mark the creator as an admin role in the payload so the backend receives the initiator

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd0a24f25c832793d0d6e48ccbe385