### PR TITLE
Implement admin actions for group chats

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatEditGroupViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatEditGroupViewModel.kt
@@ -1,0 +1,311 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.rx2.await
+import uddug.com.domain.entities.chat.DialogInfo
+import uddug.com.domain.entities.profile.Image
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.domain.interactors.chat.ChatInteractor
+import uddug.com.domain.repositories.user_profile.UserProfileRepository
+import uddug.com.naukoteka.mvvm.chat.ChatStatusTextMode.GENERIC
+import java.io.File
+import java.time.Instant
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatEditGroupViewModel @Inject constructor(
+    private val chatInteractor: ChatInteractor,
+    private val userProfileRepository: UserProfileRepository,
+    private val chatStatusFormatter: ChatStatusFormatter,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val dialogId: Long = savedStateHandle.get<Long>(DIALOG_ID_KEY) ?: 0L
+
+    private val _uiState = MutableStateFlow<ChatEditGroupUiState>(ChatEditGroupUiState.Loading)
+    val uiState: StateFlow<ChatEditGroupUiState> = _uiState
+
+    private val _events = MutableSharedFlow<ChatEditGroupEvent>()
+    val events: SharedFlow<ChatEditGroupEvent> = _events.asSharedFlow()
+
+    private var currentUser: UserProfileFullInfo? = null
+    private var initialName: String = ""
+    private var initialAvatarId: String? = null
+    private var initialMembers: Set<String> = emptySet()
+
+    init {
+        if (dialogId == 0L) {
+            _uiState.value = ChatEditGroupUiState.Error("Dialog not found")
+        } else {
+            loadDialogInfo()
+        }
+    }
+
+    private fun loadDialogInfo() {
+        viewModelScope.launch {
+            try {
+                val profile = withContext(Dispatchers.IO) {
+                    userProfileRepository.getProfileInfo().await()
+                }
+                currentUser = profile
+                val dialogInfo = chatInteractor.getDialogInfo(dialogId)
+                applyDialogInfo(dialogInfo)
+            } catch (e: Exception) {
+                _uiState.value = ChatEditGroupUiState.Error(e.message ?: "Error")
+            }
+        }
+    }
+
+    private suspend fun applyDialogInfo(dialogInfo: DialogInfo) {
+        val currentUserId = currentUser?.id
+        val members = dialogInfo.users.orEmpty().map { user ->
+            val userProfile = UserProfileFullInfo(
+                id = user.userId,
+                fullName = user.fullName,
+                nickname = user.nickname,
+                image = Image(path = user.image)
+            )
+            val isCreator = user.userId != null && user.userId == currentUserId
+            val isAdmin = user.isAdmin || isAdminRole(user.role) || isOwnerRole(user.role)
+            GroupMember(
+                user = userProfile,
+                isCreator = isCreator,
+                isAdmin = isAdmin,
+            )
+        }
+        val membersWithStatus = enrichWithStatuses(members)
+        initialName = dialogInfo.name.orEmpty()
+        initialAvatarId = dialogInfo.dialogImage?.id
+        initialMembers = membersWithStatus
+            .filterNot { it.isCreator }
+            .mapNotNull { it.user.id }
+            .toSet()
+        _uiState.value = ChatEditGroupUiState.Success(
+            groupName = dialogInfo.name.orEmpty(),
+            members = membersWithStatus,
+            avatarPath = dialogInfo.dialogImage?.path,
+            avatarId = dialogInfo.dialogImage?.id,
+            isSaving = false,
+            isAvatarUploading = false,
+            isAvatarRemoved = false,
+        )
+    }
+
+    fun onGroupNameChanged(name: String) {
+        val current = _uiState.value
+        if (current is ChatEditGroupUiState.Success) {
+            val trimmed = name.take(MAX_GROUP_NAME_LENGTH)
+            _uiState.value = current.copy(groupName = trimmed)
+        }
+    }
+
+    fun onAvatarSelected(file: File) {
+        val current = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        if (current.isAvatarUploading) return
+        _uiState.value = current.copy(isAvatarUploading = true, isAvatarRemoved = false)
+        viewModelScope.launch {
+            try {
+                val uploaded = withContext(Dispatchers.IO) {
+                    chatInteractor.uploadFiles(listOf(file), raw = false)
+                }
+                val uploadedFile = uploaded.firstOrNull()
+                val latestState = _uiState.value as? ChatEditGroupUiState.Success
+                if (uploadedFile != null && latestState != null) {
+                    _uiState.value = latestState.copy(
+                        avatarPath = uploadedFile.path,
+                        avatarId = uploadedFile.id,
+                        isAvatarUploading = false,
+                        isAvatarRemoved = false,
+                    )
+                } else {
+                    resetAvatarUploading()
+                    _events.emit(ChatEditGroupEvent.ShowImageUploadError)
+                }
+            } catch (e: Exception) {
+                resetAvatarUploading()
+                _events.emit(ChatEditGroupEvent.ShowError(e.message ?: "Error"))
+            }
+        }
+    }
+
+    private suspend fun resetAvatarUploading() {
+        val latestState = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        _uiState.value = latestState.copy(isAvatarUploading = false)
+    }
+
+    fun onRemoveAvatar() {
+        val current = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        if (current.avatarPath == null && current.avatarId == null) return
+        _uiState.value = current.copy(
+            avatarPath = null,
+            avatarId = null,
+            isAvatarRemoved = true,
+        )
+    }
+
+    fun onRemoveMember(memberId: String) {
+        updateMembers { members ->
+            members.filterNot { member ->
+                member.user.id == memberId && !member.isCreator
+            }
+        }
+    }
+
+    fun onMembersSelected(users: List<UserProfileFullInfo>) {
+        val current = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        val existingIds = current.members.mapNotNull { it.user.id }.toSet()
+        val filtered = users.filter { user ->
+            val id = user.id
+            id != null && id != currentUser?.id && !existingIds.contains(id)
+        }
+        if (filtered.isEmpty()) return
+        viewModelScope.launch {
+            val currentState = _uiState.value as? ChatEditGroupUiState.Success ?: return@launch
+            val newMembers = filtered.map { user ->
+                GroupMember(
+                    user = user,
+                    isCreator = user.id == currentUser?.id,
+                    isAdmin = false,
+                )
+            }
+            val enriched = enrichWithStatuses(currentState.members + newMembers)
+            _uiState.value = currentState.copy(members = enriched)
+        }
+    }
+
+    fun onSaveChanges() {
+        val current = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        if (current.isSaving || current.isAvatarUploading) return
+        val participants = current.members.filterNot { it.isCreator }
+        if (participants.size < MIN_MEMBERS) {
+            viewModelScope.launch { _events.emit(ChatEditGroupEvent.ShowMissingParticipantsError) }
+            return
+        }
+
+        val trimmedName = current.groupName.trim()
+        val nameToSend = trimmedName.takeIf { it.isNotBlank() && it != initialName }
+        val participantsIds = participants.mapNotNull { it.user.id }
+        val usersToSend = if (participantsIds.toSet() != initialMembers) participantsIds else null
+        val clearImage = current.isAvatarRemoved && !initialAvatarId.isNullOrEmpty()
+        val imageIdToSend = current.avatarId?.takeIf { !current.isAvatarRemoved && it != initialAvatarId }
+
+        if (nameToSend == null && usersToSend == null && !clearImage && imageIdToSend == null) {
+            viewModelScope.launch {
+                val info = runCatching { chatInteractor.getDialogInfo(dialogId) }.getOrNull()
+                if (info != null) {
+                    applyDialogInfo(info)
+                    _events.emit(ChatEditGroupEvent.GroupUpdated(info))
+                } else {
+                    _events.emit(ChatEditGroupEvent.GroupUpdated(null))
+                }
+            }
+            return
+        }
+
+        _uiState.value = current.copy(isSaving = true)
+
+        viewModelScope.launch {
+            try {
+                val updatedInfo = chatInteractor.updateDialog(
+                    dialogId = dialogId,
+                    name = nameToSend,
+                    imageId = imageIdToSend,
+                    clearImage = clearImage,
+                    users = usersToSend,
+                )
+                applyDialogInfo(updatedInfo)
+                _events.emit(ChatEditGroupEvent.GroupUpdated(updatedInfo))
+            } catch (e: Exception) {
+                val latestState = _uiState.value as? ChatEditGroupUiState.Success
+                if (latestState != null) {
+                    _uiState.value = latestState.copy(isSaving = false)
+                }
+                _events.emit(ChatEditGroupEvent.ShowError(e.message ?: "Error"))
+            }
+        }
+    }
+
+    private fun updateMembers(transform: (List<GroupMember>) -> List<GroupMember>) {
+        val current = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        val updated = transform(current.members)
+        _uiState.value = current.copy(members = updated)
+    }
+
+    private suspend fun enrichWithStatuses(members: List<GroupMember>): List<GroupMember> {
+        val userIds = members.mapNotNull { it.user.id }
+        if (userIds.isEmpty()) return members
+        val statusMap = runCatching {
+            withContext(Dispatchers.IO) { chatInteractor.getUsersStatus(userIds) }
+                .associateBy { it.userId }
+        }.getOrElse { emptyMap() }
+        if (statusMap.isEmpty()) return members
+        return members.map { member ->
+            val status = member.user.id?.let { id -> statusMap[id] }
+            val statusText = status?.let {
+                if (it.isOnline) {
+                    chatStatusFormatter.online()
+                } else {
+                    it.lastSeen?.let { lastSeen ->
+                        runCatching { Instant.parse(lastSeen) }
+                            .map { instant -> chatStatusFormatter.formatLastSeen(instant, GENERIC) }
+                            .getOrNull()
+                    }
+                }
+            }
+            member.copy(status = statusText)
+        }
+    }
+
+    private fun isOwnerRole(role: String?): Boolean {
+        if (role.isNullOrBlank()) return false
+        val normalized = role.lowercase()
+        return normalized == ROLE_OWNER || normalized.contains("owner") || normalized.contains("влад")
+    }
+
+    private fun isAdminRole(role: String?): Boolean {
+        if (role.isNullOrBlank()) return false
+        val normalized = role.lowercase()
+        return normalized == ROLE_ADMIN || normalized.contains("admin") || normalized.contains("админ")
+    }
+
+    companion object {
+        const val DIALOG_ID_KEY = "dialog_id"
+        private const val MAX_GROUP_NAME_LENGTH = 100
+        private const val MIN_MEMBERS = 2
+        private const val ROLE_OWNER = "37:201"
+        private const val ROLE_ADMIN = "37:202"
+    }
+}
+
+sealed class ChatEditGroupUiState {
+    object Loading : ChatEditGroupUiState()
+    data class Success(
+        val groupName: String,
+        val members: List<GroupMember>,
+        val avatarPath: String?,
+        val avatarId: String?,
+        val isSaving: Boolean,
+        val isAvatarUploading: Boolean,
+        val isAvatarRemoved: Boolean,
+    ) : ChatEditGroupUiState()
+
+    data class Error(val message: String) : ChatEditGroupUiState()
+}
+
+sealed class ChatEditGroupEvent {
+    data class GroupUpdated(val dialogInfo: DialogInfo?) : ChatEditGroupEvent()
+    data class ShowError(val message: String) : ChatEditGroupEvent()
+    object ShowImageUploadError : ChatEditGroupEvent()
+    object ShowMissingParticipantsError : ChatEditGroupEvent()
+}

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.withContext
@@ -13,6 +16,7 @@ import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.User
 import uddug.com.domain.interactors.chat.ChatInteractor
+import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.domain.repositories.user_profile.UserProfileRepository
 import uddug.com.naukoteka.mvvm.chat.ChatStatusFormatter
 import uddug.com.naukoteka.mvvm.chat.ChatStatusTextMode.GENERIC
@@ -35,6 +39,10 @@ class ChatGroupDetailViewModel @Inject constructor(
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery
 
+    private val _events = MutableSharedFlow<ChatGroupDetailEvent>()
+    val events: SharedFlow<ChatGroupDetailEvent> = _events.asSharedFlow()
+
+    private var dialogId: Long? = null
     private var currentUserId: String? = null
 
     fun selectTab(index: Int) {
@@ -42,6 +50,7 @@ class ChatGroupDetailViewModel @Inject constructor(
     }
 
     fun loadDialogInfo(dialogId: Long) {
+        this.dialogId = dialogId
         viewModelScope.launch {
             try {
                 _searchQuery.value = ""
@@ -57,6 +66,7 @@ class ChatGroupDetailViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 _searchQuery.value = ""
+                dialogId = dialogInfo.id
                 val currentUser = withContext(Dispatchers.IO) {
                     userProfileRepository.getProfileInfo().await()
                 }
@@ -83,6 +93,11 @@ class ChatGroupDetailViewModel @Inject constructor(
                 val userIds = users.mapNotNull { it.userId }
                 val statuses = if (userIds.isNotEmpty()) chatInteractor.getUsersStatus(userIds) else emptyList()
                 val statusMap = statuses.associateBy { it.userId }
+                val notificationsDisabled = runCatching {
+                    withContext(Dispatchers.IO) {
+                        chatInteractor.getDialogs()
+                    }.firstOrNull { it.dialogId == dialogInfo.id }?.notificationsDisable ?: false
+                }.getOrDefault(false)
                 val participants = users.map { user ->
                     val status = statusMap[user.userId]
                     val statusText = status?.let {
@@ -107,6 +122,7 @@ class ChatGroupDetailViewModel @Inject constructor(
                     files = files,
                     dialogId = dialogInfo.id,
                     isCurrentUserAdmin = isCurrentUserAdmin,
+                    notificationsDisabled = notificationsDisabled,
                 )
             } catch (e: Exception) {
                 _uiState.value = ChatGroupDetailUiState.Error(e.message ?: "Error")
@@ -122,48 +138,150 @@ class ChatGroupDetailViewModel @Inject constructor(
         _searchQuery.value = ""
     }
 
-    fun grantAdmin(userId: String) {
-        updateParticipants {
-            it.map { participant ->
-                if (participant.user.userId == userId && !participant.isOwner) {
-                    val updatedUser = participant.user.copy(isAdmin = true)
-                    participant.copy(user = updatedUser, isAdmin = true)
+    fun refreshDialogInfo() {
+        dialogId?.let { loadDialogInfo(it) }
+    }
+
+    fun toggleNotifications() {
+        val currentState = _uiState.value as? ChatGroupDetailUiState.Success ?: return
+        viewModelScope.launch {
+            try {
+                if (currentState.notificationsDisabled) {
+                    chatInteractor.enableNotifications(currentState.dialogId)
+                    val latestState = _uiState.value as? ChatGroupDetailUiState.Success ?: return@launch
+                    _uiState.value = latestState.copy(notificationsDisabled = false)
+                    _events.emit(ChatGroupDetailEvent.NotificationsUpdated(false))
                 } else {
-                    participant
+                    chatInteractor.disableNotifications(currentState.dialogId)
+                    val latestState = _uiState.value as? ChatGroupDetailUiState.Success ?: return@launch
+                    _uiState.value = latestState.copy(notificationsDisabled = true)
+                    _events.emit(ChatGroupDetailEvent.NotificationsUpdated(true))
                 }
+            } catch (e: Exception) {
+                _events.emit(ChatGroupDetailEvent.ShowError(e.message ?: "Error"))
+            }
+        }
+    }
+
+    fun deleteGroup() {
+        val currentState = _uiState.value as? ChatGroupDetailUiState.Success ?: return
+        if (!currentState.isCurrentUserAdmin) return
+        viewModelScope.launch {
+            try {
+                chatInteractor.deleteGroupDialog(currentState.dialogId)
+                _events.emit(ChatGroupDetailEvent.GroupDeleted)
+            } catch (e: Exception) {
+                _events.emit(ChatGroupDetailEvent.ShowError(e.message ?: "Error"))
+            }
+        }
+    }
+
+    fun grantAdmin(userId: String) {
+        val currentState = _uiState.value as? ChatGroupDetailUiState.Success ?: return
+        if (!currentState.isCurrentUserAdmin) return
+        viewModelScope.launch {
+            try {
+                chatInteractor.makeDialogAdmin(currentState.dialogId, userId)
+                val latestState = _uiState.value as? ChatGroupDetailUiState.Success ?: return@launch
+                val updatedParticipants = latestState.participants.map { participant ->
+                    if (participant.user.userId == userId && !participant.isOwner) {
+                        val updatedUser = participant.user.copy(isAdmin = true)
+                        participant.copy(user = updatedUser, isAdmin = true)
+                    } else {
+                        participant
+                    }
+                }
+                _uiState.value = latestState.copy(
+                    participants = updatedParticipants,
+                    isCurrentUserAdmin = isCurrentUserAdmin(updatedParticipants)
+                )
+            } catch (e: Exception) {
+                _events.emit(ChatGroupDetailEvent.ShowError(e.message ?: "Error"))
             }
         }
     }
 
     fun revokeAdmin(userId: String) {
-        updateParticipants {
-            it.map { participant ->
-                if (participant.user.userId == userId && participant.isAdmin && !participant.isOwner) {
-                    val updatedUser = participant.user.copy(isAdmin = false)
-                    participant.copy(user = updatedUser, isAdmin = false)
-                } else {
-                    participant
+        val currentState = _uiState.value as? ChatGroupDetailUiState.Success ?: return
+        if (!currentState.isCurrentUserAdmin) return
+        viewModelScope.launch {
+            try {
+                chatInteractor.removeDialogAdmin(currentState.dialogId, userId)
+                val latestState = _uiState.value as? ChatGroupDetailUiState.Success ?: return@launch
+                val updatedParticipants = latestState.participants.map { participant ->
+                    if (participant.user.userId == userId && participant.isAdmin && !participant.isOwner) {
+                        val updatedUser = participant.user.copy(isAdmin = false)
+                        participant.copy(user = updatedUser, isAdmin = false)
+                    } else {
+                        participant
+                    }
                 }
+                _uiState.value = latestState.copy(
+                    participants = updatedParticipants,
+                    isCurrentUserAdmin = isCurrentUserAdmin(updatedParticipants)
+                )
+            } catch (e: Exception) {
+                _events.emit(ChatGroupDetailEvent.ShowError(e.message ?: "Error"))
             }
         }
     }
 
     fun removeParticipant(userId: String) {
-        updateParticipants { participants ->
-            participants.filterNot { participant ->
-                participant.user.userId == userId && !participant.isOwner
+        val currentState = _uiState.value as? ChatGroupDetailUiState.Success ?: return
+        if (!currentState.isCurrentUserAdmin) return
+        val updatedParticipants = currentState.participants.filterNot { participant ->
+            participant.user.userId == userId && !participant.isOwner
+        }
+        if (updatedParticipants.size == currentState.participants.size) return
+        viewModelScope.launch {
+            try {
+                val users = updatedParticipants
+                    .filterNot { it.isCurrentUser }
+                    .mapNotNull { it.user.userId }
+                chatInteractor.updateDialog(currentState.dialogId, users = users)
+                _uiState.value = currentState.copy(
+                    participants = updatedParticipants,
+                    isCurrentUserAdmin = isCurrentUserAdmin(updatedParticipants)
+                )
+            } catch (e: Exception) {
+                _events.emit(ChatGroupDetailEvent.ShowError(e.message ?: "Error"))
             }
         }
     }
 
-    private fun updateParticipants(transform: (List<Participant>) -> List<Participant>) {
+    fun addParticipants(members: List<UserProfileFullInfo>) {
         val currentState = _uiState.value as? ChatGroupDetailUiState.Success ?: return
         if (!currentState.isCurrentUserAdmin) return
-        val updatedParticipants = transform(currentState.participants)
-        _uiState.value = currentState.copy(
-            participants = updatedParticipants,
-            isCurrentUserAdmin = isCurrentUserAdmin(updatedParticipants)
-        )
+        val existingIds = currentState.participants
+            .mapNotNull { it.user.userId }
+            .toMutableSet()
+        val selfId = currentUserId
+        val newIds = members.mapNotNull { user ->
+            val userId = user.id
+            if (userId == null || userId == selfId || existingIds.contains(userId)) {
+                null
+            } else {
+                existingIds.add(userId)
+                userId
+            }
+        }
+        if (newIds.isEmpty()) return
+        viewModelScope.launch {
+            try {
+                val users = currentState.participants
+                    .filterNot { it.isCurrentUser }
+                    .mapNotNull { it.user.userId }
+                    .toMutableSet()
+                users.addAll(newIds)
+                val updatedDialog = chatInteractor.updateDialog(
+                    dialogId = currentState.dialogId,
+                    users = users.toList()
+                )
+                setDialogInfo(updatedDialog)
+            } catch (e: Exception) {
+                _events.emit(ChatGroupDetailEvent.ShowError(e.message ?: "Error"))
+            }
+        }
     }
 
     private fun createParticipant(user: User, statusText: String?): Participant {
@@ -215,6 +333,7 @@ sealed class ChatGroupDetailUiState {
         val files: List<MediaMessage>,
         val dialogId: Long,
         val isCurrentUserAdmin: Boolean,
+        val notificationsDisabled: Boolean,
     ) : ChatGroupDetailUiState()
 
     data class Error(val message: String) : ChatGroupDetailUiState()
@@ -227,3 +346,9 @@ data class Participant(
     val isOwner: Boolean,
     val isCurrentUser: Boolean,
 )
+
+sealed class ChatGroupDetailEvent {
+    data class ShowError(val message: String) : ChatGroupDetailEvent()
+    data class NotificationsUpdated(val disabled: Boolean) : ChatGroupDetailEvent()
+    object GroupDeleted : ChatGroupDetailEvent()
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
@@ -7,11 +7,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
+import android.widget.Toast
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import androidx.core.os.bundleOf
-import android.widget.Toast
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -19,6 +19,7 @@ import kotlinx.coroutines.launch
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatCreateMultiEvent
 import uddug.com.naukoteka.mvvm.chat.ChatCreateMultiViewModel
+import uddug.com.naukoteka.mvvm.chat.MIN_SELECTION_KEY
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatCreateMultiScreen
 import uddug.com.naukoteka.ui.chat.ChatCreateGroupFragment
@@ -40,6 +41,9 @@ class ChatCreateMultiFragment : Fragment() {
         navigationView?.showNavigationBottomBar(true)
     }
 
+    private val mode: String
+        get() = arguments?.getString(MODE_ARG) ?: MODE_CREATE
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
@@ -50,15 +54,26 @@ class ChatCreateMultiFragment : Fragment() {
             viewModel.events.collectLatest { event ->
                 when (event) {
                     is ChatCreateMultiEvent.OpenGroupDetails -> {
-                        val args = bundleOf(
-                            ChatCreateGroupFragment.SELECTED_USERS_ARG to ArrayList(event.selectedUsers)
-                        )
-                        findNavController().navigate(R.id.chatCreateGroupFragment, args)
+                        if (mode == MODE_EDIT) {
+                            findNavController().previousBackStackEntry?.savedStateHandle
+                                ?.set(ChatEditGroupFragment.SELECTED_USERS_ARG, ArrayList(event.selectedUsers))
+                            findNavController().popBackStack()
+                        } else {
+                            val args = bundleOf(
+                                ChatCreateGroupFragment.SELECTED_USERS_ARG to ArrayList(event.selectedUsers)
+                            )
+                            findNavController().navigate(R.id.chatCreateGroupFragment, args)
+                        }
                     }
-                    ChatCreateMultiEvent.ShowMinimumMembersError -> {
+                    is ChatCreateMultiEvent.ShowMinimumMembersError -> {
+                        val messageRes = if (event.minSelection <= 1) {
+                            R.string.chat_edit_group_min_selection_error
+                        } else {
+                            R.string.chat_create_group_min_members_error
+                        }
                         Toast.makeText(
                             requireContext(),
-                            R.string.chat_create_group_min_members_error,
+                            messageRes,
                             Toast.LENGTH_SHORT
                         ).show()
                     }
@@ -72,16 +87,30 @@ class ChatCreateMultiFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
+        val titleRes = if (mode == MODE_EDIT) {
+            R.string.chat_edit_group_add_members_title
+        } else {
+            R.string.chat_create_single_title
+        }
+
         return ComposeView(requireContext()).apply {
             setContent {
                 MaterialTheme {
                     ChatCreateMultiScreen(
                         viewModel = viewModel,
-                        onBackPressed = { findNavController().popBackStack() }
+                        onBackPressed = { findNavController().popBackStack() },
+                        titleRes = titleRes
                     )
                 }
             }
         }
+    }
+
+    companion object {
+        const val MODE_ARG = "chat_create_multi_mode"
+        const val MODE_CREATE = "create"
+        const val MODE_EDIT = "edit"
+        const val MIN_SELECTION_ARG = MIN_SELECTION_KEY
     }
 }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditGroupFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditGroupFragment.kt
@@ -1,0 +1,126 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatEditGroupEvent
+import uddug.com.naukoteka.mvvm.chat.ChatEditGroupViewModel
+import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
+import uddug.com.naukoteka.ui.chat.compose.ChatEditGroupScreen
+
+@AndroidEntryPoint
+class ChatEditGroupFragment : Fragment() {
+
+    private val viewModel: ChatEditGroupViewModel by viewModels()
+
+    private var navigationView: ContainerNavigationView? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        navigationView = requireActivity() as? ContainerNavigationView
+    }
+
+    override fun onResume() {
+        super.onResume()
+        navigationView?.showNavigationBottomBar(false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        lifecycleScope.launch {
+            viewModel.events.collectLatest { event ->
+                when (event) {
+                    is ChatEditGroupEvent.GroupUpdated -> {
+                        event.dialogInfo?.let {
+                            findNavController().previousBackStackEntry?.savedStateHandle
+                                ?.set(ChatGroupDetailFragment.UPDATED_DIALOG_INFO, it)
+                        }
+                        findNavController().popBackStack()
+                    }
+
+                    is ChatEditGroupEvent.ShowError -> {
+                        Toast.makeText(requireContext(), event.message, Toast.LENGTH_SHORT).show()
+                    }
+
+                    ChatEditGroupEvent.ShowImageUploadError -> {
+                        Toast.makeText(
+                            requireContext(),
+                            R.string.chat_create_group_image_upload_error,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+
+                    ChatEditGroupEvent.ShowMissingParticipantsError -> {
+                        Toast.makeText(
+                            requireContext(),
+                            R.string.chat_create_group_missing_participants_error,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            }
+        }
+
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<ArrayList<UserProfileFullInfo>>(SELECTED_USERS_ARG)
+            ?.observe(viewLifecycleOwner) { users ->
+                if (users != null) {
+                    viewModel.onMembersSelected(users)
+                    findNavController().currentBackStackEntry?.savedStateHandle
+                        ?.remove<ArrayList<UserProfileFullInfo>>(SELECTED_USERS_ARG)
+                }
+            }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatEditGroupScreen(
+                        viewModel = viewModel,
+                        onBackPressed = { findNavController().popBackStack() },
+                        onAddParticipantsClick = {
+                            val args = Bundle().apply {
+                                putString(ChatCreateMultiFragment.MODE_ARG, ChatCreateMultiFragment.MODE_EDIT)
+                                putInt(ChatCreateMultiFragment.MIN_SELECTION_ARG, 1)
+                            }
+                            findNavController().navigate(R.id.chatCreateMultiFragment, args)
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        navigationView = null
+    }
+
+    companion object {
+        const val DIALOG_ID = ChatEditGroupViewModel.DIALOG_ID_KEY
+        const val SELECTED_USERS_ARG = "chat_edit_group_selected_users"
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.Toast
 import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
@@ -16,9 +17,11 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import uddug.com.domain.entities.chat.DialogInfo
+import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.naukoteka.R
-import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailViewModel
+import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailEvent
 import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailUiState
+import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatGroupDetailComponent
 
@@ -28,6 +31,8 @@ class ChatGroupDetailFragment : Fragment() {
     private var navigationView: ContainerNavigationView? = null
 
     private val viewModel: ChatGroupDetailViewModel by viewModels()
+
+    private var dialogId: Long = 0
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -39,36 +44,82 @@ class ChatGroupDetailFragment : Fragment() {
         navigationView?.showNavigationBottomBar(false)
     }
 
-    companion object {
-        const val DIALOG_ID = "DIALOG_ID"
-        const val DIALOG_DETAIL = "DIALOG_DETAIL"
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        dialogId = arguments?.getLong(DIALOG_ID) ?: dialogId
         setupObservers()
     }
 
     private fun setupObservers() {
         lifecycleScope.launch {
-            viewModel.uiState.collectLatest { state ->
-                when (state) {
-                    else -> {}
+            viewModel.uiState.collectLatest { _ ->
+                // Reserved for future UI state handling
+            }
+        }
+
+        lifecycleScope.launch {
+            viewModel.events.collectLatest { event ->
+                when (event) {
+                    is ChatGroupDetailEvent.GroupDeleted -> {
+                        findNavController().getBackStackEntry(R.id.chatListFragment)
+                            .savedStateHandle["refreshChats"] = true
+                        findNavController().popBackStack(R.id.chatListFragment, false)
+                    }
+
+                    is ChatGroupDetailEvent.NotificationsUpdated -> {
+                        val messageRes = if (event.disabled) {
+                            R.string.chat_disable_notifications
+                        } else {
+                            R.string.chat_enable_notifications
+                        }
+                        Toast.makeText(requireContext(), messageRes, Toast.LENGTH_SHORT).show()
+                    }
+
+                    is ChatGroupDetailEvent.ShowError -> {
+                        Toast.makeText(requireContext(), event.message, Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         }
+
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<DialogInfo>(UPDATED_DIALOG_INFO)
+            ?.observe(viewLifecycleOwner) { info ->
+                if (info != null) {
+                    dialogId = info.id
+                    viewModel.setDialogInfo(info)
+                    findNavController().currentBackStackEntry?.savedStateHandle
+                        ?.remove<DialogInfo>(UPDATED_DIALOG_INFO)
+                }
+            }
+
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<ArrayList<UserProfileFullInfo>>(ChatEditGroupFragment.SELECTED_USERS_ARG)
+            ?.observe(viewLifecycleOwner) { users ->
+                if (!users.isNullOrEmpty()) {
+                    viewModel.addParticipants(users)
+                }
+                findNavController().currentBackStackEntry?.savedStateHandle
+                    ?.remove<ArrayList<UserProfileFullInfo>>(ChatEditGroupFragment.SELECTED_USERS_ARG)
+            }
     }
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View? {
+    ): View {
         requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
 
         arguments?.getParcelable<DialogInfo>(DIALOG_DETAIL)
-            ?.let { viewModel.setDialogInfo(it) }
-            ?: arguments?.getLong(DIALOG_ID)?.let { viewModel.loadDialogInfo(it) }
+            ?.let {
+                dialogId = it.id
+                viewModel.setDialogInfo(it)
+            }
+            ?: arguments?.getLong(DIALOG_ID)?.let {
+                dialogId = it
+                viewModel.loadDialogInfo(it)
+            }
 
         return ComposeView(requireContext()).apply {
             setContent {
@@ -77,14 +128,24 @@ class ChatGroupDetailFragment : Fragment() {
                         viewModel = viewModel,
                         onBackPressed = { requireActivity().onBackPressed() },
                         onSearchClick = {
-                            val dialogId = (viewModel.uiState.value as? ChatGroupDetailUiState.Success)?.dialogId ?: 0L
+                            val currentDialogId = (viewModel.uiState.value as? ChatGroupDetailUiState.Success)?.dialogId ?: dialogId
                             findNavController().navigate(
                                 R.id.chatDetailSearchFragment,
-                                Bundle().apply { putLong(ChatDetailDialogFragment.DIALOG_ID, dialogId) }
+                                Bundle().apply { putLong(ChatDetailDialogFragment.DIALOG_ID, currentDialogId) }
                             )
                         },
                         onAddParticipantsClick = {
-                            findNavController().navigate(R.id.chatCreateMultiFragment)
+                            val args = Bundle().apply {
+                                putString(ChatCreateMultiFragment.MODE_ARG, ChatCreateMultiFragment.MODE_EDIT)
+                                putInt(ChatCreateMultiFragment.MIN_SELECTION_ARG, 1)
+                            }
+                            findNavController().navigate(R.id.chatCreateMultiFragment, args)
+                        },
+                        onEditGroupClick = { id ->
+                            val args = Bundle().apply {
+                                putLong(ChatEditGroupFragment.DIALOG_ID, id)
+                            }
+                            findNavController().navigate(R.id.chatEditGroupFragment, args)
                         }
                     )
                 }
@@ -95,5 +156,11 @@ class ChatGroupDetailFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_UNSPECIFIED)
+    }
+
+    companion object {
+        const val DIALOG_ID = "DIALOG_ID"
+        const val DIALOG_DETAIL = "DIALOG_DETAIL"
+        const val UPDATED_DIALOG_INFO = "UPDATED_DIALOG_INFO"
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
@@ -28,11 +28,14 @@ fun ChatCreateMultiScreen(
     modifier: Modifier = Modifier,
     viewModel: ChatCreateMultiViewModel,
     onBackPressed: () -> Unit,
+    titleRes: Int = R.string.chat_create_single_title,
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
     val successState = uiState as? ChatCreateMultiUiState.Success
-    val isActionEnabled = (successState?.selected?.size ?: 0) >= 2
+    val isActionEnabled = successState?.let { state ->
+        state.selected.size >= state.minSelection
+    } ?: false
 
     Column(
         modifier = Modifier
@@ -42,7 +45,8 @@ fun ChatCreateMultiScreen(
         ChatToolbarCreateSingleComponent(
             onBackPressed = onBackPressed,
             onActionClick = { viewModel.onCreateGroupClick() },
-            isActionEnabled = isActionEnabled
+            isActionEnabled = isActionEnabled,
+            titleRes = titleRes
         )
 
         when (uiState) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditGroupScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditGroupScreen.kt
@@ -1,0 +1,468 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.shape.CircleShape
+import coil.compose.AsyncImage
+import uddug.com.naukoteka.BuildConfig
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatEditGroupUiState
+import uddug.com.naukoteka.mvvm.chat.ChatEditGroupViewModel
+import uddug.com.naukoteka.mvvm.chat.GroupMember
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
+import uddug.com.naukoteka.ui.chat.compose.util.uriToFile
+
+@Composable
+fun ChatEditGroupScreen(
+    viewModel: ChatEditGroupViewModel,
+    onBackPressed: () -> Unit,
+    onAddParticipantsClick: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null) {
+            val file = uriToFile(context, uri)
+            if (file != null) {
+                viewModel.onAvatarSelected(file)
+            } else {
+                Toast.makeText(
+                    context,
+                    R.string.chat_create_group_image_upload_error,
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
+    }
+
+    val successState = uiState as? ChatEditGroupUiState.Success
+    val confirmEnabled = successState?.let { state ->
+        state.members.count { !it.isCreator } >= 2 && !state.isSaving && !state.isAvatarUploading
+    } ?: false
+
+    var selectedMemberId by remember { mutableStateOf<String?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.chat_edit_group),
+                        fontSize = 20.sp,
+                        color = Color.Black
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chat_back),
+                            contentDescription = null,
+                            tint = Color(0xFF2E83D9)
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { viewModel.onSaveChanges() },
+                        enabled = confirmEnabled
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chat_create_apply),
+                            contentDescription = null,
+                            tint = if (confirmEnabled) Color(0xFF2E83D9) else Color(0x4D2E83D9)
+                        )
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp
+            )
+        },
+        backgroundColor = Color.White
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+        ) {
+            when (val state = uiState) {
+                ChatEditGroupUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                is ChatEditGroupUiState.Error -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(text = state.message, color = Color.Red)
+                    }
+                }
+
+                is ChatEditGroupUiState.Success -> {
+                    LaunchedEffect(state.members) {
+                        selectedMemberId?.let { id ->
+                            if (state.members.none { it.user.id == id }) {
+                                selectedMemberId = null
+                            }
+                        }
+                    }
+
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp)
+                    ) {
+                        item {
+                            EditGroupHeader(
+                                state = state,
+                                onAvatarClick = { imagePickerLauncher.launch("image/*") },
+                                onRemoveAvatar = viewModel::onRemoveAvatar,
+                                onNameChanged = viewModel::onGroupNameChanged,
+                                onAddParticipantsClick = onAddParticipantsClick
+                            )
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Text(
+                                text = stringResource(
+                                    R.string.chat_create_group_members,
+                                    state.members.size
+                                ),
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 16.sp,
+                                color = Color.Black
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                        }
+
+                        itemsIndexed(state.members) { index, member ->
+                            EditGroupMemberRow(
+                                member = member,
+                                onMoreClick = { selectedMemberId = it.user.id }
+                            )
+                            if (index < state.members.lastIndex) {
+                                Divider(color = Color(0xFFEAEAF2))
+                            }
+                        }
+                    }
+
+                    val selectedMember = state.members.firstOrNull { it.user.id == selectedMemberId }
+                    if (selectedMember != null) {
+                        EditGroupMemberActionsBottomSheet(
+                            onDismissRequest = { selectedMemberId = null },
+                            onRemoveClick = {
+                                selectedMember.user.id?.let { id -> viewModel.onRemoveMember(id) }
+                                selectedMemberId = null
+                            }
+                        )
+                    }
+
+                    if (state.isSaving) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(Color.White.copy(alpha = 0.6f)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditGroupHeader(
+    state: ChatEditGroupUiState.Success,
+    onAvatarClick: () -> Unit,
+    onRemoveAvatar: () -> Unit,
+    onNameChanged: (String) -> Unit,
+    onAddParticipantsClick: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            EditableGroupAvatar(
+                avatarPath = state.avatarPath,
+                isUploading = state.isAvatarUploading,
+                onClick = onAvatarClick,
+                onRemoveClick = onRemoveAvatar,
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                OutlinedTextField(
+                    value = state.groupName,
+                    onValueChange = onNameChanged,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = {
+                        Text(
+                            text = stringResource(R.string.chat_create_group_name_placeholder),
+                            color = Color(0xFFB0B2C3)
+                        )
+                    },
+                    singleLine = true,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        backgroundColor = Color.White,
+                        focusedBorderColor = Color(0xFF2E83D9),
+                        unfocusedBorderColor = Color(0xFFE0E0E8),
+                        cursorColor = Color(0xFF2E83D9),
+                        textColor = Color.Black
+                    )
+                )
+                Text(
+                    text = stringResource(
+                        R.string.chat_create_group_name_counter,
+                        state.groupName.length
+                    ),
+                    fontSize = 12.sp,
+                    color = Color(0xFF8083A0),
+                    modifier = Modifier.align(Alignment.End)
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .clickable { onAddParticipantsClick() }
+                .background(Color(0xFFF5F5F9))
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = Color(0xFF2E83D9)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = stringResource(R.string.chat_create_group_add_participant),
+                color = Color(0xFF2E83D9),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditableGroupAvatar(
+    avatarPath: String?,
+    isUploading: Boolean,
+    onClick: () -> Unit,
+    onRemoveClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(72.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(Color(0xFFF5F5F9))
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        if (!avatarPath.isNullOrEmpty()) {
+            AsyncImage(
+                model = BuildConfig.IMAGE_SERVER_URL + avatarPath,
+                contentDescription = stringResource(R.string.chat_create_group_avatar_description),
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+            IconButton(
+                onClick = onRemoveClick,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(4.dp)
+                    .size(24.dp)
+                    .background(Color(0x99000000), CircleShape)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.chat_edit_group_remove_avatar),
+                    tint = Color.White
+                )
+            }
+        } else {
+            Icon(
+                imageVector = Icons.Default.AccountCircle,
+                contentDescription = stringResource(R.string.chat_create_group_avatar_description),
+                tint = Color(0xFF2E83D9),
+                modifier = Modifier.size(32.dp)
+            )
+        }
+
+        if (isUploading) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(Color.White.copy(alpha = 0.6f)),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditGroupMemberRow(
+    member: GroupMember,
+    onMoreClick: (GroupMember) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Avatar(
+            member.user.image?.path,
+            member.user.fullName,
+            size = 44.dp
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = member.user.fullName.orEmpty(),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp,
+                color = Color.Black
+            )
+            member.status?.takeIf { it.isNotBlank() }?.let { status ->
+                Text(
+                    text = status,
+                    fontSize = 12.sp,
+                    color = Color(0xFF8083A0)
+                )
+            }
+        }
+
+        if (!member.isCreator) {
+            IconButton(onClick = { onMoreClick(member) }) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = null,
+                    tint = Color(0xFFB0B2C3)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditGroupMemberActionsBottomSheet(
+    onDismissRequest: () -> Unit,
+    onRemoveClick: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.chat_group_participant_actions_title),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) {
+                        onRemoveClick()
+                        onDismissRequest()
+                    }
+                    .padding(vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.chat_group_remove_participant),
+                    color = Color(0xFFFF3B30),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
@@ -25,11 +25,12 @@ fun ChatToolbarCreateSingleComponent(
     onBackPressed: () -> Unit,
     onActionClick: (() -> Unit)? = null,
     isActionEnabled: Boolean = true,
+    titleRes: Int = R.string.chat_create_single_title,
 ) {
     TopAppBar(
         title = {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(text = stringResource(R.string.chat_create_single_title), fontSize = 20.sp, color = Color.Black)
+                Text(text = stringResource(titleRes), fontSize = 20.sp, color = Color.Black)
             }
         },
         actions = {

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -57,6 +57,12 @@
     </fragment>
 
     <fragment
+        android:id="@+id/chatEditGroupFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatEditGroupFragment">
+
+    </fragment>
+
+    <fragment
         android:id="@+id/chatFolderSettingsFragment"
         android:name="uddug.com.naukoteka.ui.chat.ChatFolderSettingsFragment">
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -118,4 +118,11 @@
   <string name="chat_file_attachment_unknown_type">ملف</string>
   <string name="chat_file_download_started">جاري تنزيل الملف…</string>
   <string name="labor_activity_name">%1$s в <font color="#2E83D9">%2$s</font></string>
+  <string name="chat_edit_group">Edit group</string>
+  <string name="chat_disable_notifications">Disable notifications</string>
+  <string name="chat_enable_notifications">Enable notifications</string>
+  <string name="chat_delete_group">Delete group</string>
+  <string name="chat_edit_group_remove_avatar">Remove photo</string>
+  <string name="chat_edit_group_add_members_title">Add participants</string>
+  <string name="chat_edit_group_min_selection_error">Select at least one participant</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -217,4 +217,10 @@
     <item quantity="other">%d дня назад</item>
   </plurals>
   <string name="chat_edit_group">Редактировать группу</string>
+  <string name="chat_disable_notifications">Отключить уведомления</string>
+  <string name="chat_enable_notifications">Включить уведомления</string>
+  <string name="chat_delete_group">Удалить группу</string>
+  <string name="chat_edit_group_remove_avatar">Удалить фото</string>
+  <string name="chat_edit_group_add_members_title">Добавить участников</string>
+  <string name="chat_edit_group_min_selection_error">Выберите хотя бы одного участника</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -473,6 +473,10 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_edit_group">Редактировать группу</string>
     <string name="chat_disable_notifications">Отключить уведомления</string>
     <string name="chat_enable_notifications">Включить уведомления</string>
+    <string name="chat_delete_group">Удалить группу</string>
+    <string name="chat_edit_group_remove_avatar">Удалить фото</string>
+    <string name="chat_edit_group_add_members_title">Добавить участников</string>
+    <string name="chat_edit_group_min_selection_error">Выберите хотя бы одного участника</string>
     <string name="chat_select_messages">Выделить сообщения</string>
     <string name="chat_block_chat">Заблокировать чат</string>
     <string name="chat_unblock_chat">Разблокировать чат</string>

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -15,8 +15,10 @@ import uddug.com.data.services.models.request.chat.ChatFolderRequestDto
 import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
 import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
 import uddug.com.data.services.models.request.chat.PinMessageRequestDto
+import uddug.com.data.services.models.request.chat.DialogUserActionRequestDto
 import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
 import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
+import uddug.com.data.services.models.request.chat.UpdateDialogRequestDto
 import uddug.com.data.services.models.response.chat.ChatDto
 import uddug.com.data.services.models.response.chat.DialogInfoDto
 import uddug.com.data.services.models.response.chat.FolderDetailsDto
@@ -114,6 +116,12 @@ interface ChatApiService {
         @Body request: CreateDialogRequestDto,
     ): DialogInfoDto
 
+    @PATCH("chat/v1/dialogs/{dialogId}")
+    suspend fun updateDialog(
+        @Path("dialogId") dialogId: Long,
+        @Body request: UpdateDialogRequestDto,
+    ): DialogInfoDto
+
     @POST("chat/v1/dialogs/pin/{dialogId}")
     suspend fun pinDialog(@Path("dialogId") dialogId: Long)
 
@@ -143,6 +151,24 @@ interface ChatApiService {
 
     @DELETE("chat/v1/dialogs/{dialogId}")
     suspend fun deleteDialog(@Path("dialogId") dialogId: Long)
+
+    @DELETE("chat/v1/dialogs/chat/{dialogId}")
+    suspend fun deleteGroupDialog(@Path("dialogId") dialogId: Long)
+
+    @PATCH("chat/v1/dialogs/leave/{dialogId}")
+    suspend fun leaveDialog(@Path("dialogId") dialogId: Long)
+
+    @POST("chat/v1/dialogs/make-admin/{dialogId}")
+    suspend fun makeAdmin(
+        @Path("dialogId") dialogId: Long,
+        @Body request: DialogUserActionRequestDto,
+    )
+
+    @PATCH("chat/v1/dialogs/remove-admin/{dialogId}")
+    suspend fun removeAdmin(
+        @Path("dialogId") dialogId: Long,
+        @Body request: DialogUserActionRequestDto,
+    )
 
     @PATCH("chat/v1/messages/update")
     suspend fun updateMessage(@Body request: UpdateMessageRequestDto): MessageDto

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/DialogUserActionRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/DialogUserActionRequestDto.kt
@@ -1,0 +1,8 @@
+package uddug.com.data.services.models.request.chat
+
+import com.google.gson.annotations.SerializedName
+
+data class DialogUserActionRequestDto(
+    @SerializedName("userId") val userId: String,
+)
+

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateDialogRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateDialogRequestDto.kt
@@ -1,0 +1,15 @@
+package uddug.com.data.services.models.request.chat
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdateDialogRequestDto(
+    @SerializedName("name") val name: String? = null,
+    @SerializedName("image") val image: UpdateDialogImageRequestDto? = null,
+    @SerializedName("users") val users: List<String>? = null,
+)
+
+data class UpdateDialogImageRequestDto(
+    @SerializedName("id") val id: String,
+    @SerializedName("fileType") val fileType: Int = 0,
+)
+

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -101,6 +101,14 @@ class ChatInteractor @Inject constructor(
     ): Long =
         chatRepository.createGroupDialog(dialogName = dialogName, userRoles = userRoles, imageId = imageId)
 
+    suspend fun updateDialog(
+        dialogId: Long,
+        name: String? = null,
+        imageId: String? = null,
+        clearImage: Boolean = false,
+        users: List<String>? = null,
+    ): DialogInfo = chatRepository.updateDialog(dialogId, name, imageId, clearImage, users)
+
     suspend fun searchUsers(query: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo> =
         chatRepository.searchUsers(query, limit, page)
 
@@ -110,6 +118,10 @@ class ChatInteractor @Inject constructor(
     suspend fun pinDialog(dialogId: Long) = chatRepository.pinDialog(dialogId)
 
     suspend fun unpinDialog(dialogId: Long) = chatRepository.unpinDialog(dialogId)
+
+    suspend fun disableNotifications(dialogId: Long) = chatRepository.disableNotifications(dialogId)
+
+    suspend fun enableNotifications(dialogId: Long) = chatRepository.enableNotifications(dialogId)
 
     suspend fun pinMessage(dialogId: Long, messageId: Long) =
         chatRepository.pinMessage(dialogId, messageId)
@@ -143,4 +155,14 @@ class ChatInteractor @Inject constructor(
         query: String,
         lastMessageId: Long? = null,
     ): List<SearchMessage> = chatRepository.searchMessages(query, lastMessageId)
+
+    suspend fun deleteGroupDialog(dialogId: Long) = chatRepository.deleteGroupDialog(dialogId)
+
+    suspend fun leaveDialog(dialogId: Long) = chatRepository.leaveDialog(dialogId)
+
+    suspend fun makeDialogAdmin(dialogId: Long, userId: String) =
+        chatRepository.makeDialogAdmin(dialogId, userId)
+
+    suspend fun removeDialogAdmin(dialogId: Long, userId: String) =
+        chatRepository.removeDialogAdmin(dialogId, userId)
 }

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -95,6 +95,14 @@ interface ChatRepository {
         imageId: String? = null,
     ): Long
 
+    suspend fun updateDialog(
+        dialogId: Long,
+        name: String? = null,
+        imageId: String? = null,
+        clearImage: Boolean = false,
+        users: List<String>? = null,
+    ): DialogInfo
+
     suspend fun searchUsers(searchField: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo>
 
     suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, status: Int)
@@ -118,6 +126,14 @@ interface ChatRepository {
     suspend fun clearDialog(dialogId: Long)
 
     suspend fun deleteDialog(dialogId: Long)
+
+    suspend fun deleteGroupDialog(dialogId: Long)
+
+    suspend fun leaveDialog(dialogId: Long)
+
+    suspend fun makeDialogAdmin(dialogId: Long, userId: String)
+
+    suspend fun removeDialogAdmin(dialogId: Long, userId: String)
 
     suspend fun pinMessage(dialogId: Long, messageId: Long)
 


### PR DESCRIPTION
## Summary
- add Retrofit DTOs plus repository and interactor methods for dialog update, admin management, deletion, and leave endpoints
- build the edit-group flow with fragment, view model, and Compose UI to edit name, avatar, and participants
- expose group admin controls in the detail screen, including notification toggles, delete, and add-participant flow tied into the edit screen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd36d087688327a92d4bb38606c65f