### PR TITLE
Resolve Gson duplication with WCS SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,10 +155,12 @@ dependencies {
     implementation presentation.toothpickLifeCycle
     kapt presentation.toothpickCompiler
 
-    implementation data.gson
+    compileOnly data.gson
     implementation data.retrofit
     implementation data.retrofitLogging
-    implementation data.gsonConverter
+    implementation(data.gsonConverter) {
+        exclude group: 'com.google.code.gson', module: 'gson'
+    }
     implementation data.retrofitRxJava
 
     implementation presentation.rxJavaKotlin

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -8,8 +8,10 @@ dependencies {
 
     implementation data.retrofit
     implementation data.retrofitRxJava
-    implementation data.gsonConverter
-    implementation data.gson
+    implementation(data.gsonConverter) {
+        exclude group: 'com.google.code.gson', module: 'gson'
+    }
+    compileOnly data.gson
     implementation data.retrofitLogging
     implementation ui.gmsPlayServicesLocation
 


### PR DESCRIPTION
## Summary
- avoid packaging an extra Gson copy by switching Gson to compileOnly in app and data modules
- exclude Gson from the Retrofit Gson converter dependencies to rely on the SDK-bundled implementation

## Testing
- ./gradlew :app:dependencies --configuration debugRuntimeClasspath


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69249fcb01008329806fe04b81443bfd)