### PR TITLE
Fix chat dialog avatar handling

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -122,7 +122,7 @@ class ChatDialogViewModel @Inject constructor(
                             }
                             val image: String = when {
                                 info.interlocutor != null -> info.interlocutor?.image.orEmpty()
-                                else -> info.name.orEmpty()
+                                else -> info.dialogImage?.path.orEmpty()
                             }
                             val firstParticipantName = info.users?.firstOrNull()?.fullName.orEmpty()
                             var status: String? = null
@@ -199,10 +199,14 @@ class ChatDialogViewModel @Inject constructor(
                             val dialogId = info.id
 
                             val name = info.interlocutor?.fullName.orEmpty()
-                            val image = info.interlocutor?.image.orEmpty()
+                            val isGroup = (info.users?.size ?: 0) > 2
+                            val image = if (isGroup) {
+                                info.dialogImage?.path.orEmpty()
+                            } else {
+                                info.interlocutor?.image.orEmpty()
+                            }
                             val firstParticipantName = info.users?.firstOrNull()?.fullName.orEmpty()
                             var status: String? = null
-                            val isGroup = (info.users?.size ?: 0) > 2
                             if (!isGroup) {
                                 val userId = info.interlocutor?.userId
                                 if (userId != null) {


### PR DESCRIPTION
## Summary
- ensure chat dialog view model uses the dialog image when no interlocutor avatar is available
- handle group dialogs opened by peer ids by preferring the dialog image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd3d6570648327b1e7be829df54f03