### PR TITLE
Protect chat socket models from obfuscation

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -45,3 +45,13 @@
   **[] $VALUES;
   public *;
 }
+
+# Preserve chat socket payload models that are (de)serialised with Gson.
+# These classes are parsed from runtime JSON messages, therefore their
+# fields must not be obfuscated or removed.
+-keep class uddug.com.domain.entities.chat.ChatSocketMessage { *; }
+-keep class uddug.com.domain.entities.chat.FileDescriptor { *; }
+-keep class uddug.com.domain.entities.chat.AnswerPreview { *; }
+-keep class uddug.com.domain.entities.chat.PreviewOwner { *; }
+-keep class uddug.com.domain.entities.chat.PreviewFile { *; }
+-keep class uddug.com.domain.entities.chat.PreviewFileStat { *; }


### PR DESCRIPTION
## Summary
- keep the chat socket payload data classes from being obfuscated so Gson can parse runtime socket messages
- prevent crashes when handling chat attachments that rely on these payloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd30d046a883278dd4a05467c55702