### PR TITLE
Stop sending empty text for attachment-only chat messages

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -783,11 +783,13 @@ class ChatDialogViewModel @Inject constructor(
 
             val ownerId = if (fileDescriptors.isNotEmpty()) null else currentUser?.id.orEmpty()
 
+            val messageText = sanitizedText.takeIf { it.isNotEmpty() }
+
             val message = if (dialog.id != 0L) {
                 ChatSocketMessage(
                     dialog = dialog.id,
                     cType = cType,
-                    text = sanitizedText,
+                    text = messageText,
                     owner = ownerId,
                     files = fileDescriptors.ifEmpty { null },
                     answered = replyId
@@ -797,7 +799,7 @@ class ChatDialogViewModel @Inject constructor(
                 ChatSocketMessage(
                     interlocutor = peer,
                     cType = cType,
-                    text = sanitizedText,
+                    text = messageText,
                     owner = ownerId,
                     files = fileDescriptors.ifEmpty { null },
                     answered = replyId
@@ -832,7 +834,7 @@ class ChatDialogViewModel @Inject constructor(
                 ChatSocketMessage(
                     dialog = dialog.id,
                     cType = 4,
-                    text = "",
+                    text = null,
                     owner = null,
                     files = descriptor?.let { listOf(it) }
                 )
@@ -841,7 +843,7 @@ class ChatDialogViewModel @Inject constructor(
                 ChatSocketMessage(
                     interlocutor = peer,
                     cType = 4,
-                    text = "",
+                    text = null,
                     owner = null,
                     files = descriptor?.let { listOf(it) }
                 )


### PR DESCRIPTION
## Summary
- prevent chat socket messages from including empty text when only attachments are sent
- avoid sending empty string payloads for voice messages by sending null instead

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3c9075ed88327b1a2fee2ad989284