### PR TITLE
Configure centralized repositories

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,24 @@
 
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
+        maven { url "https://androidx.dev/storage/compose-compiler/repository/" }
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
+        maven { url "https://androidx.dev/storage/compose-compiler/repository/" }
+    }
+}
+
 rootProject.name = "naukoteka"
 
 include ':domain'


### PR DESCRIPTION
## Summary
- add pluginManagement repositories configured with standard sources
- enforce dependency resolution repositories to avoid unreachable hosts such as maven.flashphoner.com

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692468d567188329af54e4f2722b0f04)