### PR TITLE
Add participants bottom sheets to call screen

### DIFF
--- a/app/src/main/res/drawable/ic_call_participants.xml
+++ b/app/src/main/res/drawable/ic_call_participants.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M16,11c1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3 1.34,3 3,3zM8,11c1.66,0 3,-1.34 3,-3S9.66,5 8,5 5,6.34 5,8s1.34,3 3,3zM8,13c-2.33,0 -7,1.17 -7,3.5V19h14v-2.5C15,14.17 10.33,13 8,13zM16,13c-0.29,0 -0.62,0.02 -0.97,0.05 1.16,0.84 1.97,1.97 1.97,3.45V19h6v-2.5C23,14.17 18.33,13 16,13z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -473,6 +473,17 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="call_terminate_action">Завершить</string>
     <string name="call_microphone">Микрофон</string>
     <string name="call_speaker">Динамик</string>
+    <string name="call_participants_title">Участники звонка</string>
+    <string name="call_participants_statuses">Статусы</string>
+    <string name="call_participants_invite">Пригласить участника</string>
+    <string name="call_participant_status_muted">Выключен микрофон</string>
+    <string name="call_participant_status_active">Микрофон включен</string>
+    <string name="call_participant_actions_title">Функции</string>
+    <string name="call_participant_action_mute">Отключить звук</string>
+    <string name="call_participant_action_unmute">Включить звук</string>
+    <string name="call_participant_action_copy">Скопировать контакт</string>
+    <string name="call_participant_action_profile">Посмотреть профиль</string>
+    <string name="call_sheet_close">Закрыть</string>
     <string name="profile_shasre">Поделиться</string>
     <string name="profile_more">Еще</string>
     <string name="find_chat_message">Поиск чатов и сообщений</string>


### PR DESCRIPTION
## Summary
- add a participants shortcut in the call screen top bar and drive new participant list and actions bottom sheets
- render call participants with microphone statuses and invite shortcut
- provide participant action sheet entries and supporting strings and icon assets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b8d5a2608329bf00ce7d16101723)