### PR TITLE
Fix group chat avatar in dialog screen

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
@@ -67,7 +67,7 @@ fun ChatTopBar(
                         }
                 ) {
                     Avatar(
-                        url = image.takeIf { !isGroup && it.isNotEmpty() },
+                        url = image.takeIf { it.isNotEmpty() },
                         name = if (isGroup) null else name,
                         size = 36.dp,
                         overrideInitials = if (isGroup) stringResource(R.string.chat_group_initial) else null,


### PR DESCRIPTION
## Summary
- allow the chat dialog top bar to load the group avatar when it is available instead of always showing initials

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e39e186a848327a2611ae552f97f3d