### PR TITLE
Ensure group dialog roles include non-admin members

### DIFF
--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -4,6 +4,9 @@ import uddug.com.data.mapper.mapChatDtoToDomain
 import uddug.com.data.mapper.mapFolderDtoToDomain
 import uddug.com.data.services.chat.ChatApiService
 import uddug.com.data.services.models.request.chat.ChatFolderRequestDto
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
 import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
 import uddug.com.data.services.models.request.chat.DialogImageRequestDto
@@ -245,7 +248,7 @@ class ChatRepositoryImpl @Inject constructor(
             val request = CreateDialogRequestDto(
                 dialogName = dialogName,
                 dialogImage = imageId?.let { DialogImageRequestDto(it) },
-                userRoles = userRoles,
+                userRoles = userRoles.toUserRolesJson(),
             )
             val dialog = apiService.createDialog(request)
             dialog.id
@@ -264,7 +267,7 @@ class ChatRepositoryImpl @Inject constructor(
             val request = CreateDialogRequestDto(
                 dialogName = dialogName,
                 dialogImage = imageId?.let { DialogImageRequestDto(it) },
-                userRoles = userRoles,
+                userRoles = userRoles.toUserRolesJson(),
             )
             val dialog = apiService.createGroupDialog(request)
             dialog.id
@@ -414,6 +417,14 @@ class ChatRepositoryImpl @Inject constructor(
             emptyList()
         }
     }
+}
+
+private fun Map<String, String?>.toUserRolesJson(): JsonObject {
+    val json = JsonObject()
+    for ((userId, role) in this) {
+        json.add(userId, role?.let(::JsonPrimitive) ?: JsonNull.INSTANCE)
+    }
+    return json
 }
 
 private fun FileDto.toDomain(): ChatFile = ChatFile(

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/CreateDialogRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/CreateDialogRequestDto.kt
@@ -1,11 +1,12 @@
 package uddug.com.data.services.models.request.chat
 
+import com.google.gson.JsonObject
 import com.google.gson.annotations.SerializedName
 
 data class CreateDialogRequestDto(
     @SerializedName("dialogName") val dialogName: String?,
     @SerializedName("dialogImage") val dialogImage: DialogImageRequestDto?,
-    @SerializedName("userRoles") val userRoles: Map<String, String?>
+    @SerializedName("userRoles") val userRoles: JsonObject
 )
 
 data class DialogImageRequestDto(


### PR DESCRIPTION
## Summary
- serialize group dialog role assignments with explicit nulls so every selected participant is sent
- represent the userRoles payload as JSON to preserve null values for non-admin members

## Testing
- ./gradlew :data:compileDebugKotlin *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0fa77bfc83279b8c42e521342784