### PR TITLE
Send created polls through chat socket

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -711,6 +711,32 @@ class ChatDialogViewModel @Inject constructor(
         }
     }
 
+    fun sendPoll(pollId: String) {
+        viewModelScope.launch {
+            val dialog = currentDialogInfo ?: return@launch
+            val ownerId = currentUser?.id.orEmpty()
+
+            val message = if (dialog.id != 0L) {
+                ChatSocketMessage(
+                    dialog = dialog.id,
+                    cType = 9,
+                    owner = ownerId,
+                    pollId = pollId
+                )
+            } else {
+                val peer = dialog.interlocutor?.userId ?: return@launch
+                ChatSocketMessage(
+                    interlocutor = peer,
+                    cType = 9,
+                    owner = ownerId,
+                    pollId = pollId
+                )
+            }
+
+            socketService.sendMessage("message", message)
+        }
+    }
+
     fun sendVoiceMessage(file: File) {
         viewModelScope.launch {
             val dialog = currentDialogInfo ?: return@launch

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreatePollFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreatePollFragment.kt
@@ -18,6 +18,7 @@ import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatCreatePollEvent
 import uddug.com.naukoteka.mvvm.chat.ChatCreatePollViewModel
 import uddug.com.naukoteka.ui.chat.compose.ChatCreatePollScreen
+import uddug.com.naukoteka.ui.chat.ChatDialogFragment.Companion.CREATED_POLL_ID_KEY
 
 @AndroidEntryPoint
 class ChatCreatePollFragment : Fragment() {
@@ -36,6 +37,10 @@ class ChatCreatePollFragment : Fragment() {
                         Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
                     }
                     is ChatCreatePollEvent.PollCreated -> {
+                        findNavController().previousBackStackEntry?.savedStateHandle?.set(
+                            CREATED_POLL_ID_KEY,
+                            event.poll.id
+                        )
                         Toast.makeText(
                             requireContext(),
                             R.string.chat_create_poll_created_success,

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -53,6 +53,7 @@ class ChatDialogFragment : Fragment() {
     companion object {
         const val DIALOG_ID = "DIALOG_ID"
         const val INTERLOCUTOR_ID = "INTERLOCUTOR_ID"
+        const val CREATED_POLL_ID_KEY = "createdPollId"
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -109,6 +110,16 @@ class ChatDialogFragment : Fragment() {
                 if (shouldRefresh == true) {
                     viewModel.refreshDialogInfo()
                     findNavController().currentBackStackEntry?.savedStateHandle?.set("refreshDialogInfo", false)
+                }
+            }
+
+        val savedStateHandle = findNavController().currentBackStackEntry?.savedStateHandle
+        savedStateHandle
+            ?.getLiveData<String>(CREATED_POLL_ID_KEY)
+            ?.observe(viewLifecycleOwner) { pollId ->
+                if (!pollId.isNullOrBlank()) {
+                    viewModel.sendPoll(pollId)
+                    savedStateHandle.remove<String>(CREATED_POLL_ID_KEY)
                 }
             }
     }

--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatSocketMessage.kt
@@ -8,6 +8,7 @@ data class ChatSocketMessage(
     val owner: String? = null,
     val files: List<FileDescriptor>? = null,
     val answered: Long? = null,
+    val pollId: String? = null,
     val ansPreview: AnswerPreview? = null,
     val forwarded: Long? = null,
     val forwardedn: List<Long>? = null,


### PR DESCRIPTION
## Summary
- send the created poll id back to the chat dialog via the navigation result api
- post a cType=9 socket message with the poll id when returning to the chat
- extend the socket message payload with a pollId field for poll messages

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_690c7dd63ffc832983bda7d90703599a