### PR TITLE
Adjust gson dependency scope to avoid duplicates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     implementation presentation.toothpickLifeCycle
     kapt presentation.toothpickCompiler
 
-    implementation data.gson
+    compileOnly data.gson
     implementation data.retrofit
     implementation data.retrofitLogging
     implementation(data.gsonConverter) {

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation(data.gsonConverter) {
         exclude group: 'com.google.code.gson', module: 'gson'
     }
-    implementation data.gson
+    compileOnly data.gson
     implementation data.retrofitLogging
     implementation ui.gmsPlayServicesLocation
 

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -6,7 +6,7 @@ android {
 
 dependencies {
 
-    implementation data.gson
+    compileOnly data.gson
 
     implementation 'androidx.paging:paging-runtime-ktx:3.1.1'
     implementation 'androidx.paging:paging-rxjava2-ktx:3.1.1'


### PR DESCRIPTION
## Summary
- switch gson dependencies in app, data, and domain modules to compileOnly to avoid bundling duplicates already packaged in the Flashphoner SDK AAR

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b4f896548329801337a3089836ef)