### PR TITLE
Add poll creation screen for chat attachments

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreatePollViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatCreatePollViewModel.kt
@@ -1,0 +1,124 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ChatCreatePollViewModel @Inject constructor() : ViewModel() {
+
+    private var nextOptionId = 0L
+
+    private fun createOption(text: String = "") = PollOptionUi(id = nextOptionId++, text = text)
+
+    private val _uiState = MutableStateFlow(
+        ChatCreatePollUiState(
+            options = listOf(createOption(), createOption())
+        )
+    )
+    val uiState: StateFlow<ChatCreatePollUiState> = _uiState
+
+    private val _events = MutableSharedFlow<ChatCreatePollEvent>()
+    val events: SharedFlow<ChatCreatePollEvent> = _events.asSharedFlow()
+
+    fun onQuestionChange(question: String) {
+        _uiState.update { it.copy(question = question) }
+    }
+
+    fun onAnonymousVotingChange(enabled: Boolean) {
+        _uiState.update { it.copy(isAnonymous = enabled) }
+    }
+
+    fun onMultipleAnswersChange(enabled: Boolean) {
+        _uiState.update { it.copy(allowMultipleAnswers = enabled) }
+    }
+
+    fun onQuizModeChange(enabled: Boolean) {
+        _uiState.update { it.copy(isQuizMode = enabled) }
+    }
+
+    fun onOptionChange(id: Long, text: String) {
+        _uiState.update { state ->
+            val updated = state.options.map { option ->
+                if (option.id == id) option.copy(text = text) else option
+            }
+            state.copy(options = normalizeOptions(updated))
+        }
+    }
+
+    fun onCreatePoll() {
+        val state = _uiState.value
+        val options = state.options.filter { it.text.isNotBlank() }
+        if (state.question.isBlank() || options.size < 2) {
+            viewModelScope.launch {
+                _events.emit(ChatCreatePollEvent.ValidationError())
+            }
+            return
+        }
+        val poll = ChatCreatePollData(
+            question = state.question,
+            options = options.map { it.text.trim() },
+            isAnonymous = state.isAnonymous,
+            allowMultipleAnswers = state.allowMultipleAnswers,
+            isQuizMode = state.isQuizMode
+        )
+        viewModelScope.launch {
+            _events.emit(ChatCreatePollEvent.PollCreated(poll))
+        }
+    }
+
+    private fun normalizeOptions(options: List<PollOptionUi>): List<PollOptionUi> {
+        val filled = options.filter { it.text.isNotBlank() }
+        return if (filled.isEmpty()) {
+            val blanks = options.filter { it.text.isBlank() }
+            val preserved = blanks.take(2)
+            val missing = 2 - preserved.size
+            if (missing > 0) {
+                preserved + List(missing) { createOption() }
+            } else {
+                preserved
+            }
+        } else {
+            val blankOption = options.filter { it.text.isBlank() }.lastOrNull() ?: createOption()
+            var result = filled + blankOption
+            if (result.last().text.isNotBlank()) {
+                result = result + createOption()
+            }
+            result
+        }
+    }
+}
+
+data class ChatCreatePollUiState(
+    val question: String = "",
+    val options: List<PollOptionUi> = emptyList(),
+    val isAnonymous: Boolean = true,
+    val allowMultipleAnswers: Boolean = false,
+    val isQuizMode: Boolean = false
+)
+
+data class PollOptionUi(
+    val id: Long,
+    val text: String = ""
+)
+
+data class ChatCreatePollData(
+    val question: String,
+    val options: List<String>,
+    val isAnonymous: Boolean,
+    val allowMultipleAnswers: Boolean,
+    val isQuizMode: Boolean
+)
+
+sealed class ChatCreatePollEvent {
+    class ValidationError(val message: String? = null) : ChatCreatePollEvent()
+    data class PollCreated(val poll: ChatCreatePollData) : ChatCreatePollEvent()
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreatePollFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreatePollFragment.kt
@@ -1,0 +1,65 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatCreatePollEvent
+import uddug.com.naukoteka.mvvm.chat.ChatCreatePollViewModel
+import uddug.com.naukoteka.ui.chat.compose.ChatCreatePollScreen
+
+@AndroidEntryPoint
+class ChatCreatePollFragment : Fragment() {
+
+    private val viewModel: ChatCreatePollViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.events.collectLatest { event ->
+                when (event) {
+                    is ChatCreatePollEvent.ValidationError -> {
+                        val message = event.message ?: getString(R.string.chat_create_poll_validation_error)
+                        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                    }
+                    is ChatCreatePollEvent.PollCreated -> {
+                        Toast.makeText(
+                            requireContext(),
+                            R.string.chat_create_poll_created_stub,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        findNavController().popBackStack()
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatCreatePollScreen(
+                        viewModel = viewModel,
+                        onBack = { requireActivity().onBackPressed() }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -137,6 +137,9 @@ class ChatDialogFragment : Fragment() {
                         onContactClick = {
                             findNavController().navigate(R.id.sendContactFragment)
                         },
+                        onCreatePoll = {
+                            findNavController().navigate(R.id.chatCreatePollFragment)
+                        },
                         onForwardMessage = { message ->
                             val args = Bundle().apply {
                                 putLong(ARG_MESSAGE_ID, message.id)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreatePollScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreatePollScreen.kt
@@ -1,0 +1,312 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.RadioButtonUnchecked
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatCreatePollUiState
+import uddug.com.naukoteka.mvvm.chat.ChatCreatePollViewModel
+import uddug.com.naukoteka.mvvm.chat.PollOptionUi
+
+@Composable
+fun ChatCreatePollScreen(
+    viewModel: ChatCreatePollViewModel,
+    onBack: () -> Unit,
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    val canCreate = state.question.isNotBlank() && state.options.count { it.text.isNotBlank() } >= 2
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.chat_create_poll_title),
+                        color = Color(0xFF1F1F1F),
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = null,
+                            tint = Color(0xFF1F1F1F)
+                        )
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp
+            )
+        },
+        backgroundColor = Color.White
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+                .padding(padding)
+        ) {
+            val scrollState = rememberScrollState()
+            Column(
+                modifier = Modifier
+                    .weight(1f, fill = true)
+                    .verticalScroll(scrollState)
+                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.chat_create_poll_description),
+                    color = Color(0xFF6F6F7B),
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp
+                )
+                QuestionSection(
+                    state = state,
+                    onQuestionChange = viewModel::onQuestionChange
+                )
+                SettingsSection(
+                    state = state,
+                    onAnonymousChange = viewModel::onAnonymousVotingChange,
+                    onMultipleChange = viewModel::onMultipleAnswersChange,
+                    onQuizModeChange = viewModel::onQuizModeChange
+                )
+                OptionsSection(
+                    options = state.options,
+                    onOptionChange = viewModel::onOptionChange
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(
+                onClick = viewModel::onCreatePoll,
+                enabled = canCreate,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = Color(0xFF2E83D9),
+                    contentColor = Color.White,
+                    disabledBackgroundColor = Color(0x4D2E83D9),
+                    disabledContentColor = Color.White
+                )
+            ) {
+                Text(
+                    text = stringResource(R.string.chat_create_poll_create_button),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuestionSection(
+    state: ChatCreatePollUiState,
+    onQuestionChange: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.chat_create_poll_question_section),
+            color = Color(0xFF1F1F1F),
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+        OutlinedTextField(
+            value = state.question,
+            onValueChange = onQuestionChange,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = {
+                Text(
+                    text = stringResource(R.string.chat_create_poll_question_placeholder),
+                    color = Color(0xFFB0B2C3)
+                )
+            },
+            singleLine = false,
+            shape = RoundedCornerShape(12.dp),
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                backgroundColor = Color.White,
+                focusedBorderColor = Color(0xFF2E83D9),
+                unfocusedBorderColor = Color(0xFFE0E0E8),
+                cursorColor = Color(0xFF2E83D9),
+                textColor = Color(0xFF1F1F1F),
+                placeholderColor = Color(0xFFB0B2C3)
+            )
+        )
+    }
+}
+
+@Composable
+private fun SettingsSection(
+    state: ChatCreatePollUiState,
+    onAnonymousChange: (Boolean) -> Unit,
+    onMultipleChange: (Boolean) -> Unit,
+    onQuizModeChange: (Boolean) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            text = stringResource(R.string.chat_create_poll_settings_section),
+            color = Color(0xFF1F1F1F),
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+        PollSettingItem(
+            title = stringResource(R.string.chat_create_poll_setting_anonymous),
+            description = stringResource(R.string.chat_create_poll_setting_anonymous_description),
+            checked = state.isAnonymous,
+            onCheckedChange = onAnonymousChange
+        )
+        PollSettingItem(
+            title = stringResource(R.string.chat_create_poll_setting_multiple),
+            description = stringResource(R.string.chat_create_poll_setting_multiple_description),
+            checked = state.allowMultipleAnswers,
+            onCheckedChange = onMultipleChange
+        )
+        PollSettingItem(
+            title = stringResource(R.string.chat_create_poll_setting_quiz),
+            description = stringResource(R.string.chat_create_poll_setting_quiz_description),
+            checked = state.isQuizMode,
+            onCheckedChange = onQuizModeChange
+        )
+    }
+}
+
+@Composable
+private fun PollSettingItem(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFFF5F5F9), RoundedCornerShape(16.dp))
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = Color(0xFF1F1F1F),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = description,
+                color = Color(0xFF6F6F7B),
+                fontSize = 13.sp,
+                lineHeight = 18.sp
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                checkedTrackColor = Color(0xFF2E83D9),
+                uncheckedThumbColor = Color.White,
+                uncheckedTrackColor = Color(0xFFE0E0E8)
+            )
+        )
+    }
+}
+
+@Composable
+private fun OptionsSection(
+    options: List<PollOptionUi>,
+    onOptionChange: (Long, String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.chat_create_poll_options_section),
+            color = Color(0xFF1F1F1F),
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+        options.forEach { option ->
+            key(option.id) {
+                PollOptionField(
+                    value = option.text,
+                    onValueChange = { onOptionChange(option.id, it) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PollOptionField(
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier.fillMaxWidth(),
+        placeholder = {
+            Text(
+                text = stringResource(R.string.chat_create_poll_option_placeholder),
+                color = Color(0xFF8F8FA0)
+            )
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Outlined.RadioButtonUnchecked,
+                contentDescription = null,
+                tint = Color(0xFFB0B2C3)
+            )
+        },
+        singleLine = true,
+        shape = RoundedCornerShape(12.dp),
+        colors = TextFieldDefaults.textFieldColors(
+            backgroundColor = Color(0xFFF5F5F9),
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
+            cursorColor = Color(0xFF2E83D9),
+            textColor = Color(0xFF1F1F1F),
+            placeholderColor = Color(0xFF8F8FA0),
+            leadingIconColor = Color(0xFFB0B2C3)
+        )
+    )
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -78,6 +78,7 @@ fun ChatDialogComponent(
     onBackPressed: () -> Unit,
     onSearchClick: () -> Unit,
     onContactClick: () -> Unit,
+    onCreatePoll: () -> Unit,
     onForwardMessage: (MessageChat) -> Unit,
     onEditGroup: (Long) -> Unit,
     onChatDeleted: () -> Unit,
@@ -446,7 +447,10 @@ fun ChatDialogComponent(
                         permissionLauncher.launch(filePermissions)
                     }
                 },
-                onPollClick = { showAttachmentSheet = false },
+                onPollClick = {
+                    showAttachmentSheet = false
+                    onCreatePoll()
+                },
                 onContactClick = {
                     showAttachmentSheet = false
                     onContactClick()

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -77,6 +77,10 @@
         android:name="uddug.com.naukoteka.ui.chat.ForwardMessageFragment"/>
 
     <fragment
+        android:id="@+id/chatCreatePollFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatCreatePollFragment" />
+
+    <fragment
         android:id="@+id/chatAvatarPreviewFragment"
         android:name="uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -513,6 +513,22 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_create_group_missing_participants_error">Добавьте участников</string>
     <string name="chat_create_group_generic_error">Произошла ошибка. Попробуйте еще раз</string>
     <string name="chat_create_group_min_members_error">Выберите минимум двух участников</string>
+    <string name="chat_create_poll_title">Добавить опрос</string>
+    <string name="chat_create_poll_description">Вы можете создать опрос внутри чата. Для этого вам необходимо создать хотя бы два варианта ответа и активировать дополнительные функции.</string>
+    <string name="chat_create_poll_question_section">Вопрос для опроса</string>
+    <string name="chat_create_poll_question_placeholder">Задайте вопрос</string>
+    <string name="chat_create_poll_settings_section">Настройки опроса</string>
+    <string name="chat_create_poll_setting_anonymous">Анонимное голосование</string>
+    <string name="chat_create_poll_setting_anonymous_description">Мы не будем показывать, кто и за какой вариант проголосовал.</string>
+    <string name="chat_create_poll_setting_multiple">Выбор нескольких ответов</string>
+    <string name="chat_create_poll_setting_multiple_description">Участники смогут выбрать более одного варианта.</string>
+    <string name="chat_create_poll_setting_quiz">Режим викторины</string>
+    <string name="chat_create_poll_setting_quiz_description">Позволяет отметить правильный ответ и проводить викторины.</string>
+    <string name="chat_create_poll_options_section">Варианты ответа</string>
+    <string name="chat_create_poll_option_placeholder">Добавить ответ</string>
+    <string name="chat_create_poll_create_button">Создать опрос</string>
+    <string name="chat_create_poll_validation_error">Укажите вопрос и минимум два варианта ответа.</string>
+    <string name="chat_create_poll_created_stub">Опрос будет отправлен в ближайшем обновлении.</string>
     <string name="subs">Подписки</string>
 
 


### PR DESCRIPTION
## Summary
- add a dedicated poll creation ViewModel, fragment, and Compose screen with dynamic answer rows and poll settings toggles
- hook the chat attachment sheet up to the new poll screen and register navigation and string resources

## Testing
- not run (Android SDK is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_690c615a12408329a7350495dd42c8ca