### PR TITLE
Add voice message playback UI for chat attachments

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -542,5 +542,6 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
 
     <string name="chat_file_attachment_unknown_type">FILE</string>
     <string name="chat_file_download_started">Downloading file…</string>
+    <string name="chat_voice_message_playback_error">Не удалось воспроизвести голосовое сообщение</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- add playback state management for voice attachments and integrate it with the existing media player
- render chat voice messages with a dedicated compose bubble, controls, waveform artwork, and duration metadata
- provide a localized error message when a voice message fails to play

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK is not available in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ce76c0b483279320c05848022069