### PR TITLE
Add admin poll management options to message actions sheet

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -501,6 +501,8 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_message_select">Выбрать сообщение</string>
     <string name="chat_message_show_original">Показать оригинал в чате</string>
     <string name="chat_message_delete">Удалить сообщение</string>
+    <string name="chat_message_revote">Переголосовать</string>
+    <string name="chat_message_stop_quiz">Остановить викторину</string>
     <string name="chat_editing_title">Редактирование</string>
     <string name="create_group_chat">Создать групповой чат</string>
     <string name="chat_create_group_title">Создать группу</string>


### PR DESCRIPTION
## Summary
- show poll-specific actions in the message functions bottom sheet, including admin-only options for polls
- add poll revote state handling so selections can be reset before voting again
- update the chat dialog view model to stop polls and refresh message state

## Testing
- `./gradlew :app:lint` *(fails: SDK location not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145e3a9a0083298e488ca9a48b90c0)