### PR TITLE
Stop including owner on media socket messages

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -681,12 +681,14 @@ class ChatDialogViewModel @Inject constructor(
 
             val cType = 1
 
+            val ownerId = if (fileDescriptors.isNotEmpty()) null else currentUser?.id.orEmpty()
+
             val message = if (dialog.id != 0L) {
                 ChatSocketMessage(
                     dialog = dialog.id,
                     cType = cType,
                     text = sanitizedText,
-                    owner = currentUser?.id.orEmpty(),
+                    owner = ownerId,
                     files = fileDescriptors.ifEmpty { null },
                     answered = replyId
                 )
@@ -696,7 +698,7 @@ class ChatDialogViewModel @Inject constructor(
                     interlocutor = peer,
                     cType = cType,
                     text = sanitizedText,
-                    owner = currentUser?.id.orEmpty(),
+                    owner = ownerId,
                     files = fileDescriptors.ifEmpty { null },
                     answered = replyId
                 )
@@ -731,7 +733,7 @@ class ChatDialogViewModel @Inject constructor(
                     dialog = dialog.id,
                     cType = 4,
                     text = "",
-                    owner = currentUser?.id.orEmpty(),
+                    owner = null,
                     files = descriptor?.let { listOf(it) }
                 )
             } else {
@@ -740,7 +742,7 @@ class ChatDialogViewModel @Inject constructor(
                     interlocutor = peer,
                     cType = 4,
                     text = "",
-                    owner = currentUser?.id.orEmpty(),
+                    owner = null,
                     files = descriptor?.let { listOf(it) }
                 )
             }


### PR DESCRIPTION
## Summary
- skip populating the owner field when emitting chat messages that contain attachments
- omit the owner field when sending voice messages over the socket

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3aa2cd33c8327939e13b94eb18b41