### PR TITLE
Improve chat list attachment previews

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import uddug.com.data.cache.user_id.UserIdCache
+import uddug.com.data.cache.user_uuid.UserUUIDCache
 import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.SearchDialog
 import uddug.com.domain.entities.chat.SearchMessage
@@ -21,7 +23,14 @@ import javax.inject.Inject
 @HiltViewModel
 class ChatListViewModel @Inject constructor(
     private val chatRepository: ChatRepository,
+    userIdCache: UserIdCache,
+    userUUIDCache: UserUUIDCache,
 ) : ViewModel() {
+
+    private val currentUserIds: Set<String> = listOfNotNull(
+        userIdCache.entity?.takeIf { it.isNotBlank() },
+        userUUIDCache.entity?.takeIf { it.isNotBlank() },
+    ).toSet()
 
     private val _uiState = MutableStateFlow<ChatListUiState>(ChatListUiState.Loading)
     val uiState: StateFlow<ChatListUiState> = _uiState
@@ -52,6 +61,10 @@ class ChatListViewModel @Inject constructor(
 
     private var loadChatsJob: kotlinx.coroutines.Job? = null
     private var searchJob: Job? = null
+
+    fun isMessageFromMe(ownerId: String?): Boolean {
+        return ownerId.isNullOrBlank() || currentUserIds.contains(ownerId)
+    }
 
     fun loadFolders() {
         _uiState.value = ChatListUiState.Loading

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/Avatar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/Avatar.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -31,7 +32,8 @@ fun Avatar(
             contentDescription = "avatar",
             modifier = Modifier
                 .size(size)
-                .clip(CircleShape)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop
         )
     } else {
         val initials = overrideInitials ?: name.orEmpty()

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.InsertDriveFile
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.*
 import androidx.compose.animation.animateContentSize
 import androidx.compose.runtime.Composable
@@ -12,11 +14,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -24,6 +28,17 @@ import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.core.deeplink.formatMessageTime
 import uddug.com.naukoteka.ui.chat.compose.components.Avatar
+
+enum class ChatAttachmentType {
+    IMAGE,
+    VIDEO,
+    FILE,
+}
+
+data class ChatAttachmentPreview(
+    val path: String?,
+    val type: ChatAttachmentType,
+)
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -34,10 +49,11 @@ fun ChatCard(
     message: String,
     time: String,
     newMessagesCount: Int? = null,
-    attachment: String? = null,
+    attachmentPreview: ChatAttachmentPreview? = null,
     isRepost: Boolean = false,
-    isMedia: Boolean = false,
+    isGroupChat: Boolean = false,
     isFromMe: Boolean = false,
+    authorName: String? = null,
     notificationsDisable: Boolean = false,
     isPinned: Boolean = false,
     isMuted: Boolean = false,
@@ -129,34 +145,58 @@ fun ChatCard(
 
 
                     
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        val messageText = when {
-                            isRepost -> stringResource(R.string.chat_last_message_repost, message)
-                            isMedia -> stringResource(R.string.chat_last_message_media)
-                            isFromMe -> stringResource(R.string.chat_last_message_from_me, message)
-                            else -> message
+                    val messageText = when {
+                        isRepost -> stringResource(R.string.chat_last_message_repost, message)
+                        attachmentPreview != null -> when (attachmentPreview.type) {
+                            ChatAttachmentType.IMAGE -> stringResource(R.string.chat_last_message_image)
+                            ChatAttachmentType.VIDEO -> stringResource(R.string.chat_last_message_video)
+                            ChatAttachmentType.FILE -> stringResource(R.string.chat_last_message_file)
+                        }
+                        !isGroupChat && isFromMe -> stringResource(R.string.chat_last_message_from_me, message)
+                        else -> message
+                    }.ifBlank { stringResource(R.string.chat_no_messages) }
+
+                    if (isGroupChat) {
+                        val authorLabel = if (isFromMe) {
+                            stringResource(R.string.chat_last_message_author_you)
+                        } else {
+                            authorName.orEmpty()
+                        }
+                        if (authorLabel.isNotBlank()) {
+                            Text(
+                                text = authorLabel,
+                                style = TextStyle(
+                                    fontSize = 14.sp,
+                                    color = Color(0xFF2E83D9),
+                                    fontWeight = FontWeight.Medium
+                                ),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.padding(top = 4.dp)
+                            )
+                        }
+                    }
+
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(top = if (isGroupChat) 4.dp else 0.dp)
+                    ) {
+                        attachmentPreview?.let { preview ->
+                            AttachmentPreview(
+                                preview = preview,
+                                modifier = Modifier.padding(end = 8.dp)
+                            )
                         }
                         Text(
                             text = messageText,
                             style = TextStyle(
                                 fontSize = 14.sp,
-                                color = if (isFromMe) Color.Blue else Color.Gray,
-                                fontWeight = if (isRepost) FontWeight.Bold else androidx.compose.ui.text.font.FontWeight.Normal
+                                color = if (!isGroupChat && isFromMe) Color(0xFF2E83D9) else Color(0xFF4E5068),
+                                fontWeight = if (isRepost) FontWeight.Bold else FontWeight.Normal
                             ),
                             maxLines = 1,
-                            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                            overflow = TextOverflow.Ellipsis
                         )
-
-                        
-                        if (isMedia && attachment?.isNotEmpty() == true) {
-                            AsyncImage(
-                                model = BuildConfig.IMAGE_SERVER_URL + attachment,
-                                contentDescription = "Avatar",
-                                modifier = Modifier
-                                    .size(20.dp)
-                                    .clip(RectangleShape)
-                            )
-                        }
                     }
                 }
                 Column(
@@ -214,7 +254,51 @@ fun ChatCard(
     }
 }
 
+@Composable
+private fun AttachmentPreview(
+    preview: ChatAttachmentPreview,
+    modifier: Modifier = Modifier,
+    size: Dp = 24.dp,
+) {
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(Color(0xFFF2F5FA)),
+        contentAlignment = Alignment.Center
+    ) {
+        when (preview.type) {
+            ChatAttachmentType.IMAGE -> {
+                AsyncImage(
+                    model = BuildConfig.IMAGE_SERVER_URL + (preview.path ?: ""),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            ChatAttachmentType.VIDEO -> {
+                Icon(
+                    imageVector = Icons.Filled.PlayArrow,
+                    contentDescription = null,
+                    tint = Color(0xFF2E83D9),
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+
+            ChatAttachmentType.FILE -> {
+                Icon(
+                    imageVector = Icons.Filled.InsertDriveFile,
+                    contentDescription = null,
+                    tint = Color(0xFF2E83D9),
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
+    }
+}
+
 fun formatMessageTime(time: String): String {
-    
+
     return time
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -146,6 +146,10 @@
   <string name="chat_last_message_repost">Репост: %1$s</string>
   <string name="chat_last_message_media">Медиа-вложение</string>
   <string name="chat_last_message_from_me">Вы: %1$s</string>
+  <string name="chat_last_message_image">Изображение</string>
+  <string name="chat_last_message_video">Видео</string>
+  <string name="chat_last_message_file">Файл</string>
+  <string name="chat_last_message_author_you">Вы</string>
   <string name="chat_swipe_to_cancel">Смахните влево для отмены</string>
   <string name="chat_message_placeholder">Напишите сообщение</string>
   <string name="chat_reply_default_author">Ответ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,10 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_last_message_repost">Repost: %1$s</string>
     <string name="chat_last_message_media">Media attachment</string>
     <string name="chat_last_message_from_me">You: %1$s</string>
+    <string name="chat_last_message_image">Image</string>
+    <string name="chat_last_message_video">Video</string>
+    <string name="chat_last_message_file">File</string>
+    <string name="chat_last_message_author_you">You</string>
     <string name="chat_swipe_to_cancel">Swipe left to cancel</string>
     <string name="chat_message_placeholder">Write a message</string>
     <string name="chat_reply_default_author">Reply</string>

--- a/data/src/main/java/uddug/com/data/mapper/mapChatDtoToDomain.kt
+++ b/data/src/main/java/uddug/com/data/mapper/mapChatDtoToDomain.kt
@@ -42,7 +42,14 @@ fun mapUserDtoToDomain(userDto: UserDto): User {
 
 fun mapImageDtoToDomain(imageDto: ImageDto): Image {
     return Image(
-        path = imageDto.path ?: ""
+        id = imageDto.id,
+        path = imageDto.path ?: "",
+        fileName = imageDto.fileName,
+        contentType = imageDto.contentType,
+        fileSize = imageDto.fileSize,
+        fileType = imageDto.fileType,
+        fileKind = imageDto.fileKind,
+        duration = imageDto.duration,
     )
 }
 

--- a/domain/src/main/java/uddug/com/domain/entities/chat/Chat.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/Chat.kt
@@ -32,7 +32,14 @@ data class User(
 ) : Parcelable
 
 data class Image(
+    val id: String? = null,
     val path: String? = null,
+    val fileName: String? = null,
+    val contentType: String? = null,
+    val fileSize: Int? = null,
+    val fileType: Int? = null,
+    val fileKind: Int? = null,
+    val duration: String? = null,
 )
 
 data class Message(


### PR DESCRIPTION
## Summary
- ensure chat avatars and media previews render with circular cropping
- enrich chat list rows with attachment type labels and group author info
- propagate file metadata and current-user detection to support the new UI

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: requires Android SDK path)*

------
https://chatgpt.com/codex/tasks/task_e_68dd22d342e483279fa566a44856f5e8