### PR TITLE
Update call participants screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -477,6 +477,8 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="call_minimize">Свернуть</string>
     <string name="call_speaker">Динамик</string>
     <string name="call_participants_title">Участники звонка</string>
+    <string name="call_participants_count">Участники %1$d</string>
+    <string name="call_participants_search_placeholder">Поиск</string>
     <string name="call_participants_statuses">Статусы</string>
     <string name="call_participants_invite">Пригласить участника</string>
     <string name="call_participant_status_muted">Выключен микрофон</string>


### PR DESCRIPTION
## Summary
- update the call participants screen toolbar and layout to match the new design
- add participant count, search filtering, and refreshed list styling on a dark background
- keep participant actions on the same screen by opening the bottom sheet without closing the list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924dc1676108329a3fdf73b34ab6763)