### PR TITLE
Fix voice playback updates while preparing

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -251,9 +251,12 @@ fun ChatDialogComponent(
         resetVoicePlayback()
     }
 
-    LaunchedEffect(voicePlayingMessageId, isVoicePlaying) {
+    LaunchedEffect(voicePlayingMessageId, isVoicePlaying, isVoicePreparing) {
         if (voicePlayingMessageId == null) {
             voiceRemainingTime = 0L
+            return@LaunchedEffect
+        }
+        if (isVoicePreparing) {
             return@LaunchedEffect
         }
         updateVoiceRemainingTimeFromPlayer()


### PR DESCRIPTION
## Summary
- prevent voice playback banner from querying MediaPlayer duration while still preparing
- include preparation flag in LaunchedEffect dependencies so updates resume after ready

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4deebe3f4832792b5362a7fabb858