### PR TITLE
Add overlay remove avatar icon in edit group screen

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditGroupScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditGroupScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
@@ -33,6 +34,7 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -383,22 +385,29 @@ private fun EditGroupAvatarPicker(
                 CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
             }
         }
-    }
-    if (showRemove) {
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = stringResource(R.string.chat_edit_group_remove_avatar),
-            color = Color(0xFFFF3B30),
-            fontSize = 14.sp,
-            fontWeight = FontWeight.Medium,
-            modifier = Modifier
-                .clip(RoundedCornerShape(8.dp))
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null
-                ) { onRemoveAvatar() }
-                .padding(horizontal = 8.dp, vertical = 4.dp)
-        )
+
+        if (showRemove) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(4.dp)
+                    .size(20.dp)
+                    .clip(CircleShape)
+                    .background(Color.White)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    ) { onRemoveAvatar() },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.chat_edit_group_remove_avatar),
+                    tint = Color(0xFFFF3B30),
+                    modifier = Modifier.size(12.dp)
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the remove avatar text under the editor with a red close icon overlay in the avatar picker
- keep the remove control available while uploads are shown by placing it inside the avatar box

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39d8b399883278d47e442747f4700