### PR TITLE
Add banner for active voice message playback

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -58,6 +58,8 @@ import uddug.com.domain.entities.chat.MessageChat
 import uddug.com.domain.entities.chat.MessageType
 import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.ui.chat.compose.Avatar
+import uddug.com.naukoteka.ui.chat.compose.util.formatVoiceDuration
 import uddug.com.domain.entities.chat.File as ChatFile
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -449,27 +451,6 @@ private fun ChatFile.isVoiceFile(): Boolean {
     return (fileType == VOICE_FILE_TYPE)
         || (extension != null && extension in VOICE_EXTENSIONS)
         || (mimeType?.startsWith("audio") == true)
-}
-
-private fun formatVoiceDuration(duration: String?): String? {
-    val value = duration?.trim().orEmpty()
-    if (value.isEmpty()) return null
-    if (value.contains(':')) return value
-    val numeric = value.toLongOrNull() ?: return value
-    val totalSeconds = when {
-        numeric <= 0L -> return null
-        numeric > 86_400L && numeric % 1000L == 0L -> numeric / 1000L
-        numeric in 1L..86_400L -> numeric
-        else -> numeric / 1000L
-    }
-    val hours = totalSeconds / 3600
-    val minutes = (totalSeconds % 3600) / 60
-    val seconds = totalSeconds % 60
-    return if (hours > 0) {
-        String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds)
-    } else {
-        String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
-    }
 }
 
 @Composable

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/VoicePlaybackBanner.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/VoicePlaybackBanner.kt
@@ -1,0 +1,132 @@
+package uddug.com.naukoteka.ui.chat.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.naukoteka.R
+
+@Composable
+fun VoicePlaybackBanner(
+    isPlaying: Boolean,
+    isLoading: Boolean,
+    senderName: String,
+    remainingTimeText: String,
+    onPlayPauseClick: () -> Unit,
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = Color.White,
+        elevation = 4.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            val interactionSource = remember { MutableInteractionSource() }
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = rememberRipple(bounded = true, radius = 24.dp),
+                        enabled = !isLoading,
+                        onClick = onPlayPauseClick
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = Color(0xFF2E83D9)
+                    )
+                } else {
+                    val icon = if (isPlaying) R.drawable.ic_stop_voice else R.drawable.ic_play_voice
+                    Icon(
+                        painter = painterResource(id = icon),
+                        contentDescription = null,
+                        tint = Color.Unspecified
+                    )
+                }
+            }
+
+            Text(
+                text = senderName,
+                modifier = Modifier.weight(1f),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = Color(0xFF111827),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Text(
+                text = remainingTimeText,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = Color(0xFF2E83D9)
+            )
+
+            Box(
+                modifier = Modifier
+                    .border(
+                        width = 1.dp,
+                        color = Color(0xFF2E83D9),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .background(Color.Transparent, RoundedCornerShape(12.dp))
+                    .padding(horizontal = 10.dp, vertical = 4.dp)
+            ) {
+                Text(
+                    text = "x1",
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFF2E83D9)
+                )
+            }
+
+            IconButton(
+                onClick = onCloseClick,
+                modifier = Modifier.size(36.dp)
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_close),
+                    contentDescription = null,
+                    tint = Color(0xFF6F7A90)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/util/VoiceDurationFormatter.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/util/VoiceDurationFormatter.kt
@@ -1,0 +1,58 @@
+package uddug.com.naukoteka.ui.chat.compose.util
+
+import java.util.Locale
+
+fun formatVoiceDuration(duration: String?): String? {
+    val value = duration?.trim().orEmpty()
+    if (value.isEmpty()) return null
+    if (value.contains(':')) return value
+    val numeric = value.toLongOrNull() ?: return value
+    val totalSeconds = when {
+        numeric <= 0L -> return null
+        numeric > 86_400L && numeric % 1000L == 0L -> numeric / 1000L
+        numeric in 1L..86_400L -> numeric
+        else -> numeric / 1000L
+    }
+    return formatVoiceDurationFromSeconds(totalSeconds)
+}
+
+fun formatVoiceDurationFromMillis(durationMillis: Long): String {
+    if (durationMillis <= 0L) return "00:00"
+    val totalSeconds = (durationMillis / 1000).coerceAtLeast(0L)
+    return formatVoiceDurationFromSeconds(totalSeconds)
+}
+
+fun parseVoiceDurationToMillis(duration: String?): Long? {
+    val value = duration?.trim().orEmpty()
+    if (value.isEmpty()) return null
+    if (value.contains(':')) {
+        val parts = value.split(':')
+        if (parts.any { it.toLongOrNull() == null }) return null
+        var multiplier = 1L
+        var totalSeconds = 0L
+        for (segment in parts.asReversed()) {
+            totalSeconds += (segment.toLongOrNull() ?: return null) * multiplier
+            multiplier *= 60L
+        }
+        return totalSeconds * 1000L
+    }
+    val numeric = value.toLongOrNull() ?: return null
+    val totalSeconds = when {
+        numeric <= 0L -> return null
+        numeric > 86_400L && numeric % 1000L == 0L -> numeric / 1000L
+        numeric in 1L..86_400L -> numeric
+        else -> numeric / 1000L
+    }
+    return totalSeconds * 1000L
+}
+
+private fun formatVoiceDurationFromSeconds(totalSeconds: Long): String {
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable voice playback banner that appears above the chat when a voice message is playing or paused
- track active voice playback metadata and remaining time inside the chat dialog component
- extract shared voice duration formatting helpers for reuse across chat UI components

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d5a98a808327a6dbc28b6940beb4