### PR TITLE
Refine chat media search categories

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import uddug.com.domain.entities.chat.ChatMediaCategory
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
@@ -37,10 +38,10 @@ class ChatDialogDetailViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val tabToCategoryMap = mapOf(
-        0 to CATEGORY_MEDIA,
-        1 to CATEGORY_FILES,
-        2 to CATEGORY_VOICE,
-        3 to CATEGORY_NOTES,
+        0 to ChatMediaCategory.MEDIA,
+        1 to ChatMediaCategory.FILES,
+        2 to ChatMediaCategory.VOICE_MESSAGES,
+        3 to ChatMediaCategory.CALL_RECORDINGS,
     )
 
     private val _uiState = MutableStateFlow<ChatDetailUiState>(ChatDetailUiState.Loading)
@@ -232,7 +233,7 @@ class ChatDialogDetailViewModel @Inject constructor(
                 }
                 _searchMedia.value = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = CATEGORY_MEDIA,
+                    category = ChatMediaCategory.MEDIA,
                     limit = 50,
                     page = 1,
                     query = query,
@@ -241,7 +242,7 @@ class ChatDialogDetailViewModel @Inject constructor(
                 )
                 _searchFiles.value = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = CATEGORY_FILES,
+                    category = ChatMediaCategory.FILES,
                     limit = 50,
                     page = 1,
                     query = query,
@@ -250,7 +251,7 @@ class ChatDialogDetailViewModel @Inject constructor(
                 )
                 _searchNotes.value = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = CATEGORY_NOTES,
+                    category = ChatMediaCategory.CALL_RECORDINGS,
                     limit = 50,
                     page = 1,
                     query = query,
@@ -330,11 +331,6 @@ class ChatDialogDetailViewModel @Inject constructor(
     }
 
 }
-
-private const val CATEGORY_MEDIA = 1
-private const val CATEGORY_FILES = 3
-private const val CATEGORY_VOICE = 6
-private const val CATEGORY_NOTES = 7
 
 sealed class ChatDetailUiState {
     object Loading : ChatDetailUiState()

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatGroupDetailViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 
 import kotlinx.coroutines.withContext
+import uddug.com.domain.entities.chat.ChatMediaCategory
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.User
@@ -20,7 +21,6 @@ import uddug.com.domain.repositories.user_profile.UserProfileRepository
 import uddug.com.naukoteka.mvvm.chat.ChatStatusFormatter
 import uddug.com.naukoteka.mvvm.chat.ChatStatusTextMode.GENERIC
 import java.time.Instant
-import java.io.File
 import javax.inject.Inject
 
 @HiltViewModel
@@ -247,7 +247,7 @@ class ChatGroupDetailViewModel @Inject constructor(
             try {
                 val media = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = MEDIA_CATEGORY,
+                    category = ChatMediaCategory.MEDIA,
                     limit = 50,
                     page = 1,
                     query = null,
@@ -271,7 +271,7 @@ class ChatGroupDetailViewModel @Inject constructor(
             try {
                 val files = chatInteractor.getDialogMedia(
                     dialogId,
-                    category = FILES_CATEGORY,
+                    category = ChatMediaCategory.FILES,
                     limit = 50,
                     page = 1,
                     query = null,
@@ -328,8 +328,6 @@ class ChatGroupDetailViewModel @Inject constructor(
     companion object {
         private const val ROLE_OWNER = "37:201"
         private const val ROLE_ADMIN = "37:202"
-        private const val MEDIA_CATEGORY = 1
-        private const val FILES_CATEGORY = 3
     }
 }
 

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -42,6 +42,7 @@ import java.net.URLConnection
 import java.util.Locale
 import javax.inject.Inject
 import uddug.com.data.utils.toDomain
+import uddug.com.domain.entities.chat.ChatMediaCategory
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.MediaMessage
@@ -195,7 +196,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     override suspend fun getDialogMedia(
         dialogId: Long,
-        category: Int,
+        category: ChatMediaCategory,
         limit: Int,
         page: Int,
         query: String?,
@@ -205,7 +206,7 @@ class ChatRepositoryImpl @Inject constructor(
         return try {
             apiService.getDialogMedia(
                 dialogId,
-                category = category,
+                category = category.apiValue,
                 limit = limit,
                 page = page,
                 query = query,

--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatMediaCategory.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatMediaCategory.kt
@@ -1,0 +1,8 @@
+package uddug.com.domain.entities.chat
+
+enum class ChatMediaCategory(val apiValue: Int) {
+    MEDIA(1),
+    FILES(3),
+    VOICE_MESSAGES(6),
+    CALL_RECORDINGS(7),
+}

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -4,6 +4,7 @@ import uddug.com.domain.entities.chat.Chat
 import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.ChatFolderDetails
 import uddug.com.domain.entities.chat.ChatFolderDialogsPage
+import uddug.com.domain.entities.chat.ChatMediaCategory
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.MediaMessage
@@ -71,7 +72,8 @@ class ChatInteractor @Inject constructor(
         chatRepository.getMessagesWithOwnerInfo(currentUserId, dialogId, limit, lastMessageId)
 
     suspend fun getDialogMedia(
-        dialogId: Long, category: Int,
+        dialogId: Long,
+        category: ChatMediaCategory,
         limit: Int,
         page: Int,
         query: String?,

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -4,6 +4,7 @@ import uddug.com.domain.entities.chat.Chat
 import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.ChatFolderDetails
 import uddug.com.domain.entities.chat.ChatFolderDialogsPage
+import uddug.com.domain.entities.chat.ChatMediaCategory
 import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.MediaMessage
@@ -65,7 +66,7 @@ interface ChatRepository {
 
     suspend fun getDialogMedia(
         dialogId: Long,
-        category: Int,
+        category: ChatMediaCategory,
         limit: Int,
         page: Int,
         query: String?,


### PR DESCRIPTION
## Summary
- introduce a typed ChatMediaCategory enum to centralize attachment category codes
- update chat detail view models and repositories to use the new enum so media and file searches call the proper categories

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3adf975f883278f8fa2b302ad690a