### PR TITLE
Fix chat folder edit screen data mapping

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatEditFolderViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatEditFolderViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import uddug.com.domain.entities.chat.Chat
 import uddug.com.domain.entities.chat.ChatFolderDetails
-import uddug.com.domain.entities.chat.SearchDialog
+import uddug.com.domain.entities.chat.ChatFolderDialogSummary
 import uddug.com.domain.interactors.chat.ChatInteractor
 import javax.inject.Inject
 
@@ -116,7 +116,7 @@ class ChatEditFolderViewModel @Inject constructor(
             itemsById[chat.dialogId] = mapChatToSelection(chat)
         }
         details.dialogs.forEach { dialog ->
-            itemsById.putIfAbsent(dialog.dialogId, mapSearchDialogToSelection(dialog))
+            itemsById.putIfAbsent(dialog.dialogId, mapDialogSummaryToSelection(dialog))
         }
         return details.dialogIds.mapNotNull { id -> itemsById[id] }
     }
@@ -143,14 +143,25 @@ class ChatEditFolderViewModel @Inject constructor(
         )
     }
 
-    private fun mapSearchDialogToSelection(dialog: SearchDialog): ChatFolderSelectionItem {
+    private fun mapDialogSummaryToSelection(dialog: ChatFolderDialogSummary): ChatFolderSelectionItem {
+        val isGroup = dialog.dialogType != 1
+        val title = when {
+            !dialog.fullName.isNullOrBlank() -> dialog.fullName
+            !dialog.nickname.isNullOrBlank() -> dialog.nickname
+            !dialog.name.isNullOrBlank() -> dialog.name
+            else -> ""
+        }.ifBlank { dialog.name.orEmpty() }.ifBlank { dialog.dialogId.toString() }
+        val subtitle = when {
+            isGroup -> dialog.name?.takeIf { it.isNotBlank() && it != title }
+            else -> null
+        }
         return ChatFolderSelectionItem(
             dialogId = dialog.dialogId,
-            title = dialog.fullName,
-            subtitle = null,
-            avatarUrl = dialog.image,
-            initials = dialog.fullName,
-            isGroup = dialog.dialogType != 1,
+            title = title,
+            subtitle = subtitle,
+            avatarUrl = dialog.imagePath,
+            initials = title,
+            isGroup = isGroup,
         )
     }
 

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -27,6 +27,7 @@ import uddug.com.data.services.models.request.chat.UsersStatusRequestDto
 import uddug.com.data.services.models.response.chat.FileDto
 import uddug.com.data.services.models.response.chat.FolderDetailsDto
 import uddug.com.data.services.models.response.chat.FolderDialogItemDto
+import uddug.com.data.services.models.response.chat.FolderDialogSummaryDto
 import uddug.com.data.services.models.response.chat.FolderDialogsDto
 import uddug.com.data.services.models.response.chat.UserStatusDto
 import uddug.com.data.services.models.response.chat.mapDialogInfoDtoToDomain
@@ -37,6 +38,7 @@ import uddug.com.domain.entities.chat.Chat
 import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.ChatFolderDetails
 import uddug.com.domain.entities.chat.ChatFolderDialog
+import uddug.com.domain.entities.chat.ChatFolderDialogSummary
 import uddug.com.domain.entities.chat.ChatFolderDialogsPage
 import android.webkit.MimeTypeMap
 import java.time.Instant
@@ -582,6 +584,16 @@ private fun FolderDetailsDto.toDomain(): ChatFolderDetails = ChatFolderDetails(
     ),
     dialogIds = dialogIds,
     dialogs = dialogs.map { it.toDomain() },
+)
+
+private fun FolderDialogSummaryDto.toDomain(): ChatFolderDialogSummary = ChatFolderDialogSummary(
+    dialogId = id,
+    name = name,
+    fullName = fullName,
+    nickname = nickname,
+    dialogType = dialogType,
+    folderNames = folderNames,
+    imagePath = image?.path,
 )
 
 private fun FolderDialogsDto.toDomain(): ChatFolderDialogsPage = ChatFolderDialogsPage(

--- a/data/src/main/java/uddug/com/data/services/models/response/chat/FolderDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/response/chat/FolderDto.kt
@@ -1,5 +1,7 @@
 package uddug.com.data.services.models.response.chat
 
+import com.google.gson.annotations.SerializedName
+
 data class FoldersDto(
     val userId: String,
     val folders: List<FolderDto>
@@ -18,7 +20,17 @@ data class FolderDetailsDto(
     val ord: Int,
     val unreadCount: Int,
     val dialogIds: List<Long>,
-    val dialogs: List<SearchDialogDto>
+    val dialogs: List<FolderDialogSummaryDto>
+)
+
+data class FolderDialogSummaryDto(
+    val id: Long,
+    val name: String?,
+    @SerializedName("cType") val dialogType: Int,
+    val fullName: String?,
+    val nickname: String?,
+    val folderNames: List<String> = emptyList(),
+    val image: ImageDto?,
 )
 
 data class FolderDialogsDto(

--- a/domain/src/main/java/uddug/com/domain/entities/chat/ChatFolderDetails.kt
+++ b/domain/src/main/java/uddug/com/domain/entities/chat/ChatFolderDetails.kt
@@ -3,7 +3,17 @@ package uddug.com.domain.entities.chat
 data class ChatFolderDetails(
     val folder: ChatFolder,
     val dialogIds: List<Long>,
-    val dialogs: List<SearchDialog>,
+    val dialogs: List<ChatFolderDialogSummary>,
+)
+
+data class ChatFolderDialogSummary(
+    val dialogId: Long,
+    val name: String?,
+    val fullName: String?,
+    val nickname: String?,
+    val dialogType: Int,
+    val folderNames: List<String>,
+    val imagePath: String?,
 )
 
 data class ChatFolderDialog(


### PR DESCRIPTION
## Summary
- align folder details DTOs and domain models with the folder details API response
- map folder dialog summaries to selection items so the edit screen shows existing chats

## Testing
- ./gradlew :app:lintDebug *(fails: Android SDK not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691459a623a88329b59e2e8ad098bed4)