### PR TITLE
Add chat poll API and use cases

### DIFF
--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -11,8 +11,10 @@ import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
+import uddug.com.data.services.models.request.chat.AnswerPollRequestDto
 import uddug.com.data.services.models.request.chat.ChatFolderRequestDto
 import uddug.com.data.services.models.request.chat.CreateDialogRequestDto
+import uddug.com.data.services.models.request.chat.CreatePollRequestDto
 import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
 import uddug.com.data.services.models.request.chat.PinMessageRequestDto
 import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
@@ -26,6 +28,7 @@ import uddug.com.data.services.models.response.chat.FolderDetailsDto
 import uddug.com.data.services.models.response.chat.FolderDialogsDto
 import uddug.com.data.services.models.response.chat.FolderDto
 import uddug.com.data.services.models.response.chat.FoldersDto
+import uddug.com.data.services.models.response.chat.PollDto
 import uddug.com.data.services.models.request.chat.UsersStatusRequestDto
 import uddug.com.data.services.models.response.chat.UserStatusDto
 import uddug.com.data.services.models.response.chat.MessageDto
@@ -232,4 +235,30 @@ interface ChatApiService {
         @Part files: List<MultipartBody.Part>,
         @Query("raw") raw: Boolean = false,
     ): List<FileDto>
+
+    @POST("chat/v1/dialogs/poll")
+    suspend fun createPoll(@Body request: CreatePollRequestDto): PollDto
+
+    @POST("chat/v1/dialogs/poll/{pollId}/stop")
+    suspend fun stopPoll(@Path("pollId") pollId: String): Boolean
+
+    @DELETE("chat/v1/dialogs/poll/{pollId}")
+    suspend fun deletePoll(@Path("pollId") pollId: String)
+
+    @GET("chat/v1/dialogs/poll/{pollId}")
+    suspend fun getPoll(@Path("pollId") pollId: String): PollDto
+
+    @PUT("chat/v1/dialogs/poll/{pollId}/answer")
+    suspend fun answerPoll(
+        @Path("pollId") pollId: String,
+        @Body request: AnswerPollRequestDto,
+    ): PollDto
+
+    @GET("chat/v1/dialogs/poll/{pollId}/answer-users/{optionId}")
+    suspend fun getPollAnswerUsers(
+        @Path("pollId") pollId: String,
+        @Path("optionId") optionId: String,
+        @Query("limit") limit: Int = 10,
+        @Query("page") page: Int = 1,
+    ): List<UserProfileFullInfoDto>
 }

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/AnswerPollRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/AnswerPollRequestDto.kt
@@ -1,0 +1,5 @@
+package uddug.com.data.services.models.request.chat
+
+data class AnswerPollRequestDto(
+    val optionIds: List<String>,
+)

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/CreatePollRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/CreatePollRequestDto.kt
@@ -1,0 +1,15 @@
+package uddug.com.data.services.models.request.chat
+
+data class CreatePollRequestDto(
+    val subject: String,
+    val isAnonymous: Boolean,
+    val multipleAnswers: Boolean,
+    val isQuiz: Boolean,
+    val options: List<PollOptionRequestDto>,
+)
+
+data class PollOptionRequestDto(
+    val value: String,
+    val isRightAnswer: Boolean? = null,
+    val dsc: String? = null,
+)

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/PollDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/PollDto.kt
@@ -1,0 +1,50 @@
+package uddug.com.data.services.models.response.chat
+
+import uddug.com.data.services.models.response.user_profile.UserProfileFullInfoDto
+import uddug.com.data.utils.toDomain
+import uddug.com.domain.entities.chat.Poll
+import uddug.com.domain.entities.chat.PollOption
+
+data class PollDto(
+    val id: String? = null,
+    val dialogId: Long? = null,
+    val messageId: Long? = null,
+    val subject: String? = null,
+    val isAnonymous: Boolean? = null,
+    val multipleAnswers: Boolean? = null,
+    val isQuiz: Boolean? = null,
+    val isStopped: Boolean? = null,
+    val options: List<PollOptionDto>? = null,
+)
+
+data class PollOptionDto(
+    val id: String? = null,
+    val value: String? = null,
+    val dsc: String? = null,
+    val isRightAnswer: Boolean? = null,
+    val voteCount: Int? = null,
+    val voted: Boolean? = null,
+    val answeredUsers: List<UserProfileFullInfoDto>? = null,
+)
+
+fun PollDto.toDomain(): Poll = Poll(
+    id = id.orEmpty(),
+    dialogId = dialogId,
+    messageId = messageId,
+    subject = subject.orEmpty(),
+    isAnonymous = isAnonymous ?: false,
+    multipleAnswers = multipleAnswers ?: false,
+    isQuiz = isQuiz ?: false,
+    isStopped = isStopped ?: false,
+    options = options.orEmpty().map { it.toDomain() },
+)
+
+fun PollOptionDto.toDomain(): PollOption = PollOption(
+    id = id.orEmpty(),
+    value = value.orEmpty(),
+    description = dsc,
+    isRightAnswer = isRightAnswer,
+    voteCount = voteCount ?: 0,
+    isVoted = voted ?: false,
+    answeredUsers = answeredUsers.orEmpty().map { it.toDomain() },
+)

--- a/domain/src/main/java/uddug/com/domain/entities/chat/Poll.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/Poll.kt
@@ -1,0 +1,31 @@
+package uddug.com.domain.entities.chat
+
+import uddug.com.domain.entities.profile.UserProfileFullInfo
+
+data class Poll(
+    val id: String,
+    val dialogId: Long?,
+    val messageId: Long?,
+    val subject: String,
+    val isAnonymous: Boolean,
+    val multipleAnswers: Boolean,
+    val isQuiz: Boolean,
+    val isStopped: Boolean,
+    val options: List<PollOption>,
+)
+
+data class PollOption(
+    val id: String,
+    val value: String,
+    val description: String?,
+    val isRightAnswer: Boolean?,
+    val voteCount: Int,
+    val isVoted: Boolean,
+    val answeredUsers: List<UserProfileFullInfo>,
+)
+
+data class PollOptionInput(
+    val value: String,
+    val isRightAnswer: Boolean? = null,
+    val description: String? = null,
+)

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -8,6 +8,8 @@ import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.domain.entities.chat.Poll
+import uddug.com.domain.entities.chat.PollOptionInput
 import uddug.com.domain.entities.chat.SearchDialog
 import uddug.com.domain.entities.chat.SearchMessage
 import uddug.com.domain.entities.chat.UserStatus
@@ -170,4 +172,29 @@ class ChatInteractor @Inject constructor(
         query: String,
         lastMessageId: Long? = null,
     ): List<SearchMessage> = chatRepository.searchMessages(query, lastMessageId)
+
+    suspend fun createPoll(
+        subject: String,
+        isAnonymous: Boolean,
+        multipleAnswers: Boolean,
+        isQuiz: Boolean,
+        options: List<PollOptionInput>,
+    ): Poll =
+        chatRepository.createPoll(subject, isAnonymous, multipleAnswers, isQuiz, options)
+
+    suspend fun stopPoll(pollId: String): Boolean = chatRepository.stopPoll(pollId)
+
+    suspend fun deletePoll(pollId: String) = chatRepository.deletePoll(pollId)
+
+    suspend fun getPoll(pollId: String): Poll = chatRepository.getPoll(pollId)
+
+    suspend fun answerPoll(pollId: String, optionIds: List<String>): Poll =
+        chatRepository.answerPoll(pollId, optionIds)
+
+    suspend fun getPollAnswerUsers(
+        pollId: String,
+        optionId: String,
+        limit: Int = 10,
+        page: Int = 1,
+    ): List<UserProfileFullInfo> = chatRepository.getPollAnswerUsers(pollId, optionId, limit, page)
 }

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -8,6 +8,8 @@ import uddug.com.domain.entities.chat.DialogInfo
 import uddug.com.domain.entities.chat.FileDescriptor
 import uddug.com.domain.entities.chat.MediaMessage
 import uddug.com.domain.entities.chat.MessageChat
+import uddug.com.domain.entities.chat.Poll
+import uddug.com.domain.entities.chat.PollOptionInput
 import uddug.com.domain.entities.chat.SearchDialog
 import uddug.com.domain.entities.chat.SearchMessage
 import uddug.com.domain.entities.chat.UserStatus
@@ -167,4 +169,27 @@ interface ChatRepository {
         query: String,
         lastMessageId: Long? = null,
     ): List<SearchMessage>
+
+    suspend fun createPoll(
+        subject: String,
+        isAnonymous: Boolean,
+        multipleAnswers: Boolean,
+        isQuiz: Boolean,
+        options: List<PollOptionInput>,
+    ): Poll
+
+    suspend fun stopPoll(pollId: String): Boolean
+
+    suspend fun deletePoll(pollId: String)
+
+    suspend fun getPoll(pollId: String): Poll
+
+    suspend fun answerPoll(pollId: String, optionIds: List<String>): Poll
+
+    suspend fun getPollAnswerUsers(
+        pollId: String,
+        optionId: String,
+        limit: Int = 10,
+        page: Int = 1,
+    ): List<UserProfileFullInfo>
 }


### PR DESCRIPTION
## Summary
- add Retrofit DTOs and endpoints for chat poll management
- expose poll creation, voting, and retrieval through the chat repository
- surface new poll entities and use cases in the domain layer

## Testing
- `./gradlew :domain:compileKotlin :data:compileKotlin` *(fails: ambiguous task name)*
- `./gradlew :domain:compileDebugKotlin :data:compileDebugKotlin` *(fails: Android SDK not configured in CI)*

------
https://chatgpt.com/codex/tasks/task_e_690c6c1882188329ae93d6295d495049