### PR TITLE
Send null userRoles when no roles provided

### DIFF
--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -4,6 +4,7 @@ import uddug.com.data.mapper.mapChatDtoToDomain
 import uddug.com.data.mapper.mapFolderDtoToDomain
 import uddug.com.data.services.chat.ChatApiService
 import uddug.com.data.services.models.request.chat.ChatFolderRequestDto
+import com.google.gson.JsonElement
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
@@ -419,7 +420,11 @@ class ChatRepositoryImpl @Inject constructor(
     }
 }
 
-private fun Map<String, String?>.toUserRolesJson(): JsonObject {
+private fun Map<String, String?>.toUserRolesJson(): JsonElement {
+    if (isEmpty()) {
+        return JsonNull.INSTANCE
+    }
+
     val json = JsonObject()
     for ((userId, role) in this) {
         json.add(userId, role?.let(::JsonPrimitive) ?: JsonNull.INSTANCE)

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/CreateDialogRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/CreateDialogRequestDto.kt
@@ -1,12 +1,12 @@
 package uddug.com.data.services.models.request.chat
 
-import com.google.gson.JsonObject
+import com.google.gson.JsonElement
 import com.google.gson.annotations.SerializedName
 
 data class CreateDialogRequestDto(
     @SerializedName("dialogName") val dialogName: String?,
     @SerializedName("dialogImage") val dialogImage: DialogImageRequestDto?,
-    @SerializedName("userRoles") val userRoles: JsonObject
+    @SerializedName("userRoles") val userRoles: JsonElement
 )
 
 data class DialogImageRequestDto(


### PR DESCRIPTION
## Summary
- allow chat dialog request payload to hold a JsonElement for user roles
- return JsonNull when no user roles are supplied so the API receives an explicit null value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd112b287c83278e66231db110c836