### PR TITLE
Add folder reorder confirmation and API integration

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatFolderSettingsComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatFolderSettingsComponent.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -37,6 +38,7 @@ fun ChatFolderSettingsComponent(
     onBackPressed: () -> Unit,
 ) {
     val folders by viewModel.folders.collectAsState()
+    val isFolderOrderChanged by viewModel.isFolderOrderChanged.collectAsState()
     val reorderState = rememberReorderableLazyListState(onMove = { from, to ->
         viewModel.reorderFolders(from.index, to.index)
     })
@@ -48,6 +50,18 @@ fun ChatFolderSettingsComponent(
                 navigationIcon = {
                     IconButton(onClick = onBackPressed) {
                         Icon(Icons.Filled.ArrowBack, contentDescription = null, tint = Color(0xFF2E83D9))
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { viewModel.persistFolderOrder() },
+                        enabled = isFolderOrderChanged
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Done,
+                            contentDescription = null,
+                            tint = if (isFolderOrderChanged) Color(0xFF2E83D9) else Color(0xFFBFC4D5)
+                        )
                     }
                 },
                 backgroundColor = Color.White,

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -16,6 +16,7 @@ import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
 import uddug.com.data.services.models.request.chat.DialogImageRequestDto
 import uddug.com.data.services.models.request.chat.PinMessageRequestDto
 import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
+import uddug.com.data.services.models.request.chat.ReorderFoldersRequestDto
 import uddug.com.data.services.models.request.chat.UpdateMessageFileDto
 import uddug.com.data.services.models.request.chat.UpdateMessageRequestDto
 import uddug.com.data.services.models.request.chat.UpdateDialogInfoRequestDto
@@ -81,6 +82,16 @@ class ChatRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             println("get folders error ${e.message}")
             emptyList()
+        }
+    }
+
+    override suspend fun reorderFolders(folderIds: List<Long>): List<ChatFolder> {
+        return try {
+            apiService.reorderFolders(ReorderFoldersRequestDto(folderIds)).folders
+                .map { mapFolderDtoToDomain(it) }
+        } catch (e: Exception) {
+            println("reorder folders error ${e.message}")
+            throw e
         }
     }
 

--- a/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/chat/ChatApiService.kt
@@ -18,6 +18,7 @@ import uddug.com.data.services.models.request.chat.CreatePollRequestDto
 import uddug.com.data.services.models.request.chat.DeleteMessagesRequestDto
 import uddug.com.data.services.models.request.chat.PinMessageRequestDto
 import uddug.com.data.services.models.request.chat.ReadMessagesRequestDto
+import uddug.com.data.services.models.request.chat.ReorderFoldersRequestDto
 import uddug.com.data.services.models.request.chat.UpdateDialogInfoRequestDto
 import uddug.com.data.services.models.request.chat.UpdateGroupAdminRequestDto
 import uddug.com.data.services.models.request.chat.UpdateGroupDialogRequestDto
@@ -55,6 +56,9 @@ interface ChatApiService {
         @Path("folderId") folderId: Long,
         @Body request: ChatFolderRequestDto,
     ): FolderDto
+
+    @PATCH("chat/v1/dialogs/folder/reorder")
+    suspend fun reorderFolders(@Body request: ReorderFoldersRequestDto): FoldersDto
 
     @DELETE("chat/v1/dialogs/folder/{folderId}")
     suspend fun deleteFolder(@Path("folderId") folderId: Long)

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/ReorderFoldersRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/ReorderFoldersRequestDto.kt
@@ -1,0 +1,5 @@
+package uddug.com.data.services.models.request.chat
+
+data class ReorderFoldersRequestDto(
+    val folderIds: List<Long>,
+)

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -22,6 +22,8 @@ interface ChatRepository {
 
     suspend fun getFolders(): List<ChatFolder>
 
+    suspend fun reorderFolders(folderIds: List<Long>): List<ChatFolder>
+
     suspend fun createFolder(
         name: String,
         dialogIds: List<Long> = emptyList(),


### PR DESCRIPTION
## Summary
- add network request and repository plumbing for folder reorder API
- track folder order changes in the chat list view model and expose a save action
- add a toolbar confirmation button in the folder settings UI to trigger reorder persistence

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ddaab543c83298bad003e190f6685)