### PR TITLE
Add draggable in-app call picture-in-picture overlay

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
@@ -8,17 +8,18 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import uddug.com.naukoteka.mvvm.call.CallParticipant
 import uddug.com.naukoteka.mvvm.call.CallViewModel
 import uddug.com.naukoteka.ui.call.compose.CallScreen
+import uddug.com.naukoteka.ui.call.overlay.CallOverlayFragment
 
 @AndroidEntryPoint
 class CallFragment : Fragment() {
 
-    private val viewModel: CallViewModel by viewModels()
+    private val viewModel: CallViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -48,10 +49,32 @@ class CallFragment : Fragment() {
                         onEndCall = {
                             viewModel.endCall()
                             findNavController().popBackStack()
-                        }
+                            removeFloatingCall()
+                        },
+                        onMinimize = {
+                            showFloatingCall()
+                            findNavController().popBackStack()
+                        },
                     )
                 }
             }
+        }
+    }
+
+    private fun showFloatingCall() {
+        val fragmentManager = requireActivity().supportFragmentManager
+        if (fragmentManager.findFragmentByTag(CallOverlayFragment.TAG) == null) {
+            fragmentManager.beginTransaction()
+                .add(android.R.id.content, CallOverlayFragment(), CallOverlayFragment.TAG)
+                .commitAllowingStateLoss()
+        }
+    }
+
+    private fun removeFloatingCall() {
+        requireActivity().supportFragmentManager.findFragmentByTag(CallOverlayFragment.TAG)?.let {
+            requireActivity().supportFragmentManager.beginTransaction()
+                .remove(it)
+                .commitAllowingStateLoss()
         }
     }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/compose/CallScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/compose/CallScreen.kt
@@ -50,6 +50,7 @@ fun CallScreen(
     state: CallUiState,
     onBackPressed: () -> Unit,
     onEndCall: () -> Unit,
+    onMinimize: () -> Unit,
 ) {
     val backgroundColor = Color(0xFF0B1020)
     val isGroupCall = state.participants.size > 1
@@ -76,6 +77,15 @@ fun CallScreen(
                     IconButton(onClick = onBackPressed) {
                         Icon(
                             painter = painterResource(id = R.drawable.ic_close),
+                            tint = Color.White,
+                            contentDescription = null,
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onMinimize) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_arrow_down),
                             tint = Color.White,
                             contentDescription = null,
                         )

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlay.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlay.kt
@@ -1,0 +1,160 @@
+package uddug.com.naukoteka.ui.call.overlay
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.call.CallStatus
+import uddug.com.naukoteka.mvvm.call.CallUiState
+import uddug.com.naukoteka.ui.chat.compose.components.Avatar
+import kotlin.math.roundToInt
+
+@Composable
+fun CallOverlay(
+    state: CallUiState,
+    onExpand: () -> Unit,
+    onEndCall: () -> Unit,
+    onClose: () -> Unit,
+    onFinished: () -> Unit,
+) {
+    val overlayWidth = 240.dp
+    val overlayHeight = 160.dp
+    val margin = 16.dp
+    val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+
+    val screenWidth = with(density) { configuration.screenWidthDp.dp.toPx() }
+    val screenHeight = with(density) { configuration.screenHeightDp.dp.toPx() }
+    val widthPx = with(density) { overlayWidth.toPx() }
+    val heightPx = with(density) { overlayHeight.toPx() }
+    val marginPx = with(density) { margin.toPx() }
+
+    var offset by remember {
+        mutableStateOf(
+            Offset(
+                x = screenWidth - widthPx - marginPx,
+                y = screenHeight - heightPx - marginPx,
+            )
+        )
+    }
+
+    LaunchedEffect(state.status) {
+        if (state.status == CallStatus.FINISHED) {
+            onFinished()
+        }
+    }
+
+    Surface(
+        modifier = Modifier
+            .size(overlayWidth, overlayHeight)
+            .offset { IntOffset(offset.x.roundToInt(), offset.y.roundToInt()) }
+            .pointerInput(screenWidth, screenHeight) {
+                detectDragGestures { change, dragAmount ->
+                    change.consume()
+                    val newOffset = offset + dragAmount
+                    offset = Offset(
+                        x = newOffset.x.coerceIn(marginPx, screenWidth - widthPx - marginPx),
+                        y = newOffset.y.coerceIn(marginPx, screenHeight - heightPx - marginPx),
+                    )
+                }
+            },
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
+        tonalElevation = 8.dp,
+        shadowElevation = 12.dp,
+        onClick = onExpand,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = MaterialTheme.colorScheme.surfaceTint.copy(alpha = 0.05f))
+                .padding(12.dp)
+        ) {
+            Row(
+                modifier = Modifier.align(Alignment.TopEnd),
+            ) {
+                IconButton(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape),
+                    onClick = onClose,
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_arrow_down),
+                        contentDescription = null,
+                    )
+                }
+                IconButton(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape),
+                    onClick = onEndCall,
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_close),
+                        contentDescription = null,
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.align(Alignment.CenterStart),
+                horizontalAlignment = Alignment.Start,
+            ) {
+                Avatar(
+                    url = state.participants.firstOrNull()?.avatarUrl,
+                    name = state.participants.firstOrNull()?.name,
+                    size = 64.dp,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = state.callTitle ?: state.participants.firstOrNull()?.name
+                    ?: stringResource(id = R.string.call_status_in_call),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = when (state.status) {
+                        CallStatus.DIALING -> stringResource(id = R.string.call_status_dialing)
+                        CallStatus.CONNECTING -> stringResource(id = R.string.call_status_connecting)
+                        CallStatus.IN_CALL -> stringResource(id = R.string.call_status_in_call)
+                        CallStatus.FINISHED -> stringResource(id = R.string.call_status_finished)
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
@@ -1,0 +1,83 @@
+package uddug.com.naukoteka.ui.call.overlay
+
+import android.os.Bundle
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.findNavController
+import dagger.hilt.android.AndroidEntryPoint
+import uddug.com.naukoteka.R
+import uddug.com.naukoteka.mvvm.call.CallViewModel
+import uddug.com.naukoteka.ui.call.CallFragment
+import kotlin.math.roundToInt
+
+@AndroidEntryPoint
+class CallOverlayFragment : Fragment() {
+
+    private val viewModel: CallViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.BOTTOM or Gravity.END,
+            ).apply {
+                val margin = (16 * resources.displayMetrics.density).roundToInt()
+                setMargins(margin, margin, margin, margin)
+            }
+            setContent {
+                val state = viewModel.uiState.collectAsState().value
+
+                MaterialTheme {
+                    CallOverlay(
+                        state = state,
+                        onExpand = {
+                            openFullScreen()
+                            removeSelf()
+                        },
+                        onEndCall = {
+                            viewModel.endCall()
+                            removeSelf()
+                        },
+                        onClose = { removeSelf() },
+                        onFinished = { removeSelf() }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun openFullScreen() {
+        val navController = requireActivity().findNavController(R.id.main_nav_host_fragment)
+        val args = Bundle().apply {
+            putString(CallFragment.ARG_CALL_TITLE, viewModel.uiState.value.callTitle)
+            putParcelableArrayList(
+                CallFragment.ARG_PARTICIPANTS,
+                ArrayList(viewModel.uiState.value.participants),
+            )
+        }
+        navController.navigate(R.id.callFragment, args)
+    }
+
+    private fun removeSelf() {
+        parentFragmentManager.beginTransaction()
+            .remove(this)
+            .commitAllowingStateLoss()
+    }
+
+    companion object {
+        const val TAG = "CallOverlayFragment"
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimize action to the call screen and share call state at the activity level
- introduce a draggable in-app call overlay fragment for picture-in-picture behavior
- ensure the overlay can be closed, restored to full screen, or dismissed when the call ends

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b586c09c832995136d414436a60e)