### PR TITLE
Adjust reply card appearance and navigation

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -215,6 +215,9 @@ fun ChatDialogComponent(
 
                 is ChatDialogUiState.Success -> {
                     val messages = state.chats
+                    val messageIndexById = remember(messages) {
+                        messages.mapIndexed { index, message -> message.id to index }.toMap()
+                    }
 
                     LaunchedEffect(messages.size) {
                         if (messages.isNotEmpty()) {
@@ -297,7 +300,14 @@ fun ChatDialogComponent(
                                 selectionMode = isSelectionMode,
                                 isSelected = selectedMessages.contains(message.id),
                                 onSelectChange = { viewModel.toggleMessageSelection(message.id) },
-                                onLongPress = { selectedMessage = it }
+                                onLongPress = { selectedMessage = it },
+                                onReplyReferenceClick = { targetId ->
+                                    messageIndexById[targetId]?.let { index ->
+                                        scope.launch {
+                                            scrollState.animateScrollToItem(index)
+                                        }
+                                    }
+                                }
                             )
                         }
                     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -71,6 +71,7 @@ fun ChatMessageItem(
     isSelected: Boolean = false,
     onSelectChange: () -> Unit = {},
     onLongPress: (MessageChat) -> Unit,
+    onReplyReferenceClick: (Long) -> Unit = {},
 ) {
     val isSystem = message.type == MessageType.SYSTEM
     Row(
@@ -166,7 +167,8 @@ fun ChatMessageItem(
                 if (message.replyTo != null) {
                     ReplyBlock(
                         reply = message.replyTo!!,
-                        isMine = isMine
+                        isMine = isMine,
+                        onReplyClick = onReplyReferenceClick
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ReplyBlock.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ReplyBlock.kt
@@ -1,6 +1,7 @@
 package uddug.com.naukoteka.ui.chat.compose.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -10,13 +11,9 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.sharp.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +33,7 @@ fun ReplyBlock(
     isMine: Boolean,
     modifier: Modifier = Modifier,
     backgroundColor: Color? = null,
+    onReplyClick: (Long) -> Unit = {},
 ) {
     val resolvedBackgroundColor = backgroundColor ?: if (isMine) {
         Color.White.copy(alpha = 0.1f)
@@ -46,21 +44,13 @@ fun ReplyBlock(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .clickable { onReplyClick(reply.id) }
             .clip(RoundedCornerShape(8.dp))
             .background(resolvedBackgroundColor)
             .height(IntrinsicSize.Min)
             .padding(horizontal = 8.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Icon(
-            imageVector = Icons.Sharp.Share,
-            contentDescription = null,
-            tint = Color(0xFF2E83D9),
-            modifier = Modifier.size(16.dp)
-        )
-
-        Spacer(modifier = Modifier.width(8.dp))
-
         Box(
             modifier = Modifier
                 .fillMaxHeight()
@@ -75,9 +65,9 @@ fun ReplyBlock(
             Text(
                 text = reply.ownerName?.takeIf { it.isNotBlank() }
                     ?: stringResource(R.string.chat_reply_default_author),
-                color = Color(0xFF2E83D9),
+                color = if (isMine) Color.White else Color(0xFF2E83D9),
                 fontWeight = FontWeight.SemiBold,
-                fontSize = 12.sp,
+                fontSize = 14.sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )


### PR DESCRIPTION
## Summary
- update the reply block styling to match the forwarded message design and make it clickable
- pass reply click callbacks from chat message items
- scroll to the original message when tapping the reply preview when it exists

## Testing
- ./gradlew :app:lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3c530dcc83278c42f2f982f4d9d8