### PR TITLE
Show folder actions dialog

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -131,7 +131,7 @@
   <string name="chat_folder_menu_configure">Настроить папки</string>
   <string name="chat_folder_menu_change_order">Изменить порядок</string>
   <string name="chat_folder_action_rename">Переименовать папку</string>
-  <string name="chat_folder_action_mark_read">Отметить как прочитанное</string>
+  <string name="chat_folder_action_mark_read">Прочитать все</string>
   <string name="chat_folder_action_delete">Удалить папку</string>
   <string name="chat_folder_action_rename_title">Переименовать папку</string>
   <string name="chat_folder_action_rename_placeholder">Название папки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,7 +209,7 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_folder_menu_configure">Configure folders</string>
     <string name="chat_folder_menu_change_order">Change order</string>
     <string name="chat_folder_action_rename">Rename folder</string>
-    <string name="chat_folder_action_mark_read">Mark as read</string>
+    <string name="chat_folder_action_mark_read">Mark all as read</string>
     <string name="chat_folder_action_delete">Delete folder</string>
     <string name="chat_folder_action_rename_title">Rename folder</string>
     <string name="chat_folder_action_rename_placeholder">Folder name</string>


### PR DESCRIPTION
## Summary
- replace the folder bottom sheet with an alert dialog that exposes folder actions from the current tab
- keep rename, mark all as read, change order, and delete actions reachable via the new menu and reuse them for long presses
- adjust the folder action copy to say "Mark all as read" in both locales

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ddb4b019083298982edd905b179d1)