### PR TITLE
Ensure Gson included in runtime dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,10 +94,6 @@ android {
     namespace 'uddug.com.naukoteka'
 }
 
-configurations.all {
-    exclude group: "com.google.code.gson", module: "gson"
-}
-
 dependencies {
 
     implementation presentation.kotlin
@@ -159,7 +155,7 @@ dependencies {
     implementation presentation.toothpickLifeCycle
     kapt presentation.toothpickCompiler
 
-    compileOnly data.gson
+    implementation data.gson
     implementation data.retrofit
     implementation data.retrofitLogging
     implementation(data.gsonConverter) {

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation(data.gsonConverter) {
         exclude group: 'com.google.code.gson', module: 'gson'
     }
-    compileOnly data.gson
+    implementation data.gson
     implementation data.retrofitLogging
     implementation ui.gmsPlayServicesLocation
 


### PR DESCRIPTION
## Summary
- include Gson as an implementation dependency in app and data modules
- remove global exclusion that prevented Gson from being packaged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a75d1a048329b9b5b9a66b129214)