### PR TITLE
Handle missing Flashphoner connection on disconnect

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -52,6 +52,9 @@ class FlashphonerSessionManager @Inject constructor(
 
     fun disconnectSession() {
         stopStream()
-        sessionRef.getAndSet(null)?.disconnect()
+        val session = sessionRef.getAndSet(null) ?: return
+        if (session.connection != null) {
+            session.disconnect()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid calling Flashphoner disconnect when there is no active connection
- keep session and stream references cleared when ending a call

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0819f6748329a8eb449c0b357311)