### PR TITLE
Show last seen statuses for group members

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateGroupScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateGroupScreen.kt
@@ -392,10 +392,10 @@ private fun GroupMemberRow(
                     fontSize = 12.sp
                 )
             }
-            member.user.placeOfResidence?.takeIf { it.isNotBlank() }?.let { residence ->
+            member.status?.takeIf { it.isNotBlank() }?.let { status ->
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = residence,
+                    text = status,
                     fontSize = 12.sp,
                     color = Color(0xFF8083A0)
                 )


### PR DESCRIPTION
## Summary
- fetch member statuses during group creation and format them with the existing ChatStatusFormatter
- surface the formatted status text in the group member list instead of the location field

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd18fae9c08327b1e951b19eecf3d6