### PR TITLE
Handle socket attachments in chat messages

### DIFF
--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
@@ -4,7 +4,7 @@ data class ChatSocketMessage(
     val dialog: Long? = null,
     val interlocutor: String? = null,
     val cType: Int = 1,
-    val text: String,
+    val text: String? = null,
     val owner: String? = null,
     val files: List<FileDescriptor>? = null,
     val answered: Long? = null,
@@ -12,11 +12,23 @@ data class ChatSocketMessage(
     val forwarded: Long? = null,
     val forwardedn: List<Long>? = null,
     val dialogs: List<Long>? = null,
+    val id: Long? = null,
+    val createdAt: String? = null,
+    val ownerName: String? = null,
+    val ownerAvatarUrl: String? = null,
+    val read: Int? = null,
 )
 
 public data class FileDescriptor(
     val id: String,
-    val fileType: Int
+    val fileType: Int,
+    val path: String? = null,
+    val fileName: String? = null,
+    val contentType: String? = null,
+    val fileSize: Int? = null,
+    val fileKind: Int? = null,
+    val duration: String? = null,
+    val viewCount: Int? = null,
 )
 
 data class AnswerPreview(


### PR DESCRIPTION
## Summary
- enrich the chat socket payload model with identifiers, timestamps, and full file metadata
- convert incoming socket messages into domain messages with attachments and owner info
- map socket file descriptors to domain files so media received over the socket displays immediately

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1ab45d2483279884118a75acea99