### PR TITLE
Integrate Flashphoner SDK scaffolding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -180,6 +180,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.9.23'
     implementation 'androidx.datastore:datastore-preferences-core:1.1.1'
     implementation 'io.github.vicmikhailau:MaskedEditText:5.0.3'
+    implementation 'com.flashphoner.sdk:flashphoner-android-sdk:1.1.0'
 
     implementation 'androidx.paging:paging-runtime-ktx:3.1.1'
     implementation 'androidx.paging:paging-rxjava2-ktx:3.1.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,10 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/app/src/main/java/uddug/com/naukoteka/NaukotekaApplication.kt
+++ b/app/src/main/java/uddug/com/naukoteka/NaukotekaApplication.kt
@@ -4,9 +4,11 @@ import android.app.Application
 import android.content.res.Configuration
 import com.franmontiel.localechanger.LocaleChanger
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 import uddug.com.naukoteka.di.DI
 import uddug.com.naukoteka.di.modules.AppModule
 import uddug.com.naukoteka.ext.data.SUPPORTED_LOCALES
+import uddug.com.naukoteka.flashphoner.FlashphonerEnvironment
 import toothpick.Scope
 import toothpick.ktp.KTP
 
@@ -14,11 +16,13 @@ import toothpick.ktp.KTP
 class NaukotekaApplication : Application() {
 
     lateinit var scope: Scope
+    @Inject lateinit var flashphonerEnvironment: FlashphonerEnvironment
 
     override fun onCreate() {
         super.onCreate()
         initializeToothpick()
         LocaleChanger.initialize(this, SUPPORTED_LOCALES)
+        flashphonerEnvironment.ensureInitialised()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerConfig.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerConfig.kt
@@ -1,0 +1,6 @@
+package uddug.com.naukoteka.flashphoner
+
+data class FlashphonerConfig(
+    val serverUrl: String,
+    val streamName: String
+)

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerConfigProvider.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerConfigProvider.kt
@@ -1,0 +1,18 @@
+package uddug.com.naukoteka.flashphoner
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import uddug.com.naukoteka.R
+
+@Singleton
+class FlashphonerConfigProvider @Inject constructor(
+    @ApplicationContext private val appContext: Context
+) {
+    val defaultConfig: FlashphonerConfig
+        get() = FlashphonerConfig(
+            serverUrl = appContext.getString(R.string.flashphoner_default_server),
+            streamName = appContext.getString(R.string.flashphoner_default_stream)
+        )
+}

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
@@ -1,0 +1,48 @@
+package uddug.com.naukoteka.flashphoner
+
+import android.content.Context
+import com.flashphoner.fpwcsapi.Flashphoner
+import com.flashphoner.fpwcsapi.Session
+import com.flashphoner.fpwcsapi.SessionOptions
+import javax.inject.Inject
+import javax.inject.Singleton
+import dagger.hilt.android.qualifiers.ApplicationContext
+
+/**
+ * Central entry point to the Flashphoner Android SDK. The environment is responsible
+ * for initialising the SDK once and creating pre-configured [Session] instances that
+ * can be used by feature modules.
+ */
+@Singleton
+class FlashphonerEnvironment @Inject constructor(
+    @ApplicationContext private val appContext: Context
+) {
+
+    private var isInitialised: Boolean = false
+
+    /**
+     * Initialise Flashphoner lazily on first usage. According to the SDK documentation
+     * the call is idempotent, therefore we protect it with an [isInitialised] flag to
+     * avoid extra work on subsequent injections.
+     */
+    fun ensureInitialised() {
+        if (!isInitialised) {
+            Flashphoner.init(appContext)
+            isInitialised = true
+        }
+    }
+
+    /**
+     * Creates a new [Session] with provided [serverUrl] and optional configuration block.
+     * The caller is still responsible for connecting the session and listening for state
+     * callbacks according to the Flashphoner SDK documentation.
+     */
+    fun createSession(
+        serverUrl: String,
+        configure: SessionOptions.() -> Unit = {}
+    ): Session {
+        ensureInitialised()
+        val options = SessionOptions(serverUrl).apply(configure)
+        return Flashphoner.createSession(options)
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -1,0 +1,55 @@
+package uddug.com.naukoteka.flashphoner
+
+import com.flashphoner.fpwcsapi.Session
+import com.flashphoner.fpwcsapi.Stream
+import com.flashphoner.fpwcsapi.StreamOptions
+import com.flashphoner.fpwcsapi.SessionOptions
+import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Helper responsible for holding references to the current Flashphoner [Session] and
+ * [Stream]. The class centralises session lifecycle handling so that future features can
+ * focus on business logic instead of repetitive boilerplate.
+ */
+@Singleton
+class FlashphonerSessionManager @Inject constructor(
+    private val environment: FlashphonerEnvironment
+) {
+
+    private val sessionRef = AtomicReference<Session?>()
+    private val streamRef = AtomicReference<Stream?>()
+
+    fun prepareSession(
+        serverUrl: String,
+        configureOptions: SessionOptions.() -> Unit = {},
+        onSessionReady: Session.() -> Unit = {}
+    ): Session {
+        val session = environment.createSession(serverUrl, configureOptions)
+        session.onSessionReady()
+        sessionRef.set(session)
+        return session
+    }
+
+    fun createStream(
+        streamName: String,
+        configure: StreamOptions.() -> Unit = {}
+    ): Stream {
+        val session = sessionRef.get()
+            ?: error("Flashphoner session must be prepared before creating streams")
+        val options = StreamOptions(streamName).apply(configure)
+        val stream = session.createStream(options)
+        streamRef.set(stream)
+        return stream
+    }
+
+    fun stopStream() {
+        streamRef.getAndSet(null)?.stop()
+    }
+
+    fun disconnectSession() {
+        stopStream()
+        sessionRef.getAndSet(null)?.disconnect()
+    }
+}

--- a/app/src/main/res/values/flashphoner.xml
+++ b/app/src/main/res/values/flashphoner.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="flashphoner_default_server">wss://demo.flashphoner.com:8443</string>
+    <string name="flashphoner_default_stream">defaultStream</string>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
+        maven { url "https://maven.flashphoner.com/repository/maven-public/" }
     }
     dependencies {
         apply from: 'dependencies.gradle'
@@ -45,6 +46,7 @@ allprojects {
         google()
         jcenter()
         maven { url 'https://androidx.dev/storage/compose-compiler/repository/' }
+        maven { url "https://maven.flashphoner.com/repository/maven-public/" }
     }
 }
 


### PR DESCRIPTION
## Summary
- add Flashphoner Maven repository and dependency configuration to the project
- scaffold Flashphoner integration with initialisation, configuration and session helpers
- extend manifest permissions to cover streaming use cases

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690c632fc95083299fc4ebb09aae86ed