### PR TITLE
Add file actions bottom sheet for chat files

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/FileFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/FileFunctionsBottomSheetDialog.kt
@@ -1,0 +1,101 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import uddug.com.naukoteka.R
+
+enum class FileFunctionAction {
+    COPY_LINK,
+    DOWNLOAD,
+    SHARE,
+    EDIT_INFO,
+    SELECT,
+    DELETE,
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FileFunctionsBottomSheetDialog(
+    fileName: String,
+    onDismissRequest: () -> Unit,
+    onActionSelected: (FileFunctionAction) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 20.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.chat_file_functions_title),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontSize = MaterialTheme.typography.titleMedium.fontSize * 1.3f
+                )
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            if (fileName.isNotBlank()) {
+                Text(
+                    text = fileName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                )
+                Spacer(modifier = Modifier.height(10.dp))
+            } else {
+                Spacer(modifier = Modifier.height(10.dp))
+            }
+
+            val items = listOf(
+                FileFunctionAction.COPY_LINK to R.string.chat_file_action_copy_link,
+                FileFunctionAction.DOWNLOAD to R.string.chat_file_action_download,
+                FileFunctionAction.SHARE to R.string.chat_file_action_share,
+                FileFunctionAction.EDIT_INFO to R.string.chat_file_action_edit_info,
+                FileFunctionAction.SELECT to R.string.chat_file_action_select,
+                FileFunctionAction.DELETE to R.string.chat_file_action_delete,
+            )
+
+            items.forEach { (action, titleRes) ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                        ) {
+                            onActionSelected(action)
+                            onDismissRequest()
+                        }
+                        .padding(vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(id = titleRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -117,6 +117,17 @@
   <string name="search_contacts_hint">Поиск по контактам</string>
   <string name="chat_file_attachment_unknown_type">ملف</string>
   <string name="chat_file_download_started">جاري تنزيل الملف…</string>
+  <string name="chat_file_functions_title">Functions</string>
+  <string name="chat_file_action_copy_link">Copy link</string>
+  <string name="chat_file_action_download">Download file</string>
+  <string name="chat_file_action_share">Share</string>
+  <string name="chat_file_action_edit_info">Edit info</string>
+  <string name="chat_file_action_select">Select</string>
+  <string name="chat_file_action_delete">Delete file</string>
+  <string name="chat_file_link_copied">File link copied</string>
+  <string name="chat_file_action_not_available">Action is not available yet</string>
+  <string name="chat_file_share_title">Share file</string>
+  <string name="chat_file_share_error">No apps available to share</string>
   <string name="labor_activity_name">%1$s в <font color="#2E83D9">%2$s</font></string>
   <string name="chat_delete_group">حذف المجموعة</string>
   <string name="chat_leave_group">مغادرة المجموعة</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,6 +497,17 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_message_show_original">Показать оригинал в чате</string>
     <string name="chat_message_delete">Удалить сообщение</string>
     <string name="chat_editing_title">Редактирование</string>
+    <string name="chat_file_functions_title">Функции</string>
+    <string name="chat_file_action_copy_link">Скопировать ссылку</string>
+    <string name="chat_file_action_download">Скачать файл</string>
+    <string name="chat_file_action_share">Поделиться</string>
+    <string name="chat_file_action_edit_info">Изменить информацию</string>
+    <string name="chat_file_action_select">Выбрать</string>
+    <string name="chat_file_action_delete">Удалить файл</string>
+    <string name="chat_file_link_copied">Ссылка на файл скопирована</string>
+    <string name="chat_file_action_not_available">Функция пока недоступна</string>
+    <string name="chat_file_share_title">Поделиться файлом</string>
+    <string name="chat_file_share_error">Не удалось открыть приложения для отправки</string>
     <string name="create_group_chat">Создать групповой чат</string>
     <string name="chat_create_group_title">Создать группу</string>
     <string name="chat_create_group_name_placeholder">Укажите название группы</string>


### PR DESCRIPTION
## Summary
- add a long-press bottom sheet for chat file items with contextual actions
- implement copy link, download, and share behaviors with fallbacks for unavailable options
- provide string resources for the new file functions in default and Arabic locales

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a86a7e0c83279039169e17a9a8af