### PR TITLE
feat: add admin controls to group detail screen

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
@@ -3,21 +3,27 @@ package uddug.com.naukoteka.mvvm.chat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.await
+import kotlinx.coroutines.withContext
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.User
 import uddug.com.domain.interactors.chat.ChatInteractor
+import uddug.com.domain.repositories.user_profile.UserProfileRepository
 import uddug.com.naukoteka.mvvm.chat.ChatStatusFormatter
 import uddug.com.naukoteka.mvvm.chat.ChatStatusTextMode.GENERIC
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
 class ChatGroupDetailViewModel @Inject constructor(
     private val chatInteractor: ChatInteractor,
     private val chatStatusFormatter: ChatStatusFormatter,
+    private val userProfileRepository: UserProfileRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<ChatGroupDetailUiState>(ChatGroupDetailUiState.Loading)
@@ -26,6 +32,11 @@ class ChatGroupDetailViewModel @Inject constructor(
     private val _selectedTabIndex = MutableStateFlow(0)
     val selectedTabIndex: StateFlow<Int> = _selectedTabIndex
 
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery
+
+    private var currentUserId: String? = null
+
     fun selectTab(index: Int) {
         _selectedTabIndex.value = index
     }
@@ -33,6 +44,7 @@ class ChatGroupDetailViewModel @Inject constructor(
     fun loadDialogInfo(dialogId: Long) {
         viewModelScope.launch {
             try {
+                _searchQuery.value = ""
                 val info = chatInteractor.getDialogInfo(dialogId)
                 setDialogInfo(info)
             } catch (e: Exception) {
@@ -44,6 +56,11 @@ class ChatGroupDetailViewModel @Inject constructor(
     fun setDialogInfo(dialogInfo: DialogInfo) {
         viewModelScope.launch {
             try {
+                _searchQuery.value = ""
+                val currentUser = withContext(Dispatchers.IO) {
+                    userProfileRepository.getProfileInfo().await()
+                }
+                currentUserId = currentUser.id
                 val media = chatInteractor.getDialogMedia(
                     dialogInfo.id,
                     category = 1,
@@ -73,14 +90,15 @@ class ChatGroupDetailViewModel @Inject constructor(
                             chatStatusFormatter.online()
                         } else {
                             it.lastSeen?.let { ls ->
-                                runCatching { java.time.Instant.parse(ls) }
+                                runCatching { Instant.parse(ls) }
                                     .map { instant -> chatStatusFormatter.formatLastSeen(instant, GENERIC) }
                                     .getOrDefault("")
                             }
                         }
                     }?.takeIf { it?.isNotEmpty() == true }
-                    Participant(user, statusText)
+                    createParticipant(user, statusText)
                 }
+                val isCurrentUserAdmin = isCurrentUserAdmin(participants)
                 _uiState.value = ChatGroupDetailUiState.Success(
                     name = dialogInfo.name.orEmpty(),
                     image = dialogInfo.dialogImage?.path,
@@ -88,11 +106,102 @@ class ChatGroupDetailViewModel @Inject constructor(
                     media = media,
                     files = files,
                     dialogId = dialogInfo.id,
+                    isCurrentUserAdmin = isCurrentUserAdmin,
                 )
             } catch (e: Exception) {
                 _uiState.value = ChatGroupDetailUiState.Error(e.message ?: "Error")
             }
         }
+    }
+
+    fun onSearchQueryChange(query: String) {
+        _searchQuery.value = query
+    }
+
+    fun clearSearch() {
+        _searchQuery.value = ""
+    }
+
+    fun grantAdmin(userId: String) {
+        updateParticipants {
+            it.map { participant ->
+                if (participant.user.userId == userId && !participant.isOwner) {
+                    val updatedUser = participant.user.copy(isAdmin = true)
+                    participant.copy(user = updatedUser, isAdmin = true)
+                } else {
+                    participant
+                }
+            }
+        }
+    }
+
+    fun revokeAdmin(userId: String) {
+        updateParticipants {
+            it.map { participant ->
+                if (participant.user.userId == userId && participant.isAdmin && !participant.isOwner) {
+                    val updatedUser = participant.user.copy(isAdmin = false)
+                    participant.copy(user = updatedUser, isAdmin = false)
+                } else {
+                    participant
+                }
+            }
+        }
+    }
+
+    fun removeParticipant(userId: String) {
+        updateParticipants { participants ->
+            participants.filterNot { participant ->
+                participant.user.userId == userId && !participant.isOwner
+            }
+        }
+    }
+
+    private fun updateParticipants(transform: (List<Participant>) -> List<Participant>) {
+        val currentState = _uiState.value as? ChatGroupDetailUiState.Success ?: return
+        if (!currentState.isCurrentUserAdmin) return
+        val updatedParticipants = transform(currentState.participants)
+        _uiState.value = currentState.copy(
+            participants = updatedParticipants,
+            isCurrentUserAdmin = isCurrentUserAdmin(updatedParticipants)
+        )
+    }
+
+    private fun createParticipant(user: User, statusText: String?): Participant {
+        val isOwner = isOwnerRole(user.role)
+        val isAdmin = user.isAdmin || isAdminRole(user.role) || isOwner
+        val updatedUser = user.copy(isAdmin = isAdmin)
+        val isCurrent = user.userId != null && user.userId == currentUserId
+        return Participant(
+            user = updatedUser,
+            status = statusText,
+            isAdmin = isAdmin,
+            isOwner = isOwner,
+            isCurrentUser = isCurrent,
+        )
+    }
+
+    private fun isCurrentUserAdmin(participants: List<Participant>): Boolean {
+        val userId = currentUserId ?: return false
+        return participants.any { participant ->
+            participant.user.userId == userId && (participant.isAdmin || participant.isOwner)
+        }
+    }
+
+    private fun isOwnerRole(role: String?): Boolean {
+        if (role.isNullOrBlank()) return false
+        val normalized = role.lowercase()
+        return normalized == ROLE_OWNER || normalized.contains("owner") || normalized.contains("влад")
+    }
+
+    private fun isAdminRole(role: String?): Boolean {
+        if (role.isNullOrBlank()) return false
+        val normalized = role.lowercase()
+        return normalized == ROLE_ADMIN || normalized.contains("admin") || normalized.contains("админ")
+    }
+
+    companion object {
+        private const val ROLE_OWNER = "37:201"
+        private const val ROLE_ADMIN = "37:202"
     }
 }
 
@@ -105,6 +214,7 @@ sealed class ChatGroupDetailUiState {
         val media: List<MediaMessage>,
         val files: List<MediaMessage>,
         val dialogId: Long,
+        val isCurrentUserAdmin: Boolean,
     ) : ChatGroupDetailUiState()
 
     data class Error(val message: String) : ChatGroupDetailUiState()
@@ -113,4 +223,7 @@ sealed class ChatGroupDetailUiState {
 data class Participant(
     val user: User,
     val status: String?,
+    val isAdmin: Boolean,
+    val isOwner: Boolean,
+    val isCurrentUser: Boolean,
 )

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
@@ -82,6 +82,9 @@ class ChatGroupDetailFragment : Fragment() {
                                 R.id.chatDetailSearchFragment,
                                 Bundle().apply { putLong(ChatDetailDialogFragment.DIALOG_ID, dialogId) }
                             )
+                        },
+                        onAddParticipantsClick = {
+                            findNavController().navigate(R.id.chatCreateMultiFragment)
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
@@ -8,12 +8,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.*
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,6 +36,7 @@ import uddug.com.naukoteka.ui.chat.compose.components.Avatar
 import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailViewModel
 import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailUiState
 import uddug.com.naukoteka.mvvm.chat.Participant
+import uddug.com.naukoteka.ui.chat.compose.components.SearchField
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,14 +44,11 @@ fun ChatGroupDetailComponent(
     viewModel: ChatGroupDetailViewModel,
     onBackPressed: () -> Unit,
     onSearchClick: () -> Unit,
+    onAddParticipantsClick: (Long) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val selectedTabIndex by viewModel.selectedTabIndex.collectAsState()
-    val tabs = listOf(
-        stringResource(R.string.chat_group_tab_participants),
-        stringResource(R.string.chat_group_tab_media),
-        stringResource(R.string.chat_group_tab_files)
-    )
+    val searchQuery by viewModel.searchQuery.collectAsState()
     Scaffold(
         topBar = {
             androidx.compose.material.TopAppBar(
@@ -103,18 +106,22 @@ fun ChatGroupDetailComponent(
                         .background(Color.White)
                         .padding(paddingValues)
                 ) {
-                      Column(
-                          modifier = Modifier
-                              .fillMaxWidth()
-                              .padding(16.dp),
-                          horizontalAlignment = Alignment.CenterHorizontally
-                      ) {
-                          Avatar(
-                              url = null,
-                              name = null,
-                              size = 100.dp,
-                              overrideInitials = stringResource(R.string.chat_group_initial),
-                          )
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Avatar(
+                            url = state.image,
+                            name = state.name,
+                            size = 100.dp,
+                            overrideInitials = if (state.image.isNullOrEmpty()) {
+                                stringResource(R.string.chat_group_initial)
+                            } else {
+                                null
+                            },
+                        )
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
                             text = state.name,
@@ -219,6 +226,15 @@ fun ChatGroupDetailComponent(
                             }
                         }
                     }
+                    val tabTitles = listOf(
+                        stringResource(
+                            R.string.chat_group_tab_participants_count,
+                            state.participants.size
+                        ),
+                        stringResource(R.string.chat_group_tab_media),
+                        stringResource(R.string.chat_group_tab_files)
+                    )
+
                     TabRow(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -232,7 +248,7 @@ fun ChatGroupDetailComponent(
                         },
                         divider = {}
                     ) {
-                        tabs.forEachIndexed { index, title ->
+                        tabTitles.forEachIndexed { index, title ->
                             Tab(
                                 selected = selectedTabIndex == index,
                                 onClick = { viewModel.selectTab(index) },
@@ -251,10 +267,39 @@ fun ChatGroupDetailComponent(
                         }
                     }
                     androidx.compose.material3.Divider(color = Color(0xFFEAEAF2))
+                    var selectedParticipant by remember { mutableStateOf<Participant?>(null) }
+
                     when (selectedTabIndex) {
-                        0 -> ParticipantsContent(state.participants)
+                        0 -> ParticipantsContent(
+                            participants = state.participants,
+                            searchQuery = searchQuery,
+                            onSearchQueryChange = viewModel::onSearchQueryChange,
+                            onClearSearch = viewModel::clearSearch,
+                            isCurrentUserAdmin = state.isCurrentUserAdmin,
+                            onAddParticipantClick = { onAddParticipantsClick(state.dialogId) },
+                            onParticipantMoreClick = { participant ->
+                                selectedParticipant = participant
+                            }
+                        )
                         1 -> MediaContent(state.media)
                         2 -> FilesContent(state.files)
+                    }
+
+                    val participantForActions = selectedParticipant
+                    if (participantForActions != null) {
+                        ParticipantActionsBottomSheet(
+                            participant = participantForActions,
+                            onDismissRequest = { selectedParticipant = null },
+                            onGrantAdminClick = {
+                                participantForActions.user.userId?.let { viewModel.grantAdmin(it) }
+                            },
+                            onRevokeAdminClick = {
+                                participantForActions.user.userId?.let { viewModel.revokeAdmin(it) }
+                            },
+                            onRemoveClick = {
+                                participantForActions.user.userId?.let { viewModel.removeParticipant(it) }
+                            }
+                        )
                     }
                 }
             }
@@ -263,38 +308,243 @@ fun ChatGroupDetailComponent(
 }
 
 @Composable
-fun ParticipantsContent(users: List<Participant>) {
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
-        items(users) { participant ->
-            Row(
+fun ParticipantsContent(
+    participants: List<Participant>,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    onClearSearch: () -> Unit,
+    isCurrentUserAdmin: Boolean,
+    onAddParticipantClick: () -> Unit,
+    onParticipantMoreClick: (Participant) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        if (isCurrentUserAdmin) {
+            SearchField(
+                title = stringResource(R.string.chat_group_search_hint),
+                query = searchQuery,
+                onSearchChanged = onSearchQueryChange,
+                showClearIcon = searchQuery.isNotEmpty(),
+                onClearClick = onClearSearch
+            )
+            Text(
+                text = stringResource(R.string.chat_group_add_participant),
+                color = Color(0xFF2E83D9),
+                fontWeight = FontWeight.SemiBold,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Avatar(
-                    participant.user.image,
-                    participant.user.fullName,
-                    size = 40.dp
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Column(horizontalAlignment = Alignment.Start) {
-                    Text(
-                        text = participant.user.fullName.orEmpty(),
-                        fontWeight = FontWeight.Bold,
-                        textAlign = TextAlign.Start
-                    )
-                    participant.status?.let {
-                        Text(
-                            text = it,
-                            fontSize = 12.sp,
-                            color = Color.Gray,
-                            textAlign = TextAlign.Start
-                        )
-                    }
+                    .padding(horizontal = 20.dp, vertical = 12.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { onAddParticipantClick() }
+                    .padding(vertical = 4.dp)
+            )
+        }
+
+        val filteredParticipants = remember(searchQuery, participants) {
+            if (searchQuery.isBlank()) {
+                participants
+            } else {
+                val queryLower = searchQuery.trim().lowercase()
+                participants.filter { participant ->
+                    val name = participant.user.fullName.orEmpty().lowercase()
+                    val nickname = participant.user.nickname.orEmpty().lowercase()
+                    name.contains(queryLower) || nickname.contains(queryLower)
                 }
             }
-            androidx.compose.material3.Divider(color = Color(0xFFEAEAF2))
         }
+
+        if (filteredParticipants.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                Text(text = stringResource(R.string.chat_search_no_results))
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = 16.dp)
+            ) {
+                items(
+                    filteredParticipants,
+                    key = { participant ->
+                        participant.user.userId
+                            ?: participant.user.nickname
+                            ?: participant.user.fullName
+                            ?: participant.hashCode().toString()
+                    }
+                ) { participant ->
+                    ParticipantRow(
+                        participant = participant,
+                        isCurrentUserAdmin = isCurrentUserAdmin,
+                        onMoreClick = onParticipantMoreClick
+                    )
+                    Divider(color = Color(0xFFEAEAF2))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ParticipantRow(
+    participant: Participant,
+    isCurrentUserAdmin: Boolean,
+    onMoreClick: (Participant) -> Unit,
+) {
+    val canManageParticipant = isCurrentUserAdmin &&
+        !participant.isCurrentUser &&
+        !participant.isOwner &&
+        participant.user.userId != null
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Avatar(
+            participant.user.image,
+            participant.user.fullName,
+            size = 44.dp
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = participant.user.fullName.orEmpty(),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp,
+                color = Color.Black
+            )
+            if (participant.isOwner) {
+                Text(
+                    text = stringResource(R.string.chat_group_owner_label),
+                    color = Color(0xFF2E83D9),
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 12.sp,
+                )
+            } else if (participant.isAdmin) {
+                Text(
+                    text = stringResource(R.string.chat_group_admin_label),
+                    color = Color(0xFF2E83D9),
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 12.sp,
+                )
+            }
+            participant.status?.takeIf { it.isNotBlank() }?.let { status ->
+                Text(
+                    text = status,
+                    fontSize = 12.sp,
+                    color = Color(0xFF8083A0)
+                )
+            }
+        }
+
+        if (canManageParticipant) {
+            IconButton(onClick = { onMoreClick(participant) }) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = null,
+                    tint = Color(0xFFB0B2C3)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ParticipantActionsBottomSheet(
+    participant: Participant,
+    onDismissRequest: () -> Unit,
+    onGrantAdminClick: () -> Unit,
+    onRevokeAdminClick: () -> Unit,
+    onRemoveClick: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.chat_group_participant_actions_title),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (!participant.isOwner) {
+                if (participant.isAdmin) {
+                    ParticipantActionRow(
+                        text = stringResource(R.string.chat_group_remove_admin),
+                        onClick = {
+                            onRevokeAdminClick()
+                            onDismissRequest()
+                        }
+                    )
+                } else {
+                    ParticipantActionRow(
+                        text = stringResource(R.string.chat_group_make_admin),
+                        onClick = {
+                            onGrantAdminClick()
+                            onDismissRequest()
+                        }
+                    )
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+
+                ParticipantActionRow(
+                    text = stringResource(R.string.chat_group_remove_participant),
+                    textColor = Color(0xFFFF3B30),
+                    onClick = {
+                        onRemoveClick()
+                        onDismissRequest()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ParticipantActionRow(
+    text: String,
+    textColor: Color = Color.Black,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) { onClick() }
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = text,
+            color = textColor,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium
+        )
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -157,6 +157,15 @@
   <string name="chat_group_tab_files">Файлы</string>
   <string name="chat_group_info_title">Информация</string>
   <string name="chat_group_initial">Г</string>
+  <string name="chat_group_search_hint">Поиск участников</string>
+  <string name="chat_group_add_participant">Добавить участника</string>
+  <string name="chat_group_participant_actions_title">Действия с участником</string>
+  <string name="chat_group_make_admin">Назначить администратором</string>
+  <string name="chat_group_remove_admin">Снять права администратора</string>
+  <string name="chat_group_remove_participant">Удалить из группы</string>
+  <string name="chat_group_owner_label">Владелец</string>
+  <string name="chat_group_admin_label">Админ</string>
+  <string name="chat_group_tab_participants_count">Участники %1$d</string>
   <string name="chat_detail_tab_messages">Сообщения</string>
   <string name="chat_detail_tab_media">Медиа</string>
   <string name="chat_detail_tab_files">Файлы</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,6 +235,15 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_group_tab_files">Files</string>
     <string name="chat_group_info_title">Information</string>
     <string name="chat_group_initial">G</string>
+    <string name="chat_group_search_hint">Search participants</string>
+    <string name="chat_group_add_participant">Add participant</string>
+    <string name="chat_group_participant_actions_title">Participant actions</string>
+    <string name="chat_group_make_admin">Make admin</string>
+    <string name="chat_group_remove_admin">Remove admin rights</string>
+    <string name="chat_group_remove_participant">Remove from group</string>
+    <string name="chat_group_owner_label">Owner</string>
+    <string name="chat_group_admin_label">Admin</string>
+    <string name="chat_group_tab_participants_count">Participants %1$d</string>
     <string name="chat_detail_tab_messages">Messages</string>
     <string name="chat_detail_tab_media">Media</string>
     <string name="chat_detail_tab_files">Files</string>


### PR DESCRIPTION
## Summary
- add admin search bar and entry point to invite participants from the group detail screen
- surface admin/owner badges with a contextual actions sheet for participant management
- extend the group detail view model and string resources to support the new UI states

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd289630ec832796efb2c9af922a11