### PR TITLE
Fix media search category mapping in chat detail view models

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
@@ -331,7 +331,7 @@ class ChatDialogDetailViewModel @Inject constructor(
 
 }
 
-private const val CATEGORY_MEDIA = 5
+private const val CATEGORY_MEDIA = 1
 private const val CATEGORY_FILES = 3
 private const val CATEGORY_VOICE = 6
 private const val CATEGORY_NOTES = 7

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
@@ -328,7 +328,7 @@ class ChatGroupDetailViewModel @Inject constructor(
     companion object {
         private const val ROLE_OWNER = "37:201"
         private const val ROLE_ADMIN = "37:202"
-        private const val MEDIA_CATEGORY = 5
+        private const val MEDIA_CATEGORY = 1
         private const val FILES_CATEGORY = 3
     }
 }


### PR DESCRIPTION
## Summary
- update the media tab category mapping to request category 1 for dialog and group chat searches, matching the API expectations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3ac84addc832786d264823edf8895