### PR TITLE
Update Flashphoner integration for latest SDK

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/NaukotekaApplication.kt
+++ b/app/src/main/java/uddug/com/naukoteka/NaukotekaApplication.kt
@@ -4,11 +4,9 @@ import android.app.Application
 import android.content.res.Configuration
 import com.franmontiel.localechanger.LocaleChanger
 import dagger.hilt.android.HiltAndroidApp
-import javax.inject.Inject
 import uddug.com.naukoteka.di.DI
 import uddug.com.naukoteka.di.modules.AppModule
 import uddug.com.naukoteka.ext.data.SUPPORTED_LOCALES
-import uddug.com.naukoteka.flashphoner.FlashphonerEnvironment
 import toothpick.Scope
 import toothpick.ktp.KTP
 
@@ -16,13 +14,10 @@ import toothpick.ktp.KTP
 class NaukotekaApplication : Application() {
 
     lateinit var scope: Scope
-    @Inject lateinit var flashphonerEnvironment: FlashphonerEnvironment
-
     override fun onCreate() {
         super.onCreate()
         initializeToothpick()
         LocaleChanger.initialize(this, SUPPORTED_LOCALES)
-        flashphonerEnvironment.ensureInitialised()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
@@ -1,13 +1,11 @@
 package uddug.com.naukoteka.flashphoner
 
-import android.content.Context
+import android.app.Activity
 import com.flashphoner.fpwcsapi.Flashphoner
-import com.flashphoner.fpwcsapi.Session
-import com.flashphoner.fpwcsapi.SessionOptions
+import com.flashphoner.fpwcsapi.session.Session
 import com.flashphoner.fpwcsapi.session.SessionOptions
 import javax.inject.Inject
 import javax.inject.Singleton
-import dagger.hilt.android.qualifiers.ApplicationContext
 
 /**
  * Central entry point to the Flashphoner Android SDK. The environment is responsible
@@ -15,9 +13,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
  * can be used by feature modules.
  */
 @Singleton
-class FlashphonerEnvironment @Inject constructor(
-    @ApplicationContext private val appContext: Context
-) {
+class FlashphonerEnvironment @Inject constructor() {
 
     private var isInitialised: Boolean = false
 
@@ -26,9 +22,9 @@ class FlashphonerEnvironment @Inject constructor(
      * the call is idempotent, therefore we protect it with an [isInitialised] flag to
      * avoid extra work on subsequent injections.
      */
-    fun ensureInitialised() {
+    fun ensureInitialised(activity: Activity) {
         if (!isInitialised) {
-            Flashphoner.init(appContext)
+            Flashphoner.init(activity)
             isInitialised = true
         }
     }
@@ -39,10 +35,11 @@ class FlashphonerEnvironment @Inject constructor(
      * callbacks according to the Flashphoner SDK documentation.
      */
     fun createSession(
+        activity: Activity,
         serverUrl: String,
         configure: SessionOptions.() -> Unit = {}
     ): Session {
-        ensureInitialised()
+        ensureInitialised(activity)
         val options = SessionOptions(serverUrl).apply(configure)
         return Flashphoner.createSession(options)
     }

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -1,9 +1,10 @@
 package uddug.com.naukoteka.flashphoner
 
-import com.flashphoner.fpwcsapi.Session
-import com.flashphoner.fpwcsapi.Stream
-import com.flashphoner.fpwcsapi.StreamOptions
-import com.flashphoner.fpwcsapi.SessionOptions
+import android.app.Activity
+import com.flashphoner.fpwcsapi.session.Session
+import com.flashphoner.fpwcsapi.session.Stream
+import com.flashphoner.fpwcsapi.session.StreamOptions
+import com.flashphoner.fpwcsapi.session.SessionOptions
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,11 +23,12 @@ class FlashphonerSessionManager @Inject constructor(
     private val streamRef = AtomicReference<Stream?>()
 
     fun prepareSession(
+        activity: Activity,
         serverUrl: String,
         configureOptions: SessionOptions.() -> Unit = {},
         onSessionReady: Session.() -> Unit = {}
     ): Session {
-        val session = environment.createSession(serverUrl, configureOptions)
+        val session = environment.createSession(activity, serverUrl, configureOptions)
         session.onSessionReady()
         sessionRef.set(session)
         return session

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogSearchFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogSearchFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatDialogDetailViewModel
+import uddug.com.naukoteka.ui.chat.ForwardMessageFragment.Companion.ARG_MESSAGE_ID
 import uddug.com.naukoteka.ui.chat.compose.ChatDetailDialogSearchComponent
 
 @AndroidEntryPoint
@@ -38,7 +39,7 @@ class ChatDetailDialogSearchFragment : Fragment() {
                         onMessageSelected = { dialogId, messageId ->
                             val args = Bundle().apply {
                                 putLong(ChatDialogFragment.DIALOG_ID, dialogId)
-                                putLong(ChatDialogFragment.MESSAGE_ID, messageId)
+                                putLong(ARG_MESSAGE_ID, messageId)
                             }
                             findNavController().navigate(R.id.chatDialogFragment, args)
                         }


### PR DESCRIPTION
## Summary
- adjust Flashphoner environment and session manager to use the session package classes from wcs-android-sdk 1.1.0.64
- require an Activity when initialising Flashphoner and remove the invalid application-level initialisation
- fix chat search navigation to reuse the existing ARG_MESSAGE_ID argument constant

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924812b1474832997baa3dbea68cf50)