### PR TITLE
Add folder editing screen for chat folders

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatEditFolderViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatEditFolderViewModel.kt
@@ -1,0 +1,174 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.LinkedHashMap
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uddug.com.domain.entities.chat.Chat
+import uddug.com.domain.entities.chat.ChatFolderDetails
+import uddug.com.domain.entities.chat.SearchDialog
+import uddug.com.domain.interactors.chat.ChatInteractor
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatEditFolderViewModel @Inject constructor(
+    private val chatInteractor: ChatInteractor,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val folderId: Long = requireNotNull(savedStateHandle.get<Long>(FOLDER_ID_ARG)) {
+        "Folder id is required"
+    }
+
+    private val _uiState = MutableStateFlow(ChatEditFolderState())
+    val uiState: StateFlow<ChatEditFolderState> = _uiState
+
+    private val _events = MutableSharedFlow<ChatEditFolderEvent>()
+    val events: SharedFlow<ChatEditFolderEvent> = _events.asSharedFlow()
+
+    init {
+        loadFolder()
+    }
+
+    fun onFolderNameChanged(name: String) {
+        _uiState.update { it.copy(folderName = name) }
+    }
+
+    fun onChatsSelected(chats: List<ChatFolderSelectionItem>) {
+        val unique = LinkedHashMap<Long, ChatFolderSelectionItem>()
+        chats.forEach { item -> unique[item.dialogId] = item }
+        _uiState.update { state ->
+            state.copy(selectedChats = unique.values.toList())
+        }
+    }
+
+    fun onChatRemoved(dialogId: Long) {
+        _uiState.update { state ->
+            state.copy(selectedChats = state.selectedChats.filterNot { it.dialogId == dialogId })
+        }
+    }
+
+    fun onSaveClick() {
+        val current = _uiState.value
+        if (current.isSaving || current.isLoading) return
+        val name = current.folderName.trim()
+        if (name.isEmpty()) {
+            viewModelScope.launch { _events.emit(ChatEditFolderEvent.ShowNameRequired) }
+            return
+        }
+        _uiState.update { it.copy(isSaving = true) }
+        viewModelScope.launch {
+            try {
+                chatInteractor.updateFolder(
+                    folderId = folderId,
+                    name = name,
+                    dialogIds = current.selectedChats.map { it.dialogId },
+                )
+                _events.emit(ChatEditFolderEvent.FolderUpdated)
+            } catch (e: Exception) {
+                _events.emit(ChatEditFolderEvent.ShowError(e.message))
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+
+    fun retryLoad() {
+        if (_uiState.value.isLoading) return
+        loadFolder()
+    }
+
+    private fun loadFolder() {
+        viewModelScope.launch {
+            _uiState.value = ChatEditFolderState(isLoading = true)
+            try {
+                val details = chatInteractor.getFolder(folderId)
+                val chats = runCatching { chatInteractor.getDialogs(folderId) }.getOrDefault(emptyList())
+                val selectedChats = combineFolderData(details, chats)
+                _uiState.value = ChatEditFolderState(
+                    isLoading = false,
+                    folderName = details.folder.name,
+                    selectedChats = selectedChats,
+                )
+            } catch (e: Exception) {
+                _uiState.value = ChatEditFolderState(
+                    isLoading = false,
+                    errorMessage = e.message
+                )
+            }
+        }
+    }
+
+    private fun combineFolderData(
+        details: ChatFolderDetails,
+        chats: List<Chat>,
+    ): List<ChatFolderSelectionItem> {
+        val itemsById = LinkedHashMap<Long, ChatFolderSelectionItem>()
+        chats.forEach { chat ->
+            itemsById[chat.dialogId] = mapChatToSelection(chat)
+        }
+        details.dialogs.forEach { dialog ->
+            itemsById.putIfAbsent(dialog.dialogId, mapSearchDialogToSelection(dialog))
+        }
+        return details.dialogIds.mapNotNull { id -> itemsById[id] }
+    }
+
+    private fun mapChatToSelection(chat: Chat): ChatFolderSelectionItem {
+        val isGroup = chat.dialogType != 1
+        val title = if (isGroup) {
+            chat.dialogName
+        } else {
+            chat.interlocutor.fullName ?: chat.interlocutor.nickname ?: chat.dialogName
+        }
+        val avatarUrl = if (isGroup) chat.dialogImage?.path else chat.interlocutor.image
+        val subtitle = when {
+            isGroup -> chat.lastMessage.text
+            else -> null
+        }
+        return ChatFolderSelectionItem(
+            dialogId = chat.dialogId,
+            title = title.orEmpty(),
+            subtitle = subtitle,
+            avatarUrl = avatarUrl,
+            initials = title,
+            isGroup = isGroup,
+        )
+    }
+
+    private fun mapSearchDialogToSelection(dialog: SearchDialog): ChatFolderSelectionItem {
+        return ChatFolderSelectionItem(
+            dialogId = dialog.dialogId,
+            title = dialog.fullName,
+            subtitle = null,
+            avatarUrl = dialog.image,
+            initials = dialog.fullName,
+            isGroup = dialog.dialogType != 1,
+        )
+    }
+
+    companion object {
+        const val FOLDER_ID_ARG = "folder_id"
+    }
+}
+
+data class ChatEditFolderState(
+    val isLoading: Boolean = true,
+    val folderName: String = "",
+    val selectedChats: List<ChatFolderSelectionItem> = emptyList(),
+    val isSaving: Boolean = false,
+    val errorMessage: String? = null,
+)
+
+sealed class ChatEditFolderEvent {
+    object FolderUpdated : ChatEditFolderEvent()
+    object ShowNameRequired : ChatEditFolderEvent()
+    data class ShowError(val message: String?) : ChatEditFolderEvent()
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditFolderFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditFolderFragment.kt
@@ -1,0 +1,112 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import java.util.ArrayList
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatEditFolderEvent
+import uddug.com.naukoteka.mvvm.chat.ChatEditFolderViewModel
+import uddug.com.naukoteka.mvvm.chat.ChatFolderSelectionItem
+import uddug.com.naukoteka.ui.chat.compose.ChatEditFolderScreen
+
+@AndroidEntryPoint
+class ChatEditFolderFragment : Fragment() {
+
+    private val viewModel: ChatEditFolderViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatEditFolderScreen(
+                        viewModel = viewModel,
+                        onBackPressed = { findNavController().popBackStack() },
+                        onAddChatsClick = { openAddChatsScreen() },
+                        onRetryClick = { viewModel.retryLoad() }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        observeEvents()
+        observeSelectedChatsResult()
+    }
+
+    private fun observeEvents() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.events.collectLatest { event ->
+                when (event) {
+                    ChatEditFolderEvent.FolderUpdated -> {
+                        findNavController().previousBackStackEntry?.savedStateHandle?.set(
+                            REFRESH_FOLDERS_KEY,
+                            true
+                        )
+                        findNavController().previousBackStackEntry?.savedStateHandle?.set(
+                            REFRESH_CHATS_KEY,
+                            true
+                        )
+                        findNavController().popBackStack()
+                    }
+                    ChatEditFolderEvent.ShowNameRequired -> {
+                        Toast.makeText(
+                            requireContext(),
+                            R.string.chat_create_folder_name_required,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                    is ChatEditFolderEvent.ShowError -> {
+                        val message = event.message
+                            ?: getString(R.string.chat_edit_folder_generic_error)
+                        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun observeSelectedChatsResult() {
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<ArrayList<ChatFolderSelectionItem>>(ChatFolderAddChatsFragment.SELECTED_CHATS_KEY)
+            ?.observe(viewLifecycleOwner) { chats ->
+                if (chats != null) {
+                    viewModel.onChatsSelected(chats)
+                    findNavController().currentBackStackEntry?.savedStateHandle
+                        ?.set(ChatFolderAddChatsFragment.SELECTED_CHATS_KEY, null)
+                }
+            }
+    }
+
+    private fun openAddChatsScreen() {
+        val selectedIds = viewModel.uiState.value.selectedChats
+            .map { it.dialogId }
+            .toLongArray()
+        val args = Bundle().apply {
+            putLongArray(ChatFolderAddChatsFragment.SELECTED_IDS_ARG, selectedIds)
+        }
+        findNavController().navigate(R.id.chatFolderAddChatsFragment, args)
+    }
+
+    companion object {
+        const val REFRESH_FOLDERS_KEY = "refresh_folders"
+        const val REFRESH_CHATS_KEY = "refresh_chats"
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import uddug.com.domain.entities.chat.Chat
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatEditFolderViewModel
 import uddug.com.naukoteka.mvvm.chat.ChatListEvents
 import uddug.com.naukoteka.mvvm.chat.ChatListUiState
 import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
@@ -55,6 +56,26 @@ class ChatListFragment : Fragment() {
                 if (shouldRefresh) {
                     viewModel.refreshChats()
                     findNavController().currentBackStackEntry?.savedStateHandle?.remove<Boolean>("refreshChats")
+                }
+            }
+
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<Boolean>(ChatEditFolderFragment.REFRESH_FOLDERS_KEY)
+            ?.observe(viewLifecycleOwner) { shouldRefresh ->
+                if (shouldRefresh == true) {
+                    viewModel.loadFolders()
+                    findNavController().currentBackStackEntry?.savedStateHandle
+                        ?.remove<Boolean>(ChatEditFolderFragment.REFRESH_FOLDERS_KEY)
+                }
+            }
+
+        findNavController().currentBackStackEntry?.savedStateHandle
+            ?.getLiveData<Boolean>(ChatEditFolderFragment.REFRESH_CHATS_KEY)
+            ?.observe(viewLifecycleOwner) { shouldRefresh ->
+                if (shouldRefresh == true) {
+                    viewModel.refreshChats()
+                    findNavController().currentBackStackEntry?.savedStateHandle
+                        ?.remove<Boolean>(ChatEditFolderFragment.REFRESH_CHATS_KEY)
                 }
             }
     }
@@ -133,6 +154,12 @@ class ChatListFragment : Fragment() {
                         },
                         onChangeFolderOrder = {
                             findNavController().navigate(R.id.chatFolderSettingsFragment)
+                        },
+                        onEditFolder = { folderId ->
+                            val args = Bundle().apply {
+                                putLong(ChatEditFolderViewModel.FOLDER_ID_ARG, folderId)
+                            }
+                            findNavController().navigate(R.id.chatEditFolderFragment, args)
                         }
                     )
                 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditFolderScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditFolderScreen.kt
@@ -1,0 +1,281 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatEditFolderState
+import uddug.com.naukoteka.mvvm.chat.ChatEditFolderViewModel
+import uddug.com.naukoteka.mvvm.chat.ChatFolderSelectionItem
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
+
+@Composable
+fun ChatEditFolderScreen(
+    viewModel: ChatEditFolderViewModel,
+    onBackPressed: () -> Unit,
+    onAddChatsClick: () -> Unit,
+    onRetryClick: () -> Unit,
+) {
+    val state by viewModel.uiState.collectAsState()
+    val isActionEnabled = state.folderName.isNotBlank() && !state.isSaving && state.errorMessage == null && !state.isLoading
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.chat_edit_folder_title),
+                        fontSize = 20.sp,
+                        color = Color.Black
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chat_back),
+                            contentDescription = null,
+                            tint = Color(0xFF2E83D9)
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { viewModel.onSaveClick() },
+                        enabled = isActionEnabled
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_chat_create_apply),
+                            contentDescription = null,
+                            tint = if (isActionEnabled) Color(0xFF2E83D9) else Color(0x4D2E83D9)
+                        )
+                    }
+                },
+                backgroundColor = Color.White,
+                elevation = 0.dp
+            )
+        }
+    ) { padding ->
+        when {
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.White)
+                        .padding(padding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = Color(0xFF2E83D9))
+                }
+            }
+
+            state.errorMessage != null -> {
+                ChatEditFolderError(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.White)
+                        .padding(padding),
+                    message = state.errorMessage,
+                    onRetryClick = onRetryClick
+                )
+            }
+
+            else -> {
+                ChatEditFolderContent(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.White)
+                        .padding(padding)
+                        .padding(horizontal = 16.dp),
+                    state = state,
+                    onNameChanged = viewModel::onFolderNameChanged,
+                    onAddChatsClick = onAddChatsClick,
+                    onChatRemoved = viewModel::onChatRemoved
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChatEditFolderError(
+    modifier: Modifier,
+    message: String?,
+    onRetryClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = message ?: stringResource(id = R.string.chat_edit_folder_generic_error),
+            color = Color(0xFF8083A0),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 24.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.chat_edit_folder_retry),
+            color = Color(0xFF2E83D9),
+            modifier = Modifier.clickable(onClick = onRetryClick)
+        )
+    }
+}
+
+@Composable
+private fun ChatEditFolderContent(
+    modifier: Modifier,
+    state: ChatEditFolderState,
+    onNameChanged: (String) -> Unit,
+    onAddChatsClick: () -> Unit,
+    onChatRemoved: (Long) -> Unit,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Text(
+            text = stringResource(R.string.chat_edit_folder_description),
+            color = Color(0xFF8083A0),
+            fontSize = 14.sp,
+            modifier = Modifier.padding(top = 16.dp)
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = stringResource(R.string.chat_create_folder_name_label),
+            color = Color.Black,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 16.sp
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = state.folderName,
+            onValueChange = onNameChanged,
+            placeholder = {
+                Text(text = stringResource(R.string.chat_create_folder_name_placeholder))
+            },
+            modifier = Modifier
+                .fillMaxWidth(),
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                textColor = Color.Black,
+                focusedBorderColor = Color(0xFF2E83D9),
+                unfocusedBorderColor = Color(0xFFBFC4D5)
+            )
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.chat_create_folder_selected_title),
+                color = Color.Black,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp
+            )
+            Text(
+                text = stringResource(R.string.chat_create_folder_add),
+                color = Color(0xFF2E83D9),
+                fontSize = 16.sp,
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .clickable { onAddChatsClick() }
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        if (state.selectedChats.isEmpty()) {
+            Text(
+                text = stringResource(R.string.chat_create_folder_empty_placeholder),
+                color = Color(0xFF8083A0),
+                fontSize = 14.sp
+            )
+        } else {
+            LazyColumn {
+                items(state.selectedChats, key = { it.dialogId }) { chat ->
+                    ChatEditFolderRow(
+                        item = chat,
+                        onRemove = { onChatRemoved(chat.dialogId) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChatEditFolderRow(
+    item: ChatFolderSelectionItem,
+    onRemove: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Avatar(url = item.avatarUrl, name = item.initials, size = 48.dp)
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 12.dp)
+        ) {
+            Text(
+                text = item.title,
+                color = Color.Black,
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            item.subtitle?.takeIf { it.isNotBlank() }?.let { subtitle ->
+                Text(
+                    text = subtitle,
+                    color = Color(0xFF8083A0),
+                    fontSize = 14.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+        IconButton(onClick = onRemove) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = null,
+                tint = Color(0xFFBFC4D5)
+            )
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -48,6 +48,7 @@ fun ChatListComponent(
     onShowAttachments: (Long) -> Unit,
     onFolderSettings: () -> Unit,
     onChangeFolderOrder: () -> Unit,
+    onEditFolder: (Long) -> Unit,
 ) {
     var selectedDialogId by remember { mutableStateOf<Long?>(null) }
     val isSelectionMode by viewModel.isSelectionMode.collectAsState()
@@ -118,7 +119,8 @@ fun ChatListComponent(
                     selectedChats = selectedChats,
                     onChatSelect = { viewModel.toggleChatSelection(it) },
                     onOpenFolderSettings = onFolderSettings,
-                    onChangeFolderOrder = onChangeFolderOrder
+                    onChangeFolderOrder = onChangeFolderOrder,
+                    onEditFolder = onEditFolder
                 )
             }
         } else {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -26,13 +26,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -60,6 +58,7 @@ fun ChatTabBar(
     onChatSelect: (Long) -> Unit,
     onOpenFolderSettings: () -> Unit,
     onChangeFolderOrder: () -> Unit,
+    onEditFolder: (Long) -> Unit,
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
 
@@ -70,7 +69,6 @@ fun ChatTabBar(
 
     val mainFolderId = folders.firstOrNull()?.id
     var folderActionsTarget by remember { mutableStateOf<FolderActionsTarget?>(null) }
-    var folderToRename by remember { mutableStateOf<ChatFolder?>(null) }
     var folderToDelete by remember { mutableStateOf<ChatFolder?>(null) }
 
     LaunchedEffect(folders, currentFolderId) {
@@ -106,7 +104,7 @@ fun ChatTabBar(
                                 text = stringResource(R.string.chat_folder_action_rename)
                             ) {
                                 folderActionsTarget = null
-                                folderToRename = folder
+                                onEditFolder(folder.id)
                             }
                         }
                         FolderActionItem(
@@ -137,38 +135,6 @@ fun ChatTabBar(
                 },
                 confirmButton = {},
                 dismissButton = {}
-            )
-        }
-
-        folderToRename?.let { folder ->
-            var name by remember(folder) { mutableStateOf(folder.name) }
-            AlertDialog(
-                onDismissRequest = { folderToRename = null },
-                title = { Text(text = stringResource(R.string.chat_folder_action_rename_title)) },
-                text = {
-                    OutlinedTextField(
-                        value = name,
-                        onValueChange = { name = it },
-                        singleLine = true,
-                        label = { Text(stringResource(R.string.chat_folder_action_rename_placeholder)) }
-                    )
-                },
-                confirmButton = {
-                    TextButton(
-                        onClick = {
-                            viewModel.renameFolder(folder.id, name.trim())
-                            folderToRename = null
-                        },
-                        enabled = name.isNotBlank()
-                    ) {
-                        Text(text = stringResource(R.string.chat_folder_action_rename_confirm))
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { folderToRename = null }) {
-                        Text(text = stringResource(R.string.chat_folder_action_delete_confirm_negative))
-                    }
-                }
             )
         }
 

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -73,6 +73,14 @@
         android:name="uddug.com.naukoteka.ui.chat.ChatCreateFolderFragment" />
 
     <fragment
+        android:id="@+id/chatEditFolderFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatEditFolderFragment">
+        <argument
+            android:name="folder_id"
+            app:argType="long" />
+    </fragment>
+
+    <fragment
         android:id="@+id/chatFolderAddChatsFragment"
         android:name="uddug.com.naukoteka.ui.chat.ChatFolderAddChatsFragment">
         <argument

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -139,6 +139,10 @@
   <string name="chat_folder_action_delete_confirm_message">Вы уверены, что хотите удалить папку "%1$s"?</string>
   <string name="chat_folder_action_delete_confirm_positive">Удалить</string>
   <string name="chat_folder_action_delete_confirm_negative">Отмена</string>
+  <string name="chat_edit_folder_title">Настройка папки</string>
+  <string name="chat_edit_folder_description">Вы можете создать папки с нужными чатами и переключаться между ними.\nЧтобы удалить папку или изменить порядок сортировки, нажмите кнопку «Изменить».</string>
+  <string name="chat_edit_folder_generic_error">Не удалось загрузить информацию о папке</string>
+  <string name="chat_edit_folder_retry">Повторить</string>
   <string name="chat_unknown_user">Неизвестный</string>
   <string name="chat_no_messages">Нет сообщений</string>
   <string name="chat_unknown_time">Неизвестно</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,6 +218,11 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_folder_action_delete_confirm_message">Are you sure you want to delete the folder "%1$s"?</string>
     <string name="chat_folder_action_delete_confirm_positive">Delete</string>
     <string name="chat_folder_action_delete_confirm_negative">Cancel</string>
+    <string name="chat_edit_folder_title">Folder settings</string>
+    <string name="chat_edit_folder_description">You can create folders with the chats you need and switch between them.
+To delete a folder or change the sorting order, tap the “Edit” button.</string>
+    <string name="chat_edit_folder_generic_error">Failed to load folder information</string>
+    <string name="chat_edit_folder_retry">Try again</string>
     <string name="chat_unknown_user">Unknown</string>
     <string name="chat_no_messages">No messages</string>
     <string name="chat_unknown_time">Unknown</string>


### PR DESCRIPTION
## Summary
- add a dedicated Compose screen, fragment, and view model for editing chat folders
- route the rename action to the new editor and update navigation with refresh handling
- extend string resources for the new screen in Russian and English

## Testing
- ❌ `./gradlew app:compileDebugKotlin` *(fails: SDK location not found in CI container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df3773470832992a62cf20406422e)