### PR TITLE
Add poll results screen for chat polls

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogFragment.kt
@@ -99,14 +99,17 @@ class ChatDetailDialogFragment : Fragment() {
                         onContactClick = {
 
                         },
+                        onCreatePoll = {
+
+                        },
+                        onOpenPollResults = {
+
+                        },
                         onForwardMessage = { message ->
                             val args = Bundle().apply {
                                 putLong(ARG_MESSAGE_ID, message.id)
                             }
                             findNavController().navigate(R.id.forwardMessageFragment, args)
-                        },
-                        onCreatePoll = {
-
                         },
                         onEditGroup = {
 

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatPollResultsViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatPollResultsViewModel.kt
@@ -1,0 +1,118 @@
+package uddug.com.naukoteka.mvvm.chat
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import uddug.com.domain.entities.chat.Poll
+import uddug.com.domain.interactors.chat.ChatInteractor
+import uddug.com.naukoteka.ui.chat.ChatPollResultsFragment
+import kotlin.math.roundToInt
+
+@HiltViewModel
+class ChatPollResultsViewModel @Inject constructor(
+    private val chatInteractor: ChatInteractor,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val pollId: String = savedStateHandle.get<String>(ChatPollResultsFragment.ARG_POLL_ID).orEmpty()
+
+    private val _uiState = MutableStateFlow(ChatPollResultsUiState(isLoading = true))
+    val uiState: StateFlow<ChatPollResultsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadPoll()
+    }
+
+    fun loadPoll() {
+        if (pollId.isBlank()) {
+            _uiState.update { it.copy(isLoading = false, errorMessage = null, poll = null) }
+            return
+        }
+        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        viewModelScope.launch {
+            try {
+                val poll = withContext(Dispatchers.IO) { chatInteractor.getPoll(pollId) }
+                _uiState.update { state ->
+                    state.copy(
+                        isLoading = false,
+                        errorMessage = null,
+                        poll = poll.toUi()
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update { state ->
+                    state.copy(
+                        isLoading = false,
+                        errorMessage = e.message,
+                        poll = null
+                    )
+                }
+            }
+        }
+    }
+
+    private fun Poll.toUi(): PollResultsUiModel {
+        val totalVotes = options.sumOf { it.voteCount }
+        val safeTotal = if (totalVotes <= 0) 0 else totalVotes
+        val optionUi = options.map { option ->
+            val percent = if (safeTotal > 0) {
+                ((option.voteCount.toDouble() / safeTotal) * 100).roundToInt()
+            } else {
+                0
+            }
+            PollResultOptionUi(
+                id = option.id,
+                text = option.value,
+                percent = percent.coerceIn(0, 100),
+                isSelected = option.isVoted,
+                isRightAnswer = option.isRightAnswer == true,
+                description = option.description
+            )
+        }
+        return PollResultsUiModel(
+            id = id,
+            question = subject,
+            isAnonymous = isAnonymous,
+            allowsMultipleAnswers = multipleAnswers,
+            isQuiz = isQuiz,
+            isStopped = isStopped,
+            totalVotes = safeTotal,
+            options = optionUi
+        )
+    }
+}
+
+data class ChatPollResultsUiState(
+    val isLoading: Boolean = false,
+    val poll: PollResultsUiModel? = null,
+    val errorMessage: String? = null,
+)
+
+data class PollResultsUiModel(
+    val id: String,
+    val question: String,
+    val isAnonymous: Boolean,
+    val allowsMultipleAnswers: Boolean,
+    val isQuiz: Boolean,
+    val isStopped: Boolean,
+    val totalVotes: Int,
+    val options: List<PollResultOptionUi>,
+)
+
+data class PollResultOptionUi(
+    val id: String,
+    val text: String,
+    val percent: Int,
+    val isSelected: Boolean,
+    val isRightAnswer: Boolean,
+    val description: String?,
+)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -27,9 +27,10 @@ import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.ChatDetailDialogFragment.Companion.DIALOG_DETAIL
 import uddug.com.naukoteka.ui.chat.ForwardMessageFragment.Companion.ARG_MESSAGE_ID
-import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
 import uddug.com.naukoteka.ui.chat.compose.ChatDialogComponent
 import uddug.com.naukoteka.ui.chat.compose.ChatListComponent
+import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
+import uddug.com.naukoteka.ui.chat.ChatPollResultsFragment
 
 @AndroidEntryPoint
 class ChatDialogFragment : Fragment() {
@@ -150,6 +151,12 @@ class ChatDialogFragment : Fragment() {
                         },
                         onCreatePoll = {
                             findNavController().navigate(R.id.chatCreatePollFragment)
+                        },
+                        onOpenPollResults = { pollId ->
+                            val args = Bundle().apply {
+                                putString(ChatPollResultsFragment.ARG_POLL_ID, pollId)
+                            }
+                            findNavController().navigate(R.id.chatPollResultsFragment, args)
                         },
                         onForwardMessage = { message ->
                             val args = Bundle().apply {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatPollResultsFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatPollResultsFragment.kt
@@ -1,0 +1,40 @@
+package uddug.com.naukoteka.ui.chat
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import uddug.com.naukoteka.mvvm.chat.ChatPollResultsViewModel
+import uddug.com.naukoteka.ui.chat.compose.ChatPollResultsScreen
+
+@AndroidEntryPoint
+class ChatPollResultsFragment : Fragment() {
+
+    private val viewModel: ChatPollResultsViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    ChatPollResultsScreen(
+                        viewModel = viewModel,
+                        onBack = { requireActivity().onBackPressed() }
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_POLL_ID = "pollId"
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -79,6 +79,7 @@ fun ChatDialogComponent(
     onSearchClick: () -> Unit,
     onContactClick: () -> Unit,
     onCreatePoll: () -> Unit,
+    onOpenPollResults: (String) -> Unit,
     onForwardMessage: (MessageChat) -> Unit,
     onEditGroup: (Long) -> Unit,
     onChatDeleted: () -> Unit,
@@ -320,6 +321,9 @@ fun ChatDialogComponent(
                                 },
                                 onPollVote = { pollId, optionIds ->
                                     viewModel.voteInPoll(pollId, optionIds)
+                                },
+                                onPollResults = { pollId ->
+                                    onOpenPollResults(pollId)
                                 }
                             )
                         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatPollResultsScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatPollResultsScreen.kt
@@ -1,0 +1,308 @@
+package uddug.com.naukoteka.ui.chat.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.chat.ChatPollResultsUiState
+import uddug.com.naukoteka.mvvm.chat.ChatPollResultsViewModel
+import uddug.com.naukoteka.mvvm.chat.PollResultOptionUi
+import uddug.com.naukoteka.mvvm.chat.PollResultsUiModel
+
+private val PrimaryTextColor = Color(0xFF111827)
+private val SecondaryTextColor = Color(0xFF6F7A90)
+private val AccentColor = Color(0xFF2E83D9)
+private val SurfaceColor = Color.White
+
+@Composable
+fun ChatPollResultsScreen(
+    viewModel: ChatPollResultsViewModel,
+    onBack: () -> Unit,
+) {
+    val state by viewModel.uiState.collectAsState()
+    ChatPollResultsScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::loadPoll
+    )
+}
+
+@Composable
+fun ChatPollResultsScreen(
+    state: ChatPollResultsUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(id = R.string.chat_poll_results_title),
+                        color = PrimaryTextColor,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = null,
+                            tint = PrimaryTextColor
+                        )
+                    }
+                },
+                backgroundColor = SurfaceColor,
+                elevation = 0.dp
+            )
+        },
+        backgroundColor = SurfaceColor
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SurfaceColor)
+                .padding(paddingValues)
+        ) {
+            when {
+                state.isLoading -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.align(Alignment.Center),
+                        color = AccentColor
+                    )
+                }
+                state.poll != null -> {
+                    PollResultsContent(model = state.poll)
+                }
+                else -> {
+                    PollResultsError(
+                        modifier = Modifier.align(Alignment.Center),
+                        message = state.errorMessage,
+                        onRetry = onRetry
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PollResultsContent(model: PollResultsUiModel) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .background(SurfaceColor)
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(
+                text = model.question,
+                color = PrimaryTextColor,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                lineHeight = 24.sp,
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis
+            )
+            val pollTypeText = if (model.isAnonymous) {
+                stringResource(id = R.string.chat_poll_results_anonymous)
+            } else {
+                stringResource(id = R.string.chat_poll_results_public)
+            }
+            val votesText = pluralStringResource(
+                id = R.plurals.chat_poll_results_votes,
+                count = model.totalVotes,
+                model.totalVotes
+            )
+            Text(
+                text = stringResource(
+                    id = R.string.chat_poll_results_meta,
+                    pollTypeText,
+                    votesText
+                ),
+                color = SecondaryTextColor,
+                fontSize = 14.sp,
+                lineHeight = 20.sp
+            )
+            if (model.allowsMultipleAnswers) {
+                Text(
+                    text = stringResource(id = R.string.chat_poll_results_multiple_allowed),
+                    color = SecondaryTextColor,
+                    fontSize = 12.sp
+                )
+            }
+            if (model.isQuiz) {
+                Text(
+                    text = stringResource(id = R.string.chat_poll_results_quiz_mode),
+                    color = SecondaryTextColor,
+                    fontSize = 12.sp
+                )
+            }
+            if (model.isStopped) {
+                Text(
+                    text = stringResource(id = R.string.chat_poll_results_stopped),
+                    color = SecondaryTextColor,
+                    fontSize = 12.sp
+                )
+            }
+        }
+
+        Text(
+            text = stringResource(id = R.string.chat_poll_results_options_section),
+            color = PrimaryTextColor,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            model.options.forEach { option ->
+                PollResultOptionItem(option)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PollResultOptionItem(option: PollResultOptionUi) {
+    val background = when {
+        option.isRightAnswer -> AccentColor.copy(alpha = 0.08f)
+        option.isSelected -> AccentColor.copy(alpha = 0.05f)
+        else -> Color(0xFFF5F5F9)
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(background)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "${option.percent}%",
+                color = AccentColor,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Text(
+                    text = option.text,
+                    color = PrimaryTextColor,
+                    fontSize = 15.sp,
+                    fontWeight = if (option.isSelected || option.isRightAnswer) FontWeight.SemiBold else FontWeight.Normal,
+                    lineHeight = 20.sp
+                )
+                option.description?.takeIf { it.isNotBlank() }?.let { description ->
+                    Text(
+                        text = description,
+                        color = SecondaryTextColor,
+                        fontSize = 13.sp,
+                        lineHeight = 18.sp
+                    )
+                }
+                if (option.isRightAnswer) {
+                    Text(
+                        text = stringResource(id = R.string.chat_poll_results_correct_answer),
+                        color = AccentColor,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                } else if (option.isSelected) {
+                    Text(
+                        text = stringResource(id = R.string.chat_poll_results_your_choice),
+                        color = AccentColor,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+        }
+        LinearProgressIndicator(
+            progress = option.percent.coerceIn(0, 100) / 100f,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp)),
+            backgroundColor = Color(0xFFE4E8F1),
+            color = AccentColor
+        )
+    }
+}
+
+@Composable
+private fun PollResultsError(
+    modifier: Modifier = Modifier,
+    message: String?,
+    onRetry: () -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = stringResource(id = R.string.chat_poll_results_error),
+            color = SecondaryTextColor,
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center
+        )
+        message?.takeIf { it.isNotBlank() }?.let { details ->
+            Text(
+                text = details,
+                color = SecondaryTextColor,
+                fontSize = 13.sp,
+                textAlign = TextAlign.Center
+            )
+        }
+        TextButton(
+            onClick = onRetry,
+            colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
+        ) {
+            Text(
+                text = stringResource(id = R.string.chat_poll_results_retry),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatMessageItem.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.RadioButton
 import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.Composable
@@ -79,6 +80,7 @@ fun ChatMessageItem(
     onLongPress: (MessageChat) -> Unit,
     onReplyReferenceClick: (Long) -> Unit = {},
     onPollVote: (pollId: String, optionIds: List<String>) -> Unit = { _, _ -> },
+    onPollResults: (pollId: String) -> Unit = {},
 ) {
     val isSystem = message.type == MessageType.SYSTEM
     Row(
@@ -184,9 +186,10 @@ fun ChatMessageItem(
                     if (isPollMessage) {
                         PollMessageContent(
                             poll = message.poll!!,
-                            question = message.text,
+                            question = message.poll?.subject ?: message.text,
                             isMine = isMine,
-                            onVote = { selected -> onPollVote(message.poll!!.id, selected) }
+                            onVote = { selected -> onPollVote(message.poll!!.id, selected) },
+                            onShowResults = { onPollResults(message.poll!!.id) }
                         )
                     } else {
                         if (!message.text.isNullOrBlank()) {
@@ -252,6 +255,7 @@ private fun PollMessageContent(
     question: String?,
     isMine: Boolean,
     onVote: (List<String>) -> Unit,
+    onShowResults: () -> Unit,
 ) {
     val headlineColor = if (isMine) Color.White else Color(0xFF2E83D9)
     val primaryTextColor = if (isMine) Color.White else Color(0xFF111827)
@@ -334,6 +338,27 @@ private fun PollMessageContent(
                 fontWeight = FontWeight.Medium,
                 fontSize = 16.sp,
                 color = buttonContentColor,
+            )
+        }
+
+        val textButtonColors = ButtonDefaults.textButtonColors(
+            contentColor = if (isMine) Color.White else accentColor,
+            disabledContentColor = if (isMine) {
+                Color.White.copy(alpha = 0.4f)
+            } else {
+                accentColor.copy(alpha = 0.4f)
+            }
+        )
+        TextButton(
+            onClick = onShowResults,
+            enabled = poll.options.isNotEmpty(),
+            colors = textButtonColors,
+            modifier = Modifier.align(Alignment.End)
+        ) {
+            Text(
+                text = stringResource(R.string.chat_poll_view_results),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold
             )
         }
     }

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -102,6 +102,14 @@
         android:name="uddug.com.naukoteka.ui.chat.ChatCreatePollFragment" />
 
     <fragment
+        android:id="@+id/chatPollResultsFragment"
+        android:name="uddug.com.naukoteka.ui.chat.ChatPollResultsFragment">
+        <argument
+            android:name="pollId"
+            app:argType="string" />
+    </fragment>
+
+    <fragment
         android:id="@+id/chatAvatarPreviewFragment"
         android:name="uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -552,6 +552,25 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_poll_description_single">Вы можете выбрать один вариант ответа. Результаты будут доступны всем участникам чата.</string>
     <string name="chat_poll_description_multiple">Вы можете выбрать несколько вариантов ответа. Результаты будут доступны всем участникам чата.</string>
     <string name="chat_poll_vote">Проголосовать</string>
+    <string name="chat_poll_view_results">Посмотреть результаты</string>
+    <string name="chat_poll_results_title">Результаты опроса</string>
+    <string name="chat_poll_results_anonymous">Анонимный опрос</string>
+    <string name="chat_poll_results_public">Публичный опрос</string>
+    <plurals name="chat_poll_results_votes">
+        <item quantity="one">%d голос</item>
+        <item quantity="few">%d голоса</item>
+        <item quantity="many">%d голосов</item>
+        <item quantity="other">%d голосов</item>
+    </plurals>
+    <string name="chat_poll_results_meta">%1$s • %2$s</string>
+    <string name="chat_poll_results_multiple_allowed">Можно выбрать несколько вариантов</string>
+    <string name="chat_poll_results_quiz_mode">Режим викторины</string>
+    <string name="chat_poll_results_options_section">Настройки опроса</string>
+    <string name="chat_poll_results_correct_answer">Правильный ответ</string>
+    <string name="chat_poll_results_your_choice">Ваш выбор</string>
+    <string name="chat_poll_results_stopped">Опрос завершён</string>
+    <string name="chat_poll_results_error">Не удалось загрузить результаты. Попробуйте снова.</string>
+    <string name="chat_poll_results_retry">Повторить</string>
     <string name="subs">Подписки</string>
 
 


### PR DESCRIPTION
## Summary
- add a dedicated poll results fragment, view model, and compose screen with detailed statistics
- wire chat messages to open the results screen, including a quick access button and navigation entry
- extend resources with strings and navigation arguments required for poll analytics display

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not configured in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145ee63a048329a881d598bc1cc884)