### PR TITLE
Remove file icon for file messages in chat list

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -182,12 +182,14 @@ fun ChatCard(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.padding(top = if (isGroupChat) 4.dp else 0.dp)
                     ) {
-                        attachmentPreview?.let { preview ->
-                            AttachmentPreview(
-                                preview = preview,
-                                modifier = Modifier.padding(end = 8.dp)
-                            )
-                        }
+                        attachmentPreview
+                            ?.takeUnless { it.type == ChatAttachmentType.FILE }
+                            ?.let { preview ->
+                                AttachmentPreview(
+                                    preview = preview,
+                                    modifier = Modifier.padding(end = 8.dp)
+                                )
+                            }
                         Text(
                             text = messageText,
                             style = TextStyle(


### PR DESCRIPTION
## Summary
- hide the attachment preview icon when the last message is a file so the card shows only the filename text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3aa6b2ba4832797100fdee0acb0b6