### PR TITLE
Fix chat list file message preview text

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -151,7 +151,8 @@ fun ChatCard(
                         attachmentPreview != null -> when (attachmentPreview.type) {
                             ChatAttachmentType.IMAGE -> stringResource(R.string.chat_last_message_image)
                             ChatAttachmentType.VIDEO -> stringResource(R.string.chat_last_message_video)
-                            ChatAttachmentType.FILE -> message
+                            ChatAttachmentType.FILE -> message.takeIf { it.isNotBlank() }
+                                ?: stringResource(R.string.chat_last_message_file)
                         }
                         !isGroupChat && isFromMe -> stringResource(R.string.chat_last_message_from_me, message)
                         else -> message

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -390,7 +390,7 @@ fun ChatTabBar(
                                 dialogId = chat.dialogId,
                                 avatarUrl = avatarUrl,
                                 name = displayName,
-                                message = chat.lastMessage.text ?: stringResource(R.string.chat_no_messages),
+                                message = chat.lastMessage.text.orEmpty(),
                                 time = chat.lastMessage.createdAt ?: stringResource(R.string.chat_unknown_time),
                                 newMessagesCount = chat.unreadMessages,
                                 attachmentPreview = attachmentPreview,


### PR DESCRIPTION
## Summary
- show a localized "File" label when the chat preview represents a file attachment
- avoid overriding the preview message so attachment labels can be displayed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3cedc1c6883278d0644274affcb91