### PR TITLE
Fix file attachment preview and allow file-only messages

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -514,6 +514,7 @@ class ChatDialogViewModel @Inject constructor(
             val currentState = _uiState.value
             val successState = currentState as? ChatDialogUiState.Success
             val replyId = successState?.replyMessage?.id
+            val sanitizedText = if (text.isBlank()) "" else text
 
             selectedUser?.let { user ->
                 val payload = buildUserContactPayload(user) ?: return@launch
@@ -545,7 +546,7 @@ class ChatDialogViewModel @Inject constructor(
                 return@launch
             }
 
-            if (text.isBlank() && attachedFiles.isEmpty()) {
+            if (sanitizedText.isEmpty() && attachedFiles.isEmpty()) {
                 Log.d("ChatViewModel", "Message is blank and no files attached — skipping")
                 return@launch
             }
@@ -556,7 +557,7 @@ class ChatDialogViewModel @Inject constructor(
                     chatInteractor.updateMessage(
                         dialogId = dialog.id,
                         messageId = editingMessage.id,
-                        text = text,
+                        text = sanitizedText,
                         files = editingMessage.files.mapNotNull { it.toFileDescriptor() },
                     )
                 } catch (e: EOFException) {
@@ -565,7 +566,7 @@ class ChatDialogViewModel @Inject constructor(
                         "Empty response received when updating message, using local data",
                         e
                     )
-                    editingMessage.copy(text = text)
+                    editingMessage.copy(text = sanitizedText)
                 } catch (e: Exception) {
                     Log.e("ChatViewModel", "Failed to update message", e)
                     return@launch
@@ -618,7 +619,7 @@ class ChatDialogViewModel @Inject constructor(
                 ChatSocketMessage(
                     dialog = dialog.id,
                     cType = cType,
-                    text = text,
+                    text = sanitizedText,
                     owner = currentUser?.id.orEmpty(),
                     files = fileDescriptors.ifEmpty { null },
                     answered = replyId
@@ -628,7 +629,7 @@ class ChatDialogViewModel @Inject constructor(
                 ChatSocketMessage(
                     interlocutor = peer,
                     cType = cType,
-                    text = text,
+                    text = sanitizedText,
                     owner = currentUser?.id.orEmpty(),
                     files = fileDescriptors.ifEmpty { null },
                     answered = replyId

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -48,6 +48,7 @@ import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.naukoteka.mvvm.chat.ContactInfo
 import java.io.File
+import java.util.Locale
 
 @Composable
 fun ChatInputBar(
@@ -105,33 +106,44 @@ fun ChatInputBar(
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(attachedFiles) { file ->
+                    val isImage = file.isImageFile()
                     Box(
                         modifier = Modifier
                             .size(50.dp)
                             .clip(RoundedCornerShape(8.dp))
+                            .background(if (isImage) Color.Transparent else Color(0xFFE4E8F1))
                             .clickable(
                                 interactionSource = remember { MutableInteractionSource() },
                                 indication = null
-                            ) { onRemoveFile(file) }
+                            ) { onRemoveFile(file) },
+                        contentAlignment = Alignment.Center
                     ) {
-                        AsyncImage(
-                            model = file,
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier.matchParentSize()
-                        )
-                        Box(
-                            modifier = Modifier
-                                .align(Alignment.TopEnd)
-                                .size(16.dp)
-                                .background(Color.Red, CircleShape),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Close,
-                                contentDescription = "Remove",
-                                tint = Color.White,
-                                modifier = Modifier.size(10.dp)
+                        if (isImage) {
+                            AsyncImage(
+                                model = file,
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.matchParentSize()
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .align(Alignment.TopEnd)
+                                    .size(16.dp)
+                                    .background(Color.Red, CircleShape),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.Close,
+                                    contentDescription = "Remove",
+                                    tint = Color.White,
+                                    modifier = Modifier.size(10.dp)
+                                )
+                            }
+                        } else {
+                            Image(
+                                painter = painterResource(id = R.drawable.ic_attached_file_dialog),
+                                contentDescription = null,
+                                modifier = Modifier.size(28.dp)
                             )
                         }
                     }
@@ -495,4 +507,11 @@ fun RecordedAudioPreview(duration: String, isPlaying: Boolean, onPlay: () -> Uni
             Text(text = duration, color = Color.White)
         }
     }
+}
+
+private val IMAGE_FILE_EXTENSIONS = setOf("jpg", "jpeg", "png", "gif", "bmp", "webp", "heic", "heif")
+
+private fun File.isImageFile(): Boolean {
+    val extension = extension.lowercase(Locale.ROOT)
+    return IMAGE_FILE_EXTENSIONS.contains(extension)
 }


### PR DESCRIPTION
## Summary
- replace non-image attachment previews in the chat input with the dedicated attached file icon
- ensure socket messages send file uploads even when the text payload is empty

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd1a428ba48327a06fd889d57a9723