### PR TITLE
Fix reply and edit indicators in chat input bar

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatInputBar.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -389,6 +390,7 @@ fun ChatInputBar(
 
 @Composable
 private fun ReplyInfoBlock(reply: MessageChat, onCancelReply: () -> Unit) {
+    val iconColor = Color(0XFF8083A0)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -396,16 +398,30 @@ private fun ReplyInfoBlock(reply: MessageChat, onCancelReply: () -> Unit) {
             .padding(horizontal = 8.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_chat_reply),
+            contentDescription = null,
+            tint = iconColor
+        )
+        Image(
+            painter = painterResource(id = R.drawable.ic_chat_separator),
+            contentDescription = null,
+            modifier = Modifier
+                .padding(horizontal = 12.dp)
+                .width(2.dp)
+                .height(24.dp),
+            colorFilter = ColorFilter.tint(iconColor)
+        )
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = reply.ownerName ?: "",
-                color = Color(0XFF8083A0),
+                color = iconColor,
                 fontWeight = FontWeight.Bold,
                 fontSize = 12.sp
             )
             Text(
                 text = reply.text.orEmpty(),
-                color = Color(0XFF8083A0),
+                color = iconColor,
                 fontSize = 12.sp,
                 maxLines = 1
             )
@@ -431,16 +447,18 @@ private fun EditInfoBlock(message: MessageChat, onCancelEdit: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
-            imageVector = Icons.Filled.Create,
+            painter = painterResource(id = R.drawable.ic_chat_edit),
             contentDescription = null,
             tint = accentColor
         )
-        Box(
+        Image(
+            painter = painterResource(id = R.drawable.ic_chat_separator),
+            contentDescription = null,
             modifier = Modifier
                 .padding(horizontal = 12.dp)
                 .width(2.dp)
-                .height(24.dp)
-                .background(accentColor)
+                .height(24.dp),
+            colorFilter = ColorFilter.tint(accentColor)
         )
         Column(modifier = Modifier.weight(1f)) {
             Text(

--- a/app/src/main/res/drawable/ic_chat_edit.xml
+++ b/app/src/main/res/drawable/ic_chat_edit.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/app/src/main/res/drawable/ic_chat_reply.xml
+++ b/app/src/main/res/drawable/ic_chat_reply.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,9V5L3,12l7,7v-4.1c6.41,0 10.34,2.02 12,6.1 -1.2,-6 -5.08,-10.9 -12,-12Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_chat_separator.xml
+++ b/app/src/main/res/drawable/ic_chat_separator.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="2dp"
+    android:height="24dp"
+    android:viewportWidth="2"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M1,0L1,24"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round" />
+</vector>


### PR DESCRIPTION
## Summary
- replace the reply and edit info blocks with the proper chat icons and separator resources
- add new vector drawables for the reply, edit, and separator icons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3433e93483279591f42e1e64fd02