### PR TITLE
Fix media search categories for group chats

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
@@ -37,10 +37,10 @@ class ChatDialogDetailViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val tabToCategoryMap = mapOf(
-        0 to 1, 
-        1 to 3, 
-        2 to 6, 
-        3 to 7, 
+        0 to CATEGORY_MEDIA,
+        1 to CATEGORY_FILES,
+        2 to CATEGORY_VOICE,
+        3 to CATEGORY_NOTES,
     )
 
     private val _uiState = MutableStateFlow<ChatDetailUiState>(ChatDetailUiState.Loading)
@@ -232,7 +232,7 @@ class ChatDialogDetailViewModel @Inject constructor(
                 }
                 _searchMedia.value = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = 1,
+                    category = CATEGORY_MEDIA,
                     limit = 50,
                     page = 1,
                     query = query,
@@ -241,7 +241,7 @@ class ChatDialogDetailViewModel @Inject constructor(
                 )
                 _searchFiles.value = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = 3,
+                    category = CATEGORY_FILES,
                     limit = 50,
                     page = 1,
                     query = query,
@@ -250,7 +250,7 @@ class ChatDialogDetailViewModel @Inject constructor(
                 )
                 _searchNotes.value = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = 7,
+                    category = CATEGORY_NOTES,
                     limit = 50,
                     page = 1,
                     query = query,
@@ -330,6 +330,11 @@ class ChatDialogDetailViewModel @Inject constructor(
     }
 
 }
+
+private const val CATEGORY_MEDIA = 5
+private const val CATEGORY_FILES = 3
+private const val CATEGORY_VOICE = 6
+private const val CATEGORY_NOTES = 7
 
 sealed class ChatDetailUiState {
     object Loading : ChatDetailUiState()

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
@@ -247,7 +247,7 @@ class ChatGroupDetailViewModel @Inject constructor(
             try {
                 val media = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = 1,
+                    category = MEDIA_CATEGORY,
                     limit = 50,
                     page = 1,
                     query = null,
@@ -271,7 +271,7 @@ class ChatGroupDetailViewModel @Inject constructor(
             try {
                 val files = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = 3,
+                    category = FILES_CATEGORY,
                     limit = 50,
                     page = 1,
                     query = null,
@@ -328,6 +328,8 @@ class ChatGroupDetailViewModel @Inject constructor(
     companion object {
         private const val ROLE_OWNER = "37:201"
         private const val ROLE_ADMIN = "37:202"
+        private const val MEDIA_CATEGORY = 5
+        private const val FILES_CATEGORY = 3
     }
 }
 


### PR DESCRIPTION
## Summary
- switch media tab loading in group detail view to use the API media category that returns audio-visual attachments
- reuse the same media category when searching across dialog content to ensure consistent results
- centralize media category constants for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e39f7099088327a10ec75f9e77b914