### PR TITLE
Add call screens with Flashphoner setup

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
@@ -1,0 +1,68 @@
+package uddug.com.naukoteka.mvvm.call
+
+import android.app.Activity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import uddug.com.naukoteka.flashphoner.FlashphonerConfigProvider
+import uddug.com.naukoteka.flashphoner.FlashphonerEnvironment
+import uddug.com.naukoteka.flashphoner.FlashphonerSessionManager
+
+@HiltViewModel
+class CallViewModel @Inject constructor(
+    private val flashphonerEnvironment: FlashphonerEnvironment,
+    private val flashphonerConfigProvider: FlashphonerConfigProvider,
+    private val flashphonerSessionManager: FlashphonerSessionManager,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CallUiState())
+    val uiState: StateFlow<CallUiState> = _uiState
+
+    private var isCallStarted = false
+
+    fun startCall(activity: Activity, contactName: String?, avatarUrl: String?) {
+        if (isCallStarted) return
+        isCallStarted = true
+
+        _uiState.value = CallUiState(
+            contactName = contactName,
+            avatarUrl = avatarUrl,
+            status = CallStatus.DIALING,
+        )
+
+        viewModelScope.launch {
+            runCatching {
+                val config = flashphonerConfigProvider.defaultConfig
+                flashphonerEnvironment.ensureInitialised(activity)
+                flashphonerSessionManager.prepareSession(activity, config.serverUrl)
+            }.onSuccess {
+                _uiState.value = _uiState.value.copy(status = CallStatus.CONNECTING)
+                _uiState.value = _uiState.value.copy(status = CallStatus.IN_CALL)
+            }.onFailure {
+                _uiState.value = _uiState.value.copy(status = CallStatus.FINISHED)
+            }
+        }
+    }
+
+    fun endCall() {
+        flashphonerSessionManager.disconnectSession()
+        _uiState.value = _uiState.value.copy(status = CallStatus.FINISHED)
+    }
+}
+
+data class CallUiState(
+    val contactName: String? = null,
+    val avatarUrl: String? = null,
+    val status: CallStatus = CallStatus.DIALING,
+)
+
+enum class CallStatus {
+    DIALING,
+    CONNECTING,
+    IN_CALL,
+    FINISHED,
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
@@ -1,0 +1,53 @@
+package uddug.com.naukoteka.ui.call
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import uddug.com.naukoteka.mvvm.call.CallViewModel
+import uddug.com.naukoteka.ui.call.compose.CallScreen
+
+@AndroidEntryPoint
+class CallFragment : Fragment() {
+
+    private val viewModel: CallViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val contactName = arguments?.getString(ARG_CONTACT_NAME)
+        val avatarUrl = arguments?.getString(ARG_AVATAR_URL)
+
+        viewModel.startCall(requireActivity(), contactName, avatarUrl)
+
+        return ComposeView(requireContext()).apply {
+            setContent {
+                val state = viewModel.uiState.collectAsState().value
+                MaterialTheme {
+                    CallScreen(
+                        state = state,
+                        onBackPressed = { findNavController().popBackStack() },
+                        onEndCall = {
+                            viewModel.endCall()
+                            findNavController().popBackStack()
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_CONTACT_NAME = "contact_name"
+        const val ARG_AVATAR_URL = "avatar_url"
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/compose/CallScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/compose/CallScreen.kt
@@ -1,0 +1,220 @@
+package uddug.com.naukoteka.ui.call.compose
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.call.CallStatus
+import uddug.com.naukoteka.mvvm.call.CallUiState
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
+
+@Composable
+fun CallScreen(
+    state: CallUiState,
+    onBackPressed: () -> Unit,
+    onEndCall: () -> Unit,
+) {
+    val backgroundColor = Color(0xFF0B1020)
+    val statusText = when (state.status) {
+        CallStatus.DIALING -> stringResource(R.string.call_status_dialing)
+        CallStatus.CONNECTING -> stringResource(R.string.call_status_connecting)
+        CallStatus.IN_CALL -> stringResource(R.string.call_status_in_call)
+        CallStatus.FINISHED -> stringResource(R.string.call_status_finished)
+    }
+
+    Scaffold(
+        containerColor = backgroundColor,
+        topBar = {
+            TopAppBar(
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = backgroundColor,
+                    navigationIconContentColor = Color.White
+                ),
+                title = {},
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_close),
+                            tint = Color.White,
+                            contentDescription = null,
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Avatar(
+                    url = state.avatarUrl,
+                    name = state.contactName,
+                    size = 120.dp,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = state.contactName.orEmpty(),
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 24.sp,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = statusText,
+                    color = Color(0xFFB0B3C5),
+                    fontSize = 16.sp,
+                )
+                Spacer(modifier = Modifier.height(32.dp))
+                if (state.status == CallStatus.DIALING || state.status == CallStatus.CONNECTING) {
+                    CircularProgressIndicator(color = Color.White)
+                }
+            }
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                ) {
+                    CallActionButton(
+                        iconRes = R.drawable.ic_rec_mic_active,
+                        label = stringResource(R.string.call_microphone),
+                        containerColor = Color(0xFF121732),
+                        contentColor = Color.White,
+                    ) {}
+                    CallActionButton(
+                        iconRes = R.drawable.ic_profile_call,
+                        label = stringResource(R.string.call_primary_action),
+                        containerColor = Color(0xFF121732),
+                        contentColor = Color.White,
+                    ) {}
+                    CallActionButton(
+                        iconRes = R.drawable.ic_profile_send,
+                        label = stringResource(R.string.call_secondary_action),
+                        containerColor = Color(0xFF121732),
+                        contentColor = Color.White,
+                    ) {}
+                }
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp)),
+                    color = Color(0xFF1D2239),
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        CallActionButton(
+                            iconRes = R.drawable.ic_rec_mic_inactive,
+                            label = stringResource(R.string.call_microphone),
+                            containerColor = Color.Transparent,
+                            contentColor = Color.White,
+                        ) {}
+                        CallActionButton(
+                            iconRes = R.drawable.ic_mute_sound_folder,
+                            label = stringResource(R.string.call_speaker),
+                            containerColor = Color.Transparent,
+                            contentColor = Color.White,
+                        ) {}
+                        CallActionButton(
+                            iconRes = R.drawable.ic_close,
+                            label = stringResource(R.string.call_terminate_action),
+                            containerColor = Color(0xFFE64C4C),
+                            contentColor = Color.White,
+                            onClick = onEndCall,
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CallActionButton(
+    iconRes: Int,
+    label: String,
+    containerColor: Color,
+    contentColor: Color,
+    onClick: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Surface(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(CircleShape),
+            color = containerColor,
+            contentColor = contentColor,
+            onClick = onClick,
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    painter = painterResource(id = iconRes),
+                    contentDescription = label,
+                    tint = contentColor,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = contentColor,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
@@ -25,6 +25,7 @@ import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationVi
 import uddug.com.naukoteka.ui.chat.compose.ChatDetailDialogComponent
 import uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment.Companion.ARG_AVATAR_PATH
 import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
+import uddug.com.naukoteka.ui.call.CallFragment
 @AndroidEntryPoint
 class ChatDetailDialogFragment : Fragment() {
 
@@ -116,6 +117,15 @@ class ChatDetailDialogFragment : Fragment() {
                             findNavController().navigate(
                                 R.id.chatDetailSearchFragment,
                                 Bundle().apply { putLong(DIALOG_ID, dialogId) }
+                            )
+                        },
+                        onCallClick = { name, avatar ->
+                            findNavController().navigate(
+                                R.id.callFragment,
+                                Bundle().apply {
+                                    putString(CallFragment.ARG_CONTACT_NAME, name)
+                                    putString(CallFragment.ARG_AVATAR_URL, avatar)
+                                }
                             )
                         },
                         onChatDeleted = {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
@@ -22,6 +22,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailUiState
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatGroupDetailComponent
 import uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment.Companion.ARG_AVATAR_PATH
+import uddug.com.naukoteka.ui.call.CallFragment
 
 @AndroidEntryPoint
 class ChatGroupDetailFragment : Fragment() {
@@ -86,6 +87,15 @@ class ChatGroupDetailFragment : Fragment() {
                         },
                         onAddParticipantsClick = {
                             findNavController().navigate(R.id.chatCreateMultiFragment)
+                        },
+                        onCallClick = { name, avatar ->
+                            findNavController().navigate(
+                                R.id.callFragment,
+                                Bundle().apply {
+                                    putString(CallFragment.ARG_CONTACT_NAME, name)
+                                    putString(CallFragment.ARG_AVATAR_URL, avatar)
+                                }
+                            )
                         },
                         onViewAvatar = { avatarPath ->
                             findNavController().navigate(

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -111,6 +111,7 @@ fun ChatDetailDialogComponent(
     onBackPressed: () -> Unit,
     onNavigateToProfile: () -> Unit,
     onSearchClick: () -> Unit,
+    onCallClick: (String?, String?) -> Unit,
     onChatDeleted: () -> Unit,
     onViewAvatar: (String) -> Unit,
     onEditGroup: (Long) -> Unit,
@@ -284,16 +285,16 @@ fun ChatDetailDialogComponent(
                                 Modifier
                                     .weight(1f)
                                     .padding(end = 4.dp)
-                                    .background(
-                                        shape = RoundedCornerShape(8.dp),
-                                        color = Color(0xFFF5F5F9)
-                                    )
-                                    .clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
-                                        indication = null
-                                    ) {
-
-                                    }
+                                .background(
+                                    shape = RoundedCornerShape(8.dp),
+                                    color = Color(0xFFF5F5F9)
+                                )
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null
+                                ) {
+                                    onCallClick(state.profile.fullName, state.avatarPath)
+                                }
                                     .padding(12.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
@@ -77,6 +77,7 @@ fun ChatGroupDetailComponent(
     onBackPressed: () -> Unit,
     onSearchClick: () -> Unit,
     onAddParticipantsClick: (Long) -> Unit,
+    onCallClick: (String?, String?) -> Unit,
     onViewAvatar: (String) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -207,7 +208,8 @@ fun ChatGroupDetailComponent(
                             if (state.isCurrentUserAdmin && !state.isAvatarUpdating) {
                                 showAvatarDialog = true
                             }
-                        }
+                        },
+                        onCallClick = { onCallClick(state.name, state.image) }
                     )
                 } else {
                     OtherTabsContent(
@@ -220,7 +222,8 @@ fun ChatGroupDetailComponent(
                             if (state.isCurrentUserAdmin && !state.isAvatarUpdating) {
                                 showAvatarDialog = true
                             }
-                        }
+                        },
+                        onCallClick = { onCallClick(state.name, state.image) }
                     ) {
                         when (selectedTabIndex) {
                             1 -> MediaContent(state.media)
@@ -283,6 +286,7 @@ private fun ParticipantsTabContent(
     participants: List<Participant>,
     onParticipantMoreClick: (Participant) -> Unit,
     onAvatarClick: () -> Unit,
+    onCallClick: () -> Unit,
 ) {
     val listState = rememberLazyListState()
     LazyColumn(
@@ -299,6 +303,7 @@ private fun ParticipantsTabContent(
                 onAvatarClick = onAvatarClick,
                 isCurrentUserAdmin = isCurrentUserAdmin,
                 isAvatarUpdating = state.isAvatarUpdating,
+                onCallClick = onCallClick,
             )
         }
         stickyHeader {
@@ -328,6 +333,7 @@ private fun OtherTabsContent(
     selectedTabIndex: Int,
     onTabSelected: (Int) -> Unit,
     onAvatarClick: () -> Unit,
+    onCallClick: () -> Unit,
     content: @Composable () -> Unit,
 ) {
     Column(
@@ -341,6 +347,7 @@ private fun OtherTabsContent(
             onAvatarClick = onAvatarClick,
             isCurrentUserAdmin = state.isCurrentUserAdmin,
             isAvatarUpdating = state.isAvatarUpdating,
+            onCallClick = onCallClick,
         )
         GroupTabRow(
             tabTitles = tabTitles,
@@ -359,6 +366,7 @@ private fun GroupHeaderSection(
     onAvatarClick: () -> Unit,
     isCurrentUserAdmin: Boolean,
     isAvatarUpdating: Boolean,
+    onCallClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -422,7 +430,8 @@ private fun GroupHeaderSection(
             GroupHeaderAction(
                 icon = R.drawable.ic_profile_call,
                 label = stringResource(R.string.call_user),
-                modifier = Modifier.padding(end = 4.dp)
+                modifier = Modifier.padding(end = 4.dp),
+                onClick = onCallClick
             )
             GroupHeaderAction(
                 icon = R.drawable.ic_profile_send,
@@ -443,6 +452,7 @@ private fun RowScope.GroupHeaderAction(
     icon: Int,
     label: String,
     modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -454,7 +464,7 @@ private fun RowScope.GroupHeaderAction(
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null
-            ) { }
+            ) { onClick() }
             .padding(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -113,4 +113,17 @@
         android:id="@+id/chatAvatarPreviewFragment"
         android:name="uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment" />
 
+    <fragment
+        android:id="@+id/callFragment"
+        android:name="uddug.com.naukoteka.ui.call.CallFragment">
+        <argument
+            android:name="contact_name"
+            app:argType="string"
+            android:defaultValue="@null" />
+        <argument
+            android:name="avatar_url"
+            app:argType="string"
+            android:defaultValue="@null" />
+    </fragment>
+
 </navigation>

--- a/app/src/main/res/values/flashphoner.xml
+++ b/app/src/main/res/values/flashphoner.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="flashphoner_default_server">wss://demo.flashphoner.com:8443</string>
+    <string name="flashphoner_default_server">https://stage.naukotheka.ru:8444/</string>
     <string name="flashphoner_default_stream">defaultStream</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -463,6 +463,16 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="another_links_text">Прочие ссылки</string>
     <string name="group_chat">Групповой чат</string>
     <string name="call_user">Позвонить</string>
+    <string name="call_status_connecting">Подключаемся…</string>
+    <string name="call_status_dialing">Идет звонок</string>
+    <string name="call_status_finished">Звонок завершен</string>
+    <string name="call_status_loading">Загрузка…</string>
+    <string name="call_status_in_call">Звонок</string>
+    <string name="call_primary_action">Позвонить</string>
+    <string name="call_secondary_action">Сообщение</string>
+    <string name="call_terminate_action">Завершить</string>
+    <string name="call_microphone">Микрофон</string>
+    <string name="call_speaker">Динамик</string>
     <string name="profile_shasre">Поделиться</string>
     <string name="profile_more">Еще</string>
     <string name="find_chat_message">Поиск чатов и сообщений</string>


### PR DESCRIPTION
## Summary
- update the Flashphoner default server to the stage endpoint
- add a new call screen with Flashphoner session initialisation and UI controls
- wire chat profile call actions to navigate into the call experience

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not configured in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a64b1fd08329814459b5470f8be9)