### PR TITLE
Enable image viewer for chat images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,6 +171,7 @@ dependencies {
 
     implementation lib.domain
     implementation lib.data
+    implementation 'com.github.stfalcon-studio:StfalconImageViewer:v1.0.1'
     implementation("com.github.dhaval2404:imagepicker:2.1")
     debugImplementation "com.github.chuckerteam.chucker:library:4.0.0"
     releaseImplementation "com.github.chuckerteam.chucker:library-no-op:4.0.0"

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -37,6 +37,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import com.bumptech.glide.Glide
+import com.stfalcon.imageviewer.StfalconImageViewer
 import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.launch
+import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.mvvm.chat.ChatDialogUiState
 import uddug.com.naukoteka.mvvm.chat.ChatDialogViewModel
 import uddug.com.naukoteka.mvvm.chat.ContactInfo
@@ -62,6 +65,7 @@ import uddug.com.naukoteka.ui.chat.compose.components.ChatTopBar
 import uddug.com.naukoteka.ui.chat.compose.components.MessageListShimmer
 import uddug.com.naukoteka.ui.chat.compose.util.uriToFile
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.domain.entities.chat.File as ChatAttachmentFile
 import uddug.com.naukoteka.ui.chat.AudioRecorder
 import uddug.com.naukoteka.ui.chat.compose.formatMessageDate
 import uddug.com.naukoteka.ui.chat.compose.messageDate
@@ -113,6 +117,15 @@ fun ChatDialogComponent(
             recordingTime = 0L
             isRecording = true
         }
+    }
+
+    fun openImageViewer(file: ChatAttachmentFile) {
+        val imageUrl = BuildConfig.IMAGE_SERVER_URL + file.path
+        StfalconImageViewer.Builder<String>(context, listOf(imageUrl)) { imageView, image ->
+            Glide.with(context)
+                .load(image)
+                .into(imageView)
+        }.show()
     }
 
     LaunchedEffect(isRecording) {
@@ -316,7 +329,8 @@ fun ChatDialogComponent(
                                             scrollState.animateScrollToItem(index)
                                         }
                                     }
-                                }
+                                },
+                                onImageClick = ::openImageViewer
                             )
                         }
                     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -72,6 +72,7 @@ fun ChatMessageItem(
     onSelectChange: () -> Unit = {},
     onLongPress: (MessageChat) -> Unit,
     onReplyReferenceClick: (Long) -> Unit = {},
+    onImageClick: (ChatFile) -> Unit = {},
 ) {
     val isSystem = message.type == MessageType.SYSTEM
     Row(
@@ -183,6 +184,7 @@ fun ChatMessageItem(
                 message.files.firstOrNull()?.let { file ->
                     Spacer(modifier = Modifier.height(6.dp))
                     if (file.contentType?.startsWith("image") == true) {
+                        val imageInteractionSource = remember { MutableInteractionSource() }
                         Column {
                             AsyncImage(
                                 model = BuildConfig.IMAGE_SERVER_URL.plus(file.path),
@@ -190,6 +192,16 @@ fun ChatMessageItem(
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier
                                     .clip(RoundedCornerShape(12.dp))
+                                    .clickable(
+                                        interactionSource = imageInteractionSource,
+                                        indication = null
+                                    ) {
+                                        if (selectionMode) {
+                                            onSelectChange()
+                                        } else {
+                                            onImageClick(file)
+                                        }
+                                    }
                                     .fillMaxWidth()
                                     .height(140.dp)
                             )


### PR DESCRIPTION
## Summary
- add the Stfalcon ImageViewer dependency to support displaying images in chat
- hook chat image attachments to launch the viewer from the dialog component
- make chat message items notify when an image is tapped so it opens the viewer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e39d5192dc8327833f5dcfb5feb395