### PR TITLE
Fix group chat name and avatar mapping

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -345,10 +345,19 @@ fun ChatTabBar(
                     val chats = state.chats
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
                         items(chats) { chat ->
+                            val displayName = when {
+                                chat.dialogType != 1 && chat.dialogName.isNotBlank() -> chat.dialogName
+                                !chat.interlocutor.fullName.isNullOrBlank() -> chat.interlocutor.fullName!!
+                                !chat.interlocutor.nickname.isNullOrBlank() -> chat.interlocutor.nickname!!
+                                chat.dialogName.isNotBlank() -> chat.dialogName
+                                else -> stringResource(R.string.group_chat)
+                            }
+                            val avatarUrl = chat.dialogImage?.path?.takeIf { it.isNotBlank() }
+                                ?: chat.interlocutor.image
                             ChatCard(
                                 dialogId = chat.dialogId,
-                                avatarUrl = chat.interlocutor.image,
-                                name = chat.interlocutor.fullName ?: stringResource(R.string.chat_unknown_user),
+                                avatarUrl = avatarUrl,
+                                name = displayName,
                                 message = chat.lastMessage.text ?: stringResource(R.string.chat_no_messages),
                                 time = chat.lastMessage.createdAt ?: stringResource(R.string.chat_unknown_time),
                                 newMessagesCount = chat.unreadMessages,

--- a/data/src/main/java/uddug/com/data/mapper/mapChatDtoToDomain.kt
+++ b/data/src/main/java/uddug/com/data/mapper/mapChatDtoToDomain.kt
@@ -15,23 +15,13 @@ fun mapChatDtoToDomain(chatDto: ChatDto): List<Chat> {
             dialogId = dialog?.dialogId ?: 0,
             dialogName = dialog?.dialogName.orEmpty(),
             dialogType = dialog?.dialogType ?: 0,
+            dialogImage = dialog?.dialogImage?.let { mapImageDtoToDomain(it) },
             messageId = dialog?.messageId ?: 0,
             isPinned = dialog?.isPinned ?: false,
             isUnread = dialog?.isUnread ?: false,
             users = dialog?.users?.map { mapUserDtoToDomain(it) } ?: emptyList(),
-            interlocutor = mapUserDtoToDomain(dialog?.interlocutor ?: UserDto(null, "", "", "", "")),
-            lastMessage = mapMessageDtoToDomain(
-                dialog?.lastMessage ?: MessageDto(
-                    0,
-                    "",
-                    0,
-                    emptyList(),
-                    0,
-                    "",
-                    "",
-                    false
-                )
-            ),
+            interlocutor = mapUserDtoToDomain(dialog?.interlocutor ?: UserDto()),
+            lastMessage = mapMessageDtoToDomain(dialog?.lastMessage),
             unreadMessages = dialog?.unreadMessages ?: 0,
             notificationsDisable = dialog?.notificationsDisable ?: false,
             isBlocked = dialog?.isBlocked ?: false
@@ -56,15 +46,15 @@ fun mapImageDtoToDomain(imageDto: ImageDto): Image {
     )
 }
 
-fun mapMessageDtoToDomain(messageDto: MessageDto): Message {
+fun mapMessageDtoToDomain(messageDto: MessageDto?): Message {
     return Message(
-        id = messageDto.id,
-        text = messageDto.text,
-        type = messageDto.type,
-        files = messageDto.files.map { mapImageDtoToDomain(it) },
-        read = messageDto.read,
-        ownerId = messageDto.ownerId,
-        createdAt = messageDto.createdAt,
-        isPinned = messageDto.isPinned
+        id = messageDto?.id,
+        text = messageDto?.text,
+        type = messageDto?.type,
+        files = messageDto?.files?.map { mapImageDtoToDomain(it) } ?: emptyList(),
+        read = messageDto?.read,
+        ownerId = messageDto?.ownerId,
+        createdAt = messageDto?.createdAt,
+        isPinned = messageDto?.isPinned
     )
 }

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/ChatDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/ChatDto.kt
@@ -21,12 +21,13 @@ data class DialogDto(
     val dialogId: Long,
     val dialogName: String,
     val dialogType: Int,
+    val dialogImage: ImageDto? = null,
     val messageId: Long,
     val isPinned: Boolean,
     val isUnread: Boolean,
-    val users: List<UserDto>,
-    val interlocutor: UserDto,
-    val lastMessage: MessageDto,
+    val users: List<UserDto>?,
+    val interlocutor: UserDto? = null,
+    val lastMessage: MessageDto? = null,
     val unreadMessages: Int,
     val notificationsDisable: Boolean,
     val isBlocked: Boolean = false,
@@ -34,52 +35,52 @@ data class DialogDto(
 
 data class UserDto(
     val image: ImageDto? = null,
-    val fullName: String,
-    val nickname: String,
-    val userId: String,
+    val fullName: String? = null,
+    val nickname: String? = null,
+    val userId: String? = null,
     val role: String? = null,
     val isAdmin: Boolean? = null,
 )
 
 data class ImageDto(
-    val id: String,
+    val id: String? = null,
     val path: String? = null,
-    val fileName: String,
-    val contentType: String,
-    val fileSize: Int,
-    val fileType: Int,
-    val fileKind: Int,
-    val duration: String,
-    val viewCount: Int,
+    val fileName: String? = null,
+    val contentType: String? = null,
+    val fileSize: Int? = null,
+    val fileType: Int? = null,
+    val fileKind: Int? = null,
+    val duration: String? = null,
+    val viewCount: Int? = null,
 ) {
-    fun toDomain() : File {
+    fun toDomain(): File {
         return File(
-            id = this.id,
+            id = this.id.orEmpty(),
             contentType = this.contentType,
             path = this.path.orEmpty(),
-            fileName = this.fileName
+            fileName = this.fileName.orEmpty()
         )
     }
 }
 
 data class MessageDto(
-    val id: Long,
-    val text: String,
-    val type: Int,
-    val files: List<ImageDto>,
-    val read: Int,
-    val ownerId: String,
-    val createdAt: String,
-    val isPinned: Boolean,
+    val id: Long? = null,
+    val text: String? = null,
+    val type: Int? = null,
+    val files: List<ImageDto>? = null,
+    val read: Int? = null,
+    val ownerId: String? = null,
+    val createdAt: String? = null,
+    val isPinned: Boolean? = null,
 ) {
     fun toDomain(currentUserId: String): MessageChat = MessageChat(
 
-        id = id,
+        id = id ?: 0L,
         text = text,
-        type = MessageType.fromInt(type),
-        files = files.map { it.toDomain() },
+        type = MessageType.fromInt(type ?: 0),
+        files = files?.map { it.toDomain() } ?: emptyList(),
         ownerId = ownerId,
-        createdAt = Instant.parse(createdAt),
+        createdAt = createdAt?.let { Instant.parse(it) } ?: Instant.EPOCH,
         readCount = read,
         isMine = ownerId == currentUserId
     )

--- a/domain/src/main/java/uddug/com/domain/entities/chat/Chat.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/Chat.kt
@@ -9,6 +9,7 @@ data class Chat(
     val dialogId: Long,
     val dialogName: String,
     val dialogType: Int,
+    val dialogImage: Image? = null,
     val messageId: Long,
     val isPinned: Boolean,
     val isUnread: Boolean,


### PR DESCRIPTION
## Summary
- display group chats in the list using the backend provided names and avatars
- map dialog images into the domain model and make DTO parsing resilient to missing fields

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0a76e59c8327b16ef4bcfe2f62bd