### PR TITLE
Exclude Gson artifact from runtime classpaths

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,15 @@ apply plugin: 'kotlin-parcelize'
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: 'dagger.hilt.android.plugin'
 
+// Flashphoner SDK already bundles Gson classes, so exclude the Maven artifact from
+// runtime classpaths to avoid duplicate definitions while keeping it on the
+// compile classpath for modules that need it.
+configurations.configureEach {
+    if (name.contains("RuntimeClasspath")) {
+        exclude group: 'com.google.code.gson', module: 'gson'
+    }
+}
+
 android {
     lintOptions {
         abortOnError false


### PR DESCRIPTION
## Summary
- add runtime classpath exclusion for com.google.code.gson to avoid conflicts with the Flashphoner SDK
- keep Gson available on the compile classpath for modules that need it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c0e903d083298279cc9a10ad2aa0)