### PR TITLE
Fix group dialog creation participants mapping

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateGroupViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateGroupViewModel.kt
@@ -141,9 +141,10 @@ class ChatCreateGroupViewModel @Inject constructor(
                     .take(MAX_GROUP_NAME_LENGTH)
 
             val userRoles = current.members
+                .filterNot { it.isCreator }
                 .mapNotNull { member ->
                     member.user.id?.let { id ->
-                        val role = if (member.isCreator || member.isAdmin) ADMIN_ROLE else null
+                        val role = if (member.isAdmin) ADMIN_ROLE else null
                         id to role
                     }
                 }


### PR DESCRIPTION
## Summary
- exclude the current user when building group dialog role assignments
- ensure non-admin participants are still included with a null role value when creating group dialogs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0df129188327a58fa158cb1c7f6a