### PR TITLE
Implement group chat management actions

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateMultiViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreateMultiViewModel.kt
@@ -1,5 +1,6 @@
 package uddug.com.naukoteka.mvvm.chat
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,7 +18,15 @@ import javax.inject.Inject
 @HiltViewModel
 class ChatCreateMultiViewModel @Inject constructor(
     private val chatInteractor: ChatInteractor,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
+
+    companion object {
+        const val MIN_SELECTION_KEY = "min_selection"
+        private const val DEFAULT_MIN_SELECTION = 2
+    }
+
+    private val minSelection = savedStateHandle.get<Int>(MIN_SELECTION_KEY) ?: DEFAULT_MIN_SELECTION
 
     private val _uiState =
         MutableStateFlow<ChatCreateMultiUiState>(ChatCreateMultiUiState.Loading)
@@ -94,7 +103,7 @@ class ChatCreateMultiViewModel @Inject constructor(
                 .filter { user -> user.id?.let { current.selected.contains(it) } == true }
                 .distinctBy { it.id }
 
-            if (selectedUsers.size < 2) {
+            if (selectedUsers.size < minSelection) {
                 viewModelScope.launch {
                     _events.emit(ChatCreateMultiEvent.ShowMinimumMembersError)
                 }

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatEditGroupViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatEditGroupViewModel.kt
@@ -1,0 +1,345 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import uddug.com.domain.entities.chat.DialogInfo
+import uddug.com.domain.entities.chat.User
+import uddug.com.domain.entities.profile.Image
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.domain.interactors.chat.ChatInteractor
+import uddug.com.domain.repositories.user_profile.UserProfileRepository
+import java.io.File
+import java.time.Instant
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatEditGroupViewModel @Inject constructor(
+    private val chatInteractor: ChatInteractor,
+    private val userProfileRepository: UserProfileRepository,
+    private val chatStatusFormatter: ChatStatusFormatter,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    companion object {
+        const val ARG_DIALOG_ID = "dialog_id"
+        private const val MAX_GROUP_NAME_LENGTH = 100
+        private const val ADMIN_ROLE = "37:202"
+    }
+
+    private val dialogId: Long = savedStateHandle.get<Long>(ARG_DIALOG_ID) ?: 0L
+
+    private val _uiState = MutableStateFlow<ChatEditGroupUiState>(ChatEditGroupUiState.Loading)
+    val uiState: StateFlow<ChatEditGroupUiState> = _uiState
+
+    private val _events = MutableSharedFlow<ChatEditGroupEvent>()
+    val events: SharedFlow<ChatEditGroupEvent> = _events.asSharedFlow()
+
+    private var currentUserId: String? = null
+    private var originalName: String? = null
+    private var originalAvatarId: String? = null
+    private var originalMembers: Set<String> = emptySet()
+    private var originalAdminIds: Set<String> = emptySet()
+    private var removeAvatar: Boolean = false
+
+    init {
+        if (dialogId != 0L) {
+            loadDialogInfo()
+        } else {
+            _uiState.value = ChatEditGroupUiState.Error("Invalid dialog")
+        }
+    }
+
+    private fun loadDialogInfo() {
+        viewModelScope.launch {
+            try {
+                val info = chatInteractor.getDialogInfo(dialogId)
+                val currentUser = withContext(Dispatchers.IO) {
+                    userProfileRepository.getProfileInfo().await()
+                }
+                currentUserId = currentUser.id
+                applyDialogInfo(info, currentUser.id)
+            } catch (e: Exception) {
+                _uiState.value = ChatEditGroupUiState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    private suspend fun applyDialogInfo(info: DialogInfo, currentUserId: String?) {
+        val members = buildMembers(info.users.orEmpty(), currentUserId)
+        val membersWithStatuses = enrichWithStatuses(members)
+        originalName = info.name
+        originalAvatarId = info.dialogImage?.id
+        originalMembers = membersWithStatuses
+            .mapNotNull { it.user.id }
+            .filter { it != currentUserId }
+            .toSet()
+        originalAdminIds = membersWithStatuses
+            .filter { it.isAdmin && !it.isCreator }
+            .mapNotNull { it.user.id }
+            .toSet()
+        removeAvatar = false
+        _uiState.value = ChatEditGroupUiState.Success(
+            groupName = info.name.orEmpty(),
+            members = membersWithStatuses,
+            avatarPath = info.dialogImage?.path,
+            avatarId = info.dialogImage?.id,
+            isSaving = false,
+            isAvatarUploading = false,
+            isAvatarRemoved = false,
+        )
+    }
+
+    fun onGroupNameChanged(name: String) {
+        val current = _uiState.value
+        if (current is ChatEditGroupUiState.Success) {
+            val trimmed = name.take(MAX_GROUP_NAME_LENGTH)
+            _uiState.value = current.copy(groupName = trimmed)
+        }
+    }
+
+    fun onAvatarSelected(file: File) {
+        val current = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        if (current.isAvatarUploading) return
+        _uiState.value = current.copy(isAvatarUploading = true)
+        viewModelScope.launch {
+            try {
+                val uploaded = withContext(Dispatchers.IO) {
+                    chatInteractor.uploadFiles(listOf(file), raw = false)
+                }.firstOrNull()
+                if (uploaded != null) {
+                    val latest = _uiState.value as? ChatEditGroupUiState.Success
+                    if (latest != null) {
+                        _uiState.value = latest.copy(
+                            avatarPath = uploaded.path,
+                            avatarId = uploaded.id,
+                            isAvatarUploading = false,
+                            isAvatarRemoved = false,
+                        )
+                        removeAvatar = false
+                    }
+                } else {
+                    val latest = _uiState.value as? ChatEditGroupUiState.Success
+                    _uiState.value = latest?.copy(isAvatarUploading = false) ?: current.copy(isAvatarUploading = false)
+                    _events.emit(ChatEditGroupEvent.ShowImageUploadError)
+                }
+            } catch (e: Exception) {
+                val latest = _uiState.value as? ChatEditGroupUiState.Success
+                _uiState.value = latest?.copy(isAvatarUploading = false) ?: current.copy(isAvatarUploading = false)
+                _events.emit(ChatEditGroupEvent.ShowError(e.message))
+            }
+        }
+    }
+
+    fun onAvatarRemoved() {
+        val current = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        if (current.avatarPath.isNullOrBlank() && current.avatarId.isNullOrBlank()) return
+        _uiState.value = current.copy(avatarPath = null, avatarId = null, isAvatarRemoved = true)
+        removeAvatar = true
+    }
+
+    fun onGrantAdminRights(memberId: String) {
+        updateMembers { members ->
+            members.map { member ->
+                if (member.user.id == memberId && !member.isCreator) {
+                    member.copy(isAdmin = true)
+                } else {
+                    member
+                }
+            }
+        }
+    }
+
+    fun onRevokeAdminRights(memberId: String) {
+        updateMembers { members ->
+            members.map { member ->
+                if (member.user.id == memberId && !member.isCreator) {
+                    member.copy(isAdmin = false)
+                } else {
+                    member
+                }
+            }
+        }
+    }
+
+    fun onRemoveMember(memberId: String) {
+        updateMembers { members ->
+            members.filterNot { member ->
+                member.user.id == memberId && !member.isCreator
+            }
+        }
+    }
+
+    fun onParticipantsAdded(users: List<UserProfileFullInfo>) {
+        if (users.isEmpty()) return
+        updateMembers { members ->
+            val existingIds = members.mapNotNull { it.user.id }.toSet()
+            val newMembers = users
+                .filter { it.id != null && !existingIds.contains(it.id) }
+                .map {
+                    GroupMember(
+                        user = it,
+                        isCreator = false,
+                        isAdmin = false
+                    )
+                }
+            (members + newMembers)
+        }
+        viewModelScope.launch {
+            val current = _uiState.value as? ChatEditGroupUiState.Success ?: return@launch
+            val enriched = enrichWithStatuses(current.members)
+            _uiState.value = current.copy(members = enriched)
+        }
+    }
+
+    fun onSaveChanges() {
+        val current = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        if (current.isSaving || current.isAvatarUploading) return
+        val participantsCount = current.members.count { !it.isCreator }
+        if (participantsCount < 2) {
+            viewModelScope.launch { _events.emit(ChatEditGroupEvent.ShowMissingParticipantsError) }
+            return
+        }
+        val name = current.groupName.take(MAX_GROUP_NAME_LENGTH)
+        val nameChanged = name != originalName && name.isNotBlank()
+        val imageId = current.avatarId
+        val imageChanged = !imageId.isNullOrBlank() && imageId != originalAvatarId
+        val users = current.members.mapNotNull { it.user.id }
+        val currentUserId = currentUserId
+        if (currentUserId.isNullOrEmpty()) {
+            viewModelScope.launch { _events.emit(ChatEditGroupEvent.ShowError("User not found")) }
+            return
+        }
+        val usersForRequest = users.filter { it != currentUserId }
+        val usersChanged = usersForRequest.toSet() != originalMembers
+        val currentAdmins = current.members
+            .filter { it.isAdmin && !it.isCreator }
+            .mapNotNull { it.user.id }
+            .toSet()
+        val adminsAdded = currentAdmins.minus(originalAdminIds)
+        val adminsRemoved = originalAdminIds.minus(currentAdmins)
+        _uiState.value = current.copy(isSaving = true)
+        viewModelScope.launch {
+            try {
+                val updatedInfo = withContext(Dispatchers.IO) {
+                    chatInteractor.updateGroupDialog(
+                        dialogId = dialogId,
+                        dialogName = if (nameChanged) name else null,
+                        imageId = if (imageChanged) imageId else null,
+                        removeImage = removeAvatar,
+                        users = if (usersChanged) usersForRequest else null,
+                    )
+                }
+                adminsAdded.forEach { userId ->
+                    runCatching { chatInteractor.makeDialogAdmin(dialogId, userId) }
+                }
+                adminsRemoved.forEach { userId ->
+                    runCatching { chatInteractor.removeDialogAdmin(dialogId, userId) }
+                }
+                applyDialogInfo(updatedInfo, currentUserId)
+                _events.emit(ChatEditGroupEvent.GroupUpdated(dialogId))
+            } catch (e: Exception) {
+                val latest = _uiState.value as? ChatEditGroupUiState.Success
+                _uiState.value = latest?.copy(isSaving = false) ?: current.copy(isSaving = false)
+                _events.emit(ChatEditGroupEvent.ShowError(e.message))
+            } finally {
+                removeAvatar = false
+            }
+        }
+    }
+
+    private fun buildMembers(users: List<User>, currentUserId: String?): List<GroupMember> {
+        return users.map { user ->
+            val userInfo = UserProfileFullInfo(
+                id = user.userId,
+                fullName = user.fullName,
+                nickname = user.nickname,
+                image = Image(path = user.image)
+            )
+            val isOwner = isOwnerRole(user.role)
+            val isAdmin = user.isAdmin || isAdminRole(user.role) || isOwner
+            val isCreator = isOwner || user.userId == currentUserId
+            GroupMember(
+                user = userInfo,
+                isCreator = isCreator,
+                isAdmin = isAdmin
+            )
+        }
+    }
+
+    private fun updateMembers(transform: (List<GroupMember>) -> List<GroupMember>) {
+        val current = _uiState.value as? ChatEditGroupUiState.Success ?: return
+        val updated = transform(current.members)
+        _uiState.value = current.copy(members = updated)
+    }
+
+    private suspend fun enrichWithStatuses(members: List<GroupMember>): List<GroupMember> {
+        val userIds = members.mapNotNull { it.user.id }
+        if (userIds.isEmpty()) return members
+        val statusMap = runCatching {
+            withContext(Dispatchers.IO) {
+                chatInteractor.getUsersStatus(userIds)
+            }.associateBy { it.userId }
+        }.getOrElse { emptyMap() }
+        if (statusMap.isEmpty()) return members
+        return members.map { member ->
+            val statusText = member.user.id?.let { id ->
+                statusMap[id]?.let { status ->
+                    if (status.isOnline) {
+                        chatStatusFormatter.online()
+                    } else {
+                        status.lastSeen?.let { lastSeen ->
+                            runCatching { Instant.parse(lastSeen) }
+                                .map { instant -> chatStatusFormatter.formatLastSeen(instant) }
+                                .getOrNull()
+                        }
+                    }
+                }
+            }
+            member.copy(status = statusText)
+        }
+    }
+
+    private fun isOwnerRole(role: String?): Boolean {
+        if (role.isNullOrBlank()) return false
+        val normalized = role.lowercase()
+        return normalized == "37:201" || normalized.contains("owner") || normalized.contains("влад")
+    }
+
+    private fun isAdminRole(role: String?): Boolean {
+        if (role.isNullOrBlank()) return false
+        val normalized = role.lowercase()
+        return normalized == ADMIN_ROLE || normalized.contains("admin") || normalized.contains("админ")
+    }
+}
+
+sealed class ChatEditGroupUiState {
+    object Loading : ChatEditGroupUiState()
+    data class Success(
+        val groupName: String,
+        val members: List<GroupMember>,
+        val avatarPath: String?,
+        val avatarId: String?,
+        val isSaving: Boolean,
+        val isAvatarUploading: Boolean,
+        val isAvatarRemoved: Boolean,
+    ) : ChatEditGroupUiState()
+
+    data class Error(val message: String) : ChatEditGroupUiState()
+}
+
+sealed class ChatEditGroupEvent {
+    data class GroupUpdated(val dialogId: Long) : ChatEditGroupEvent()
+    data class ShowError(val message: String?) : ChatEditGroupEvent()
+    object ShowImageUploadError : ChatEditGroupEvent()
+    object ShowMissingParticipantsError : ChatEditGroupEvent()
+}

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatFunctionsViewModel.kt
@@ -98,7 +98,29 @@ class ChatFunctionsViewModel @Inject constructor(
                 chatRepository.deleteDialog(dialogId)
                 _events.emit(ChatFunctionsEvent.ChatDeleted)
             } catch (e: Exception) {
-                
+
+            }
+        }
+    }
+
+    fun deleteGroupChat(dialogId: Long) {
+        viewModelScope.launch {
+            try {
+                chatRepository.deleteGroupDialog(dialogId)
+                _events.emit(ChatFunctionsEvent.ChatDeleted)
+            } catch (e: Exception) {
+
+            }
+        }
+    }
+
+    fun leaveGroup(dialogId: Long) {
+        viewModelScope.launch {
+            try {
+                chatRepository.leaveGroupDialog(dialogId)
+                _events.emit(ChatFunctionsEvent.ChatDeleted)
+            } catch (e: Exception) {
+
             }
         }
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
@@ -30,6 +30,9 @@ class ChatCreateMultiFragment : Fragment() {
 
     private val viewModel: ChatCreateMultiViewModel by viewModels()
 
+    private val returnResult: Boolean
+        get() = arguments?.getBoolean(RETURN_RESULT_KEY) ?: false
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         navigationView = requireActivity() as ContainerNavigationView
@@ -50,10 +53,18 @@ class ChatCreateMultiFragment : Fragment() {
             viewModel.events.collectLatest { event ->
                 when (event) {
                     is ChatCreateMultiEvent.OpenGroupDetails -> {
-                        val args = bundleOf(
-                            ChatCreateGroupFragment.SELECTED_USERS_ARG to ArrayList(event.selectedUsers)
-                        )
-                        findNavController().navigate(R.id.chatCreateGroupFragment, args)
+                        if (returnResult) {
+                            findNavController().previousBackStackEntry?.savedStateHandle?.set(
+                                ChatCreateGroupFragment.SELECTED_USERS_ARG,
+                                ArrayList(event.selectedUsers)
+                            )
+                            findNavController().popBackStack()
+                        } else {
+                            val args = bundleOf(
+                                ChatCreateGroupFragment.SELECTED_USERS_ARG to ArrayList(event.selectedUsers)
+                            )
+                            findNavController().navigate(R.id.chatCreateGroupFragment, args)
+                        }
                     }
                     ChatCreateMultiEvent.ShowMinimumMembersError -> {
                         Toast.makeText(
@@ -82,6 +93,11 @@ class ChatCreateMultiFragment : Fragment() {
                 }
             }
         }
+    }
+
+    companion object {
+        const val RETURN_RESULT_KEY = "return_result"
+        const val MIN_SELECTION_ARG = ChatCreateMultiViewModel.MIN_SELECTION_KEY
     }
 }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
@@ -24,6 +24,7 @@ import uddug.com.naukoteka.R
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatDetailDialogComponent
 import uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment.Companion.ARG_AVATAR_PATH
+import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
 @AndroidEntryPoint
 class ChatDetailDialogFragment : Fragment() {
 
@@ -72,6 +73,18 @@ class ChatDetailDialogFragment : Fragment() {
                 }
             }
         }
+
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<Boolean>("refreshDialogInfo")
+            ?.observe(viewLifecycleOwner) { shouldRefresh ->
+                if (shouldRefresh == true) {
+                    val dialogId = (viewModel.uiState.value as? ChatDetailUiState.Success)?.dialogId
+                        ?: arguments?.getLong(DIALOG_ID)
+                        ?: return@observe
+                    viewModel.loadDialogInfo(dialogId)
+                    findNavController().currentBackStackEntry?.savedStateHandle?.set("refreshDialogInfo", false)
+                }
+            }
     }
 
     override fun onCreateView(
@@ -115,6 +128,12 @@ class ChatDetailDialogFragment : Fragment() {
                                     putString(ARG_AVATAR_PATH, avatarPath)
                                 }
                             )
+                        },
+                        onEditGroup = { id ->
+                            val args = Bundle().apply {
+                                putLong(ChatEditGroupFragment.ARG_DIALOG_ID, id)
+                            }
+                            findNavController().navigate(R.id.chatEditGroupFragment, args)
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -27,6 +27,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.ChatDetailDialogFragment.Companion.DIALOG_DETAIL
 import uddug.com.naukoteka.ui.chat.ForwardMessageFragment.Companion.ARG_MESSAGE_ID
+import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
 import uddug.com.naukoteka.ui.chat.compose.ChatDialogComponent
 import uddug.com.naukoteka.ui.chat.compose.ChatListComponent
 
@@ -101,6 +102,15 @@ class ChatDialogFragment : Fragment() {
             ?.observe(viewLifecycleOwner) { user ->
                 user?.let { viewModel.attachUserContact(it) }
             }
+
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<Boolean>("refreshDialogInfo")
+            ?.observe(viewLifecycleOwner) { shouldRefresh ->
+                if (shouldRefresh == true) {
+                    viewModel.refreshDialogInfo()
+                    findNavController().currentBackStackEntry?.savedStateHandle?.set("refreshDialogInfo", false)
+                }
+            }
     }
 
     override fun onCreateView(
@@ -132,6 +142,16 @@ class ChatDialogFragment : Fragment() {
                                 putLong(ARG_MESSAGE_ID, message.id)
                             }
                             findNavController().navigate(R.id.forwardMessageFragment, args)
+                        },
+                        onEditGroup = { id ->
+                            val args = Bundle().apply {
+                                putLong(ChatEditGroupFragment.ARG_DIALOG_ID, id)
+                            }
+                            findNavController().navigate(R.id.chatEditGroupFragment, args)
+                        },
+                        onChatDeleted = {
+                            findNavController().previousBackStackEntry?.savedStateHandle?.set("refreshChats", true)
+                            findNavController().popBackStack()
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditGroupFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditGroupFragment.kt
@@ -1,0 +1,112 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatEditGroupEvent
+import uddug.com.naukoteka.mvvm.chat.ChatEditGroupViewModel
+import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
+import uddug.com.naukoteka.ui.chat.compose.ChatEditGroupScreen
+import uddug.com.naukoteka.ui.chat.ChatCreateMultiFragment
+
+@AndroidEntryPoint
+class ChatEditGroupFragment : Fragment() {
+
+    private val viewModel: ChatEditGroupViewModel by viewModels()
+
+    private var navigationView: ContainerNavigationView? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        navigationView = requireActivity() as? ContainerNavigationView
+    }
+
+    override fun onResume() {
+        super.onResume()
+        navigationView?.showNavigationBottomBar(true)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+        observeParticipantsResult()
+    }
+
+    private fun setupObservers() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.events.collectLatest { event ->
+                when (event) {
+                    is ChatEditGroupEvent.GroupUpdated -> {
+                        findNavController().previousBackStackEntry?.savedStateHandle?.apply {
+                            set("refreshDialogInfo", true)
+                            set("refreshChats", true)
+                        }
+                        findNavController().popBackStack()
+                    }
+
+                    ChatEditGroupEvent.ShowImageUploadError -> Unit
+                    ChatEditGroupEvent.ShowMissingParticipantsError -> Unit
+                    is ChatEditGroupEvent.ShowError -> Unit
+                }
+            }
+        }
+    }
+
+    private fun observeParticipantsResult() {
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<ArrayList<UserProfileFullInfo>>(ChatCreateGroupFragment.SELECTED_USERS_ARG)
+            ?.observe(viewLifecycleOwner) { users ->
+                if (users != null) {
+                    viewModel.onParticipantsAdded(users)
+                    findNavController().currentBackStackEntry?.savedStateHandle
+                        ?.set(ChatCreateGroupFragment.SELECTED_USERS_ARG, null)
+                }
+            }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatEditGroupScreen(
+                        viewModel = viewModel,
+                        onBackPressed = { findNavController().popBackStack() },
+                        onAddParticipantsClick = {
+                            val args = Bundle().apply {
+                                putBoolean(ChatCreateMultiFragment.RETURN_RESULT_KEY, true)
+                                putInt(ChatCreateMultiFragment.MIN_SELECTION_ARG, 1)
+                            }
+                            findNavController().navigate(R.id.chatCreateMultiFragment, args)
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        navigationView = null
+    }
+
+    companion object {
+        const val ARG_DIALOG_ID = ChatEditGroupViewModel.ARG_DIALOG_ID
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -99,6 +99,7 @@ fun ChatDetailDialogComponent(
     onSearchClick: () -> Unit,
     onChatDeleted: () -> Unit,
     onViewAvatar: (String) -> Unit,
+    onEditGroup: (Long) -> Unit,
 ) {
     val scrollState = rememberLazyListState()
     val uiState by viewModel.uiState.collectAsState()
@@ -407,13 +408,15 @@ fun ChatDetailDialogComponent(
                     if (showMoreDialog) {
                         ChatDetailMoreSheetDialog(
                             dialogId = state.dialogId,
+                            isGroup = true,
                             onNavigateToProfile = onNavigateToProfile,
                             onDismissRequest = { showMoreDialog = false },
                             onChatDeleted = onChatDeleted,
-                            onEditGroup = {
-
-                            },
-                            isCurrentUserAdmin = false
+                            onEditGroup = { onEditGroup(state.dialogId) },
+                            isCurrentUserAdmin = state.isCurrentUserAdmin,
+                            notificationsDisabled = false,
+                            onLeaveGroup = {},
+                            onNotificationsChanged = {}
                         )
                     }
                     if (showAvatarDialog) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditGroupScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditGroupScreen.kt
@@ -1,0 +1,549 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import uddug.com.naukoteka.BuildConfig
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatEditGroupEvent
+import uddug.com.naukoteka.mvvm.chat.ChatEditGroupUiState
+import uddug.com.naukoteka.mvvm.chat.ChatEditGroupViewModel
+import uddug.com.naukoteka.mvvm.chat.GroupMember
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
+import uddug.com.naukoteka.ui.chat.compose.util.uriToFile
+
+@Composable
+fun ChatEditGroupScreen(
+    viewModel: ChatEditGroupViewModel,
+    onBackPressed: () -> Unit,
+    onAddParticipantsClick: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null) {
+            val file = uriToFile(context, uri)
+            if (file != null) {
+                viewModel.onAvatarSelected(file)
+            } else {
+                Toast.makeText(
+                    context,
+                    R.string.chat_create_group_image_upload_error,
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is ChatEditGroupEvent.GroupUpdated -> Unit
+                ChatEditGroupEvent.ShowImageUploadError -> {
+                    Toast.makeText(
+                        context,
+                        R.string.chat_create_group_image_upload_error,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                ChatEditGroupEvent.ShowMissingParticipantsError -> {
+                    Toast.makeText(
+                        context,
+                        R.string.chat_create_group_missing_participants_error,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                is ChatEditGroupEvent.ShowError -> {
+                    val message = event.message ?: context.getString(R.string.chat_create_group_generic_error)
+                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    val confirmEnabled = (uiState as? ChatEditGroupUiState.Success)?.let { state ->
+        state.members.count { !it.isCreator } >= 2 && !state.isSaving && !state.isAvatarUploading
+    } ?: false
+
+    var selectedMemberId by remember { mutableStateOf<String?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.chat_edit_group),
+                        fontSize = 20.sp,
+                        color = Color.Black
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chat_back),
+                            contentDescription = null,
+                            tint = Color(0xFF2E83D9)
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { viewModel.onSaveChanges() },
+                        enabled = confirmEnabled
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chat_create_apply),
+                            contentDescription = null,
+                            tint = if (confirmEnabled) Color(0xFF2E83D9) else Color(0x4D2E83D9)
+                        )
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp
+            )
+        },
+        backgroundColor = Color.White
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+        ) {
+            when (val state = uiState) {
+                ChatEditGroupUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                is ChatEditGroupUiState.Error -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(text = state.message, color = Color.Red)
+                    }
+                }
+
+                is ChatEditGroupUiState.Success -> {
+                    LaunchedEffect(state.members) {
+                        selectedMemberId?.let { id ->
+                            if (state.members.none { it.user.id == id }) {
+                                selectedMemberId = null
+                            }
+                        }
+                    }
+
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp)
+                    ) {
+                        item {
+                            EditGroupHeader(
+                                state = state,
+                                onAvatarClick = { imagePickerLauncher.launch("image/*") },
+                                onNameChanged = viewModel::onGroupNameChanged,
+                                onAddParticipantsClick = onAddParticipantsClick,
+                                onRemoveAvatar = viewModel::onAvatarRemoved
+                            )
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Text(
+                                text = stringResource(
+                                    R.string.chat_create_group_members,
+                                    state.members.size
+                                ),
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 16.sp,
+                                color = Color.Black
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                        }
+
+                        itemsIndexed(state.members) { index, member ->
+                            GroupMemberRow(
+                                member = member,
+                                onMoreClick = { selectedMemberId = it.user.id }
+                            )
+                            if (index < state.members.lastIndex) {
+                                Divider(color = Color(0xFFEAEAF2))
+                            }
+                        }
+                    }
+
+                    state.members.firstOrNull { it.user.id == selectedMemberId }?.let { member ->
+                        GroupMemberActionsBottomSheet(
+                            member = member,
+                            onDismissRequest = { selectedMemberId = null },
+                            onGrantAdminClick = {
+                                member.user.id?.let { viewModel.onGrantAdminRights(it) }
+                            },
+                            onRevokeAdminClick = {
+                                member.user.id?.let { viewModel.onRevokeAdminRights(it) }
+                            },
+                            onRemoveClick = {
+                                member.user.id?.let { viewModel.onRemoveMember(it) }
+                            }
+                        )
+                    }
+
+                    if (state.isSaving) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(Color.White.copy(alpha = 0.6f)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditGroupHeader(
+    state: ChatEditGroupUiState.Success,
+    onAvatarClick: () -> Unit,
+    onNameChanged: (String) -> Unit,
+    onAddParticipantsClick: () -> Unit,
+    onRemoveAvatar: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            EditGroupAvatarPicker(
+                avatarPath = state.avatarPath,
+                isUploading = state.isAvatarUploading,
+                onClick = onAvatarClick,
+                onRemoveAvatar = onRemoveAvatar,
+                showRemove = !state.avatarPath.isNullOrBlank() || !state.avatarId.isNullOrBlank()
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                OutlinedTextField(
+                    value = state.groupName,
+                    onValueChange = onNameChanged,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = {
+                        Text(
+                            text = stringResource(R.string.chat_create_group_name_placeholder),
+                            color = Color(0xFFB0B2C3)
+                        )
+                    },
+                    singleLine = true,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        backgroundColor = Color.White,
+                        focusedBorderColor = Color(0xFF2E83D9),
+                        unfocusedBorderColor = Color(0xFFE0E0E8),
+                        cursorColor = Color(0xFF2E83D9),
+                        textColor = Color.Black
+                    )
+                )
+                Text(
+                    text = stringResource(
+                        R.string.chat_create_group_name_counter,
+                        state.groupName.length
+                    ),
+                    fontSize = 12.sp,
+                    color = Color(0xFF8083A0),
+                    modifier = Modifier.align(Alignment.End)
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .clickable { onAddParticipantsClick() }
+                .background(Color(0xFFF5F5F9))
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = Color(0xFF2E83D9)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = stringResource(R.string.chat_create_group_add_participant),
+                color = Color(0xFF2E83D9),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditGroupAvatarPicker(
+    avatarPath: String?,
+    isUploading: Boolean,
+    onClick: () -> Unit,
+    onRemoveAvatar: () -> Unit,
+    showRemove: Boolean,
+) {
+    Box(
+        modifier = Modifier
+            .size(72.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(Color(0xFFF5F5F9))
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        if (!avatarPath.isNullOrEmpty()) {
+            AsyncImage(
+                model = BuildConfig.IMAGE_SERVER_URL + avatarPath,
+                contentDescription = stringResource(R.string.chat_create_group_avatar_description),
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Default.AccountCircle,
+                contentDescription = stringResource(R.string.chat_create_group_avatar_description),
+                tint = Color(0xFF2E83D9),
+                modifier = Modifier.size(32.dp)
+            )
+        }
+
+        if (isUploading) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(Color.White.copy(alpha = 0.6f)),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+            }
+        }
+    }
+    if (showRemove) {
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.chat_edit_group_remove_avatar),
+            color = Color(0xFFFF3B30),
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) { onRemoveAvatar() }
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GroupMemberActionsBottomSheet(
+    member: GroupMember,
+    onDismissRequest: () -> Unit,
+    onGrantAdminClick: () -> Unit,
+    onRevokeAdminClick: () -> Unit,
+    onRemoveClick: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.chat_group_participant_actions_title),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (!member.isCreator) {
+                if (member.isAdmin) {
+                    GroupMemberActionRow(
+                        text = stringResource(R.string.chat_group_remove_admin),
+                        onClick = {
+                            onRevokeAdminClick()
+                            onDismissRequest()
+                        }
+                    )
+                } else {
+                    GroupMemberActionRow(
+                        text = stringResource(R.string.chat_group_make_admin),
+                        onClick = {
+                            onGrantAdminClick()
+                            onDismissRequest()
+                        }
+                    )
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+
+                GroupMemberActionRow(
+                    text = stringResource(R.string.chat_group_remove_participant),
+                    textColor = Color(0xFFFF3B30),
+                    onClick = {
+                        onRemoveClick()
+                        onDismissRequest()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupMemberActionRow(
+    text: String,
+    textColor: Color = Color.Black,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) { onClick() }
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = text,
+            color = textColor,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+private fun GroupMemberRow(
+    member: GroupMember,
+    onMoreClick: (GroupMember) -> Unit,
+) {
+    val canShowActions = !member.isCreator && member.user.id != null
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Avatar(
+            url = member.user.image?.path,
+            name = member.user.fullName,
+            size = 40.dp
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = member.user.fullName.orEmpty(),
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp,
+                color = Color.Black
+            )
+            if (member.isAdmin && !member.isCreator) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.chat_create_group_admin_label),
+                    color = Color(0xFF2E83D9),
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 12.sp
+                )
+            }
+            member.status?.takeIf { it.isNotBlank() }?.let { status ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = status,
+                    fontSize = 12.sp,
+                    color = Color(0xFF8083A0)
+                )
+            }
+        }
+
+        if (canShowActions) {
+            IconButton(onClick = { onMoreClick(member) }) {
+                Icon(
+                    imageVector = Icons.Filled.MoreVert,
+                    contentDescription = null,
+                    tint = Color(0xFFB0B2C3)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
@@ -29,11 +29,15 @@ import kotlin.collections.buildList
 @Composable
 fun ChatDetailMoreSheetDialog(
     dialogId: Long,
+    isGroup: Boolean,
     onNavigateToProfile: () -> Unit,
     onDismissRequest: () -> Unit,
     onChatDeleted: () -> Unit,
     onEditGroup: () -> Unit,
     isCurrentUserAdmin: Boolean,
+    notificationsDisabled: Boolean = false,
+    onLeaveGroup: () -> Unit = {},
+    onNotificationsChanged: (Boolean) -> Unit = {},
     viewModel: ChatFunctionsViewModel = hiltViewModel(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -59,23 +63,71 @@ fun ChatDetailMoreSheetDialog(
                 .padding(20.dp)
         ) {
             val items = buildList {
-                if (isCurrentUserAdmin) {
-                    add(R.string.chat_edit_group to {
-                        onEditGroup()
+                if (isGroup) {
+                    if (isCurrentUserAdmin) {
+                        add(R.string.chat_edit_group to {
+                            onEditGroup()
+                            onDismissRequest()
+                        })
+                        add(
+                            if (notificationsDisabled) R.string.chat_enable_notifications else R.string.chat_disable_notifications
+                                to {
+                                    if (notificationsDisabled) {
+                                        viewModel.enableNotifications(dialogId)
+                                        onNotificationsChanged(false)
+                                    } else {
+                                        viewModel.disableNotifications(dialogId)
+                                        onNotificationsChanged(true)
+                                    }
+                                    onDismissRequest()
+                                }
+                        )
+                        add(R.string.chat_delete_group to {
+                            viewModel.deleteGroupChat(dialogId)
+                            onDismissRequest()
+                        })
+                    } else {
+                        add(
+                            if (notificationsDisabled) R.string.chat_enable_notifications else R.string.chat_disable_notifications
+                                to {
+                                    if (notificationsDisabled) {
+                                        viewModel.enableNotifications(dialogId)
+                                        onNotificationsChanged(false)
+                                    } else {
+                                        viewModel.disableNotifications(dialogId)
+                                        onNotificationsChanged(true)
+                                    }
+                                    onDismissRequest()
+                                }
+                        )
+                        add(R.string.chat_leave_group to {
+                            viewModel.leaveGroup(dialogId)
+                            onLeaveGroup()
+                            onDismissRequest()
+                        })
+                    }
+                } else {
+                    add(R.string.chat_go_to_profile to {
+                        onNavigateToProfile()
                         onDismissRequest()
                     })
+                    add(
+                        if (notificationsDisabled) R.string.chat_enable_notifications else R.string.chat_disable_notifications
+                            to {
+                                if (notificationsDisabled) {
+                                    viewModel.enableNotifications(dialogId)
+                                    onNotificationsChanged(false)
+                                } else {
+                                    viewModel.disableNotifications(dialogId)
+                                    onNotificationsChanged(true)
+                                }
+                                onDismissRequest()
+                            }
+                    )
+                    add(R.string.chat_delete_chat to {
+                        viewModel.deleteChat(dialogId)
+                    })
                 }
-                add(R.string.chat_go_to_profile to {
-                    onNavigateToProfile()
-                    onDismissRequest()
-                })
-                add(R.string.chat_disable_notifications to {
-                    viewModel.disableNotifications(dialogId)
-                    onDismissRequest()
-                })
-                add(R.string.chat_delete_chat to {
-                    viewModel.deleteChat(dialogId)
-                })
             }
             items.forEach { (textRes, action) ->
                 Row(

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
@@ -42,6 +42,7 @@ fun ChatTopBar(
     onDetailClick: () -> Unit,
     onSearchClick: () -> Unit,
     onBackPressed: () -> Unit,
+    onMoreClick: () -> Unit,
 ) {
     Surface(elevation = 4.dp) {
         Column {
@@ -107,7 +108,7 @@ fun ChatTopBar(
                     )
                 }
 
-                IconButton(onClick = { }) {
+                IconButton(onClick = onMoreClick) {
                     Icon(Icons.Default.MoreVert, contentDescription = "More", tint = Color(0xFF2E83D9))
                 }
             }

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -57,6 +57,12 @@
     </fragment>
 
     <fragment
+        android:id="@+id/chatEditGroupFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatEditGroupFragment">
+
+    </fragment>
+
+    <fragment
         android:id="@+id/chatFolderSettingsFragment"
         android:name="uddug.com.naukoteka.ui.chat.ChatFolderSettingsFragment">
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -118,4 +118,7 @@
   <string name="chat_file_attachment_unknown_type">ملف</string>
   <string name="chat_file_download_started">جاري تنزيل الملف…</string>
   <string name="labor_activity_name">%1$s в <font color="#2E83D9">%2$s</font></string>
+  <string name="chat_delete_group">حذف المجموعة</string>
+  <string name="chat_leave_group">مغادرة المجموعة</string>
+  <string name="chat_edit_group_remove_avatar">إزالة صورة المجموعة</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -224,4 +224,7 @@
     <item quantity="other">%d дня назад</item>
   </plurals>
   <string name="chat_edit_group">Редактировать группу</string>
+  <string name="chat_delete_group">Удалить группу</string>
+  <string name="chat_leave_group">Покинуть группу</string>
+  <string name="chat_edit_group_remove_avatar">Удалить фото группы</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,9 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_edit_group">Редактировать группу</string>
     <string name="chat_disable_notifications">Отключить уведомления</string>
     <string name="chat_enable_notifications">Включить уведомления</string>
+    <string name="chat_delete_group">Удалить группу</string>
+    <string name="chat_leave_group">Покинуть группу</string>
+    <string name="chat_edit_group_remove_avatar">Удалить фото группы</string>
     <string name="chat_select_messages">Выделить сообщения</string>
     <string name="chat_block_chat">Заблокировать чат</string>
     <string name="chat_unblock_chat">Разблокировать чат</string>

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -16,6 +16,8 @@ import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
 import uddug.com.data.services.models.request.chat.UpdateMessageFileDto
 import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
 import uddug.com.data.services.models.request.chat.UpdateDialogInfoRequestDto
+import uddug.com.data.services.models.request.chat.UpdateGroupAdminRequestDto
+import uddug.com.data.services.models.request.chat.UpdateGroupDialogRequestDto
 import uddug.com.data.services.models.request.chat.UsersStatusRequestDto
 import uddug.com.data.services.models.response.chat.FileDto
 import uddug.com.data.services.models.response.chat.FolderDetailsDto
@@ -299,6 +301,32 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun updateGroupDialog(
+        dialogId: Long,
+        dialogName: String?,
+        imageId: String?,
+        removeImage: Boolean,
+        users: List<String>?,
+    ): DialogInfo {
+        return try {
+            val imageRequest = when {
+                removeImage -> DialogImageRequestDto("")
+                imageId != null -> DialogImageRequestDto(imageId)
+                else -> null
+            }
+            val request = UpdateGroupDialogRequestDto(
+                name = dialogName,
+                image = imageRequest,
+                users = users
+            )
+            val dialogInfoDto = apiService.updateGroupDialog(dialogId, request)
+            mapDialogInfoDtoToDomain(dialogInfoDto)
+        } catch (e: Exception) {
+            println("Error updating group dialog: ${e.message}")
+            throw e
+        }
+    }
+
     override suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, status: Int) {
         val request = ReadMessagesRequestDto(dialogId, messages, status)
         apiService.markMessagesRead(request)
@@ -342,6 +370,22 @@ class ChatRepositoryImpl @Inject constructor(
 
     override suspend fun deleteDialog(dialogId: Long) {
         apiService.deleteDialog(dialogId)
+    }
+
+    override suspend fun deleteGroupDialog(dialogId: Long) {
+        apiService.deleteGroupDialog(dialogId)
+    }
+
+    override suspend fun leaveGroupDialog(dialogId: Long) {
+        apiService.leaveGroupDialog(dialogId)
+    }
+
+    override suspend fun makeDialogAdmin(dialogId: Long, userId: String) {
+        apiService.makeDialogAdmin(dialogId, UpdateGroupAdminRequestDto(userId))
+    }
+
+    override suspend fun removeDialogAdmin(dialogId: Long, userId: String) {
+        apiService.removeDialogAdmin(dialogId, UpdateGroupAdminRequestDto(userId))
     }
 
     override suspend fun pinMessage(dialogId: Long, messageId: Long) {

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -17,6 +17,8 @@ import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
 import uddug.com.data.services.models.request.chat.PinMessageRequestDto
 import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
 import uddug.com.data.services.models.request.chat.UpdateDialogInfoRequestDto
+import uddug.com.data.services.models.request.chat.UpdateGroupAdminRequestDto
+import uddug.com.data.services.models.request.chat.UpdateGroupDialogRequestDto
 import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
 import uddug.com.data.services.models.response.chat.ChatDto
 import uddug.com.data.services.models.response.chat.DialogInfoDto
@@ -121,6 +123,12 @@ interface ChatApiService {
         @Body request: UpdateDialogInfoRequestDto,
     ): DialogInfoDto
 
+    @PATCH("chat/v2/dialogs/{dialogId}")
+    suspend fun updateGroupDialog(
+        @Path("dialogId") dialogId: Long,
+        @Body request: UpdateGroupDialogRequestDto,
+    ): DialogInfoDto
+
     @POST("chat/v1/dialogs/pin/{dialogId}")
     suspend fun pinDialog(@Path("dialogId") dialogId: Long)
 
@@ -150,6 +158,24 @@ interface ChatApiService {
 
     @DELETE("chat/v1/dialogs/{dialogId}")
     suspend fun deleteDialog(@Path("dialogId") dialogId: Long)
+
+    @DELETE("chat/v2/dialogs/chat/{dialogId}")
+    suspend fun deleteGroupDialog(@Path("dialogId") dialogId: Long)
+
+    @PATCH("chat/v2/dialogs/leave/{dialogId}")
+    suspend fun leaveGroupDialog(@Path("dialogId") dialogId: Long)
+
+    @POST("chat/v2/dialogs/make-admin/{dialogId}")
+    suspend fun makeDialogAdmin(
+        @Path("dialogId") dialogId: Long,
+        @Body request: UpdateGroupAdminRequestDto,
+    )
+
+    @PATCH("chat/v2/dialogs/remove-admin/{dialogId}")
+    suspend fun removeDialogAdmin(
+        @Path("dialogId") dialogId: Long,
+        @Body request: UpdateGroupAdminRequestDto,
+    )
 
     @PATCH("chat/v1/messages/update")
     suspend fun updateMessage(@Body request: UpdateMessageRequestDto): MessageDto

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateGroupAdminRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateGroupAdminRequestDto.kt
@@ -1,0 +1,7 @@
+package uddug.com.data.services.models.request.chat
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdateGroupAdminRequestDto(
+    @SerializedName("userId") val userId: String,
+)

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateGroupDialogRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/UpdateGroupDialogRequestDto.kt
@@ -1,0 +1,9 @@
+package uddug.com.data.services.models.request.chat
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdateGroupDialogRequestDto(
+    @SerializedName("name") val name: String? = null,
+    @SerializedName("image") val image: DialogImageRequestDto? = null,
+    @SerializedName("users") val users: List<String>? = null,
+)

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -109,6 +109,15 @@ class ChatInteractor @Inject constructor(
     ): DialogInfo =
         chatRepository.updateDialogInfo(dialogId, dialogName, imageId, removeImage)
 
+    suspend fun updateGroupDialog(
+        dialogId: Long,
+        dialogName: String? = null,
+        imageId: String? = null,
+        removeImage: Boolean = false,
+        users: List<String>? = null,
+    ): DialogInfo =
+        chatRepository.updateGroupDialog(dialogId, dialogName, imageId, removeImage, users)
+
     suspend fun searchUsers(query: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo> =
         chatRepository.searchUsers(query, limit, page)
 
@@ -140,6 +149,16 @@ class ChatInteractor @Inject constructor(
 
     suspend fun uploadFiles(files: List<JavaFile>, raw: Boolean = false): List<ChatFile> =
         chatRepository.uploadFiles(files, raw)
+
+    suspend fun deleteGroupDialog(dialogId: Long) = chatRepository.deleteGroupDialog(dialogId)
+
+    suspend fun leaveGroupDialog(dialogId: Long) = chatRepository.leaveGroupDialog(dialogId)
+
+    suspend fun makeDialogAdmin(dialogId: Long, userId: String) =
+        chatRepository.makeDialogAdmin(dialogId, userId)
+
+    suspend fun removeDialogAdmin(dialogId: Long, userId: String) =
+        chatRepository.removeDialogAdmin(dialogId, userId)
 
     suspend fun getUsersStatus(userIds: List<String>): List<UserStatus> =
         chatRepository.getUsersStatus(userIds)

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -102,6 +102,14 @@ interface ChatRepository {
         removeImage: Boolean = false,
     ): DialogInfo
 
+    suspend fun updateGroupDialog(
+        dialogId: Long,
+        dialogName: String? = null,
+        imageId: String? = null,
+        removeImage: Boolean = false,
+        users: List<String>? = null,
+    ): DialogInfo
+
     suspend fun searchUsers(searchField: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo>
 
     suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, status: Int)
@@ -125,6 +133,14 @@ interface ChatRepository {
     suspend fun clearDialog(dialogId: Long)
 
     suspend fun deleteDialog(dialogId: Long)
+
+    suspend fun deleteGroupDialog(dialogId: Long)
+
+    suspend fun leaveGroupDialog(dialogId: Long)
+
+    suspend fun makeDialogAdmin(dialogId: Long, userId: String)
+
+    suspend fun removeDialogAdmin(dialogId: Long, userId: String)
 
     suspend fun pinMessage(dialogId: Long, messageId: Long)
 


### PR DESCRIPTION
## Summary
- add network DTOs, repository, and interactor methods for updating, deleting, leaving, and managing admins in group dialogs
- extend chat screens and view models with admin-aware options including delete/leave actions and navigation to the new edit group flow
- introduce edit group fragment, compose UI, and view model to rename, update avatar, manage members, and adjust admin roles

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de81a68ee48327a4cc598807433a56