### PR TITLE
Fix chat media picker crash and ensure activity context usage

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -45,3 +45,4 @@
   **[] $VALUES;
   public *;
 }
+-keep class gun0912.tedimagepicker.** { *; }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -3,6 +3,7 @@ package uddug.com.naukoteka.ui.chat.compose
 
 import android.Manifest
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.pm.PackageManager
 import android.media.MediaPlayer
 import android.net.Uri
@@ -39,12 +40,13 @@ import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import androidx.activity.ComponentActivity
 import gun0912.tedimagepicker.builder.TedImagePicker
 import kotlinx.coroutines.launch
 import uddug.com.naukoteka.mvvm.chat.ChatDialogUiState
@@ -151,11 +153,14 @@ fun ChatDialogComponent(
     }
 
     fun openMediaPicker() {
-        TedImagePicker.with(context)
-            .showCameraTile(true)
-            .startMultiImage { uriList ->
-                attachMediaFiles(uriList)
-            }
+        val activity = context.findActivity()
+        if (activity != null) {
+            TedImagePicker.with(activity)
+                .showCameraTile(true)
+                .startMultiImage { uriList ->
+                    attachMediaFiles(uriList)
+                }
+        }
     }
 
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -450,6 +455,12 @@ fun ChatDialogComponent(
             )
         }
     }
+}
+
+private tailrec fun Context.findActivity(): ComponentActivity? = when (this) {
+    is ComponentActivity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
 }
 
 private fun getContactInfo(context: Context, uri: Uri): ContactInfo? {


### PR DESCRIPTION
## Summary
- keep tedimagepicker classes from being removed by R8 to avoid runtime crashes
- resolve activity instance from compose context before launching the media picker

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd195dfe688327969a0397e4540ff5