### PR TITLE
Fix chat detail compilation errors

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -264,14 +264,6 @@ fun ChatDetailDialogComponent(
                             fontSize = 14.sp,
                             color = Color.Gray
                         )
-                        if (state.status.isNotBlank()) {
-                            Text(
-                                text = state.status,
-                                fontSize = 14.sp,
-                                color = Color.Gray
-                            )
-                        }
-
                         Spacer(modifier = Modifier.height(16.dp))
                         Row {
                             Column(

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
@@ -62,7 +62,7 @@ fun ChatDetailMoreSheetDialog(
                 .fillMaxWidth()
                 .padding(20.dp)
         ) {
-            val items = buildList {
+            val items = buildList<Pair<Int, () -> Unit>> {
                 if (isGroup) {
                     if (isCurrentUserAdmin) {
                         add(R.string.chat_edit_group to {


### PR DESCRIPTION
## Summary
- fix the chat detail action list to build an explicit list of text/action pairs
- remove the obsolete status text usage from the chat detail dialog UI

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df86b21f7c832785058aca0c6f8bb4