### PR TITLE
Show file name in chat preview

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -151,7 +151,7 @@ fun ChatCard(
                         attachmentPreview != null -> when (attachmentPreview.type) {
                             ChatAttachmentType.IMAGE -> stringResource(R.string.chat_last_message_image)
                             ChatAttachmentType.VIDEO -> stringResource(R.string.chat_last_message_video)
-                            ChatAttachmentType.FILE -> stringResource(R.string.chat_last_message_file)
+                            ChatAttachmentType.FILE -> message
                         }
                         !isGroupChat && isFromMe -> stringResource(R.string.chat_last_message_from_me, message)
                         else -> message


### PR DESCRIPTION
## Summary
- display the actual file name in chat preview cards instead of a generic label for file attachments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3cd595f083278cad1bf4fe08ef84