### PR TITLE
Enable movable call picture-in-picture overlay

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlay.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlay.kt
@@ -76,84 +76,87 @@ fun CallOverlay(
         }
     }
 
-    Surface(
-        modifier = Modifier
-            .size(overlayWidth, overlayHeight)
-            .offset { IntOffset(offset.x.roundToInt(), offset.y.roundToInt()) }
-            .pointerInput(screenWidth, screenHeight) {
-                detectDragGestures { change, dragAmount ->
-                    change.consume()
-                    val newOffset = offset + dragAmount
-                    offset = Offset(
-                        x = newOffset.x.coerceIn(marginPx, screenWidth - widthPx - marginPx),
-                        y = newOffset.y.coerceIn(marginPx, screenHeight - heightPx - marginPx),
-                    )
-                }
-            },
-        shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
-        tonalElevation = 8.dp,
-        shadowElevation = 12.dp,
-        onClick = onExpand,
-    ) {
-        Box(
+    Box(modifier = Modifier.fillMaxSize()) {
+        Surface(
             modifier = Modifier
-                .fillMaxSize()
-                .background(color = MaterialTheme.colorScheme.surfaceTint.copy(alpha = 0.05f))
-                .padding(12.dp)
+                .align(Alignment.TopStart)
+                .size(overlayWidth, overlayHeight)
+                .offset { IntOffset(offset.x.roundToInt(), offset.y.roundToInt()) }
+                .pointerInput(screenWidth, screenHeight) {
+                    detectDragGestures { change, dragAmount ->
+                        change.consume()
+                        val newOffset = offset + dragAmount
+                        offset = Offset(
+                            x = newOffset.x.coerceIn(marginPx, screenWidth - widthPx - marginPx),
+                            y = newOffset.y.coerceIn(marginPx, screenHeight - heightPx - marginPx),
+                        )
+                    }
+                },
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
+            tonalElevation = 8.dp,
+            shadowElevation = 12.dp,
+            onClick = onExpand,
         ) {
-            Row(
-                modifier = Modifier.align(Alignment.TopEnd),
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = MaterialTheme.colorScheme.surfaceTint.copy(alpha = 0.05f))
+                    .padding(12.dp)
             ) {
-                IconButton(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clip(CircleShape),
-                    onClick = onClose,
+                Row(
+                    modifier = Modifier.align(Alignment.TopEnd),
                 ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_arrow_down),
-                        contentDescription = null,
-                    )
+                    IconButton(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape),
+                        onClick = onClose,
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_arrow_down),
+                            contentDescription = null,
+                        )
+                    }
+                    IconButton(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape),
+                        onClick = onEndCall,
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_close),
+                            contentDescription = null,
+                        )
+                    }
                 }
-                IconButton(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clip(CircleShape),
-                    onClick = onEndCall,
-                ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_close),
-                        contentDescription = null,
-                    )
-                }
-            }
 
-            Column(
-                modifier = Modifier.align(Alignment.CenterStart),
-                horizontalAlignment = Alignment.Start,
-            ) {
-                Avatar(
-                    url = state.participants.firstOrNull()?.avatarUrl,
-                    name = state.participants.firstOrNull()?.name,
-                    size = 64.dp,
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-                Text(
-                    text = state.callTitle ?: state.participants.firstOrNull()?.name
-                    ?: stringResource(id = R.string.call_status_in_call),
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = when (state.status) {
-                        CallStatus.DIALING -> stringResource(id = R.string.call_status_dialing)
-                        CallStatus.CONNECTING -> stringResource(id = R.string.call_status_connecting)
-                        CallStatus.IN_CALL -> stringResource(id = R.string.call_status_in_call)
-                        CallStatus.FINISHED -> stringResource(id = R.string.call_status_finished)
-                    },
-                    style = MaterialTheme.typography.bodyMedium,
-                )
+                Column(
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    horizontalAlignment = Alignment.Start,
+                ) {
+                    Avatar(
+                        url = state.participants.firstOrNull()?.avatarUrl,
+                        name = state.participants.firstOrNull()?.name,
+                        size = 64.dp,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = state.callTitle ?: state.participants.firstOrNull()?.name
+                        ?: stringResource(id = R.string.call_status_in_call),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = when (state.status) {
+                            CallStatus.DIALING -> stringResource(id = R.string.call_status_dialing)
+                            CallStatus.CONNECTING -> stringResource(id = R.string.call_status_connecting)
+                            CallStatus.IN_CALL -> stringResource(id = R.string.call_status_in_call)
+                            CallStatus.FINISHED -> stringResource(id = R.string.call_status_finished)
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
@@ -30,13 +30,10 @@ class CallOverlayFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
                 Gravity.BOTTOM or Gravity.END,
-            ).apply {
-                val margin = (16 * resources.displayMetrics.density).roundToInt()
-                setMargins(margin, margin, margin, margin)
-            }
+            )
             setContent {
                 val state = viewModel.uiState.collectAsState().value
 


### PR DESCRIPTION
## Summary
- expand the minimized call overlay container to fill the screen so it can float over other content
- wrap the PiP UI in a full-screen box with bounded drag handling, keeping call controls accessible when minimized

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d99902248329ae3246d3940d947b)