### PR TITLE
Hook calls up to Flashphoner rooms

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
@@ -5,6 +5,13 @@ import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import com.flashphoner.fpwcsapi.bean.Connection
+import com.flashphoner.fpwcsapi.constraints.Constraints
+import com.flashphoner.fpwcsapi.room.Message
+import com.flashphoner.fpwcsapi.room.Participant
+import com.flashphoner.fpwcsapi.room.Room
+import com.flashphoner.fpwcsapi.room.RoomEvent
+import com.flashphoner.fpwcsapi.room.RoomManagerEvent
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -13,15 +20,18 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.isActive
 import kotlinx.parcelize.Parcelize
+import uddug.com.data.cache.user_id.UserIdCache
+import uddug.com.data.cache.user_uuid.UserUUIDCache
+import uddug.com.naukoteka.flashphoner.FlashphonerConfig
 import uddug.com.naukoteka.flashphoner.FlashphonerConfigProvider
-import uddug.com.naukoteka.flashphoner.FlashphonerEnvironment
 import uddug.com.naukoteka.flashphoner.FlashphonerSessionManager
 
 @HiltViewModel
 class CallViewModel @Inject constructor(
-    private val flashphonerEnvironment: FlashphonerEnvironment,
     private val flashphonerConfigProvider: FlashphonerConfigProvider,
     private val flashphonerSessionManager: FlashphonerSessionManager,
+    private val userIdCache: UserIdCache,
+    private val userUUIDCache: UserUUIDCache,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CallUiState())
@@ -32,12 +42,18 @@ class CallViewModel @Inject constructor(
 
     fun startCall(
         activity: Activity,
+        dialogId: Long,
         contactName: String?,
         avatarUrl: String?,
         participants: List<CallParticipant>? = null,
         callTitle: String? = null,
     ) {
         if (isCallStarted) return
+
+        if (dialogId <= 0) {
+            _uiState.value = _uiState.value.copy(status = CallStatus.FINISHED)
+            return
+        }
         isCallStarted = true
 
         val resolvedParticipants = participants?.takeIf { it.isNotEmpty() }
@@ -53,6 +69,7 @@ class CallViewModel @Inject constructor(
             ?: emptyList()
 
         _uiState.value = CallUiState(
+            dialogId = dialogId,
             callTitle = callTitle ?: contactName,
             participants = resolvedParticipants,
             status = CallStatus.DIALING,
@@ -61,23 +78,29 @@ class CallViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 val config = flashphonerConfigProvider.defaultConfig
-                flashphonerEnvironment.ensureInitialised(activity)
-                flashphonerSessionManager.prepareSession(activity, config.serverUrl)
+                val username = resolveUsername()
+                val streamName = buildStreamName(config, dialogId, username)
+
+                val roomManager = flashphonerSessionManager.prepareRoomManager(
+                    activity = activity,
+                    serverUrl = config.serverUrl,
+                    username = username,
+                )
+
+                roomManager.on(createRoomManagerEvent(dialogId, streamName))
             }.onSuccess {
                 _uiState.value = _uiState.value.copy(status = CallStatus.CONNECTING)
-                _uiState.value = _uiState.value.copy(status = CallStatus.IN_CALL)
-                startCallTimer()
             }.onFailure {
-                _uiState.value = _uiState.value.copy(status = CallStatus.FINISHED)
-                stopCallTimer()
+                handleCallFailure()
             }
         }
     }
 
     fun endCall() {
-        flashphonerSessionManager.disconnectSession()
+        flashphonerSessionManager.disconnectRoom()
         _uiState.value = _uiState.value.copy(status = CallStatus.FINISHED)
         stopCallTimer()
+        isCallStarted = false
     }
 
     private fun startCallTimer() {
@@ -96,9 +119,99 @@ class CallViewModel @Inject constructor(
         callDurationJob?.cancel()
         callDurationJob = null
     }
+
+    private fun createRoomManagerEvent(
+        dialogId: Long,
+        streamName: String,
+    ): RoomManagerEvent {
+        return object : RoomManagerEvent {
+            override fun onConnected(connection: Connection) {
+                flashphonerSessionManager.joinRoom(
+                    roomName = dialogId.toString(),
+                    roomEvent = { room -> room.on(createRoomEvent(streamName)) },
+                    onRoomReady = { publishLocalStream(streamName) },
+                )
+            }
+
+            override fun onDisconnection(connection: Connection) {
+                handleCallFailure()
+            }
+        }
+    }
+
+    private fun createRoomEvent(streamName: String): RoomEvent {
+        return object : RoomEvent {
+            override fun onState(room: Room) {
+                subscribeToParticipants(room.participants)
+            }
+
+            override fun onJoined(participant: Participant) {
+                subscribeToParticipants(listOf(participant))
+            }
+
+            override fun onLeft(participant: Participant) {
+                participant.stop()
+            }
+
+            override fun onPublished(participant: Participant) {
+                subscribeToParticipants(listOf(participant))
+            }
+
+            override fun onFailed(room: Room, error: String) {
+                handleCallFailure(error)
+            }
+
+            override fun onMessage(message: Message) {
+                // No-op. Signalling is handled by the backend, clients only need to join the room.
+            }
+        }
+    }
+
+    private fun publishLocalStream(streamName: String) {
+        runCatching {
+            flashphonerSessionManager.publishToCurrentRoom(streamName) {
+                constraints = Constraints(audio = true, video = false)
+            }
+        }.onSuccess {
+            _uiState.value = _uiState.value.copy(status = CallStatus.IN_CALL)
+            startCallTimer()
+        }.onFailure {
+            handleCallFailure()
+        }
+    }
+
+    private fun subscribeToParticipants(participants: Collection<Participant>) {
+        participants.forEach { participant ->
+            runCatching { participant.play(null) }
+        }
+    }
+
+    private fun handleCallFailure(@Suppress("UNUSED_PARAMETER") message: String? = null) {
+        flashphonerSessionManager.disconnectRoom()
+        _uiState.value = _uiState.value.copy(status = CallStatus.FINISHED)
+        stopCallTimer()
+        isCallStarted = false
+    }
+
+    private fun resolveUsername(): String {
+        return listOfNotNull(
+            userUUIDCache.entity?.takeIf { it.isNotBlank() },
+            userIdCache.entity?.takeIf { it.isNotBlank() },
+        ).firstOrNull() ?: "anonymous"
+    }
+
+    private fun buildStreamName(
+        config: FlashphonerConfig,
+        dialogId: Long,
+        username: String,
+    ): String {
+        return listOf(config.streamName, dialogId, username)
+            .joinToString(separator = "-")
+    }
 }
 
 data class CallUiState(
+    val dialogId: Long? = null,
     val callTitle: String? = null,
     val participants: List<CallParticipant> = emptyList(),
     val status: CallStatus = CallStatus.DIALING,

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
@@ -30,9 +30,11 @@ class CallFragment : Fragment() {
         val avatarUrl = arguments?.getString(ARG_AVATAR_URL)
         val callTitle = arguments?.getString(ARG_CALL_TITLE)
         val participants = arguments?.getParcelableArrayList<CallParticipant>(ARG_PARTICIPANTS)
+        val dialogId = arguments?.getLong(ARG_DIALOG_ID)
 
         viewModel.startCall(
             activity = requireActivity(),
+            dialogId = dialogId ?: viewModel.uiState.value.dialogId ?: 0L,
             contactName = contactName,
             avatarUrl = avatarUrl,
             participants = participants,
@@ -84,5 +86,6 @@ class CallFragment : Fragment() {
         const val ARG_AVATAR_URL = "avatar_url"
         const val ARG_CALL_TITLE = "call_title"
         const val ARG_PARTICIPANTS = "participants"
+        const val ARG_DIALOG_ID = "dialog_id"
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
@@ -59,6 +59,7 @@ class CallOverlayFragment : Fragment() {
     private fun openFullScreen() {
         val navController = requireActivity().findNavController(R.id.main_nav_host_fragment)
         val args = Bundle().apply {
+            putLong(CallFragment.ARG_DIALOG_ID, viewModel.uiState.value.dialogId ?: 0L)
             putString(CallFragment.ARG_CALL_TITLE, viewModel.uiState.value.callTitle)
             putParcelableArrayList(
                 CallFragment.ARG_PARTICIPANTS,

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
@@ -120,11 +120,15 @@ class ChatDetailDialogFragment : Fragment() {
                             )
                         },
                         onCallClick = { name, avatar ->
+                            val dialogId = (viewModel.uiState.value as? ChatDetailUiState.Success)?.dialogId
+                                ?: arguments?.getLong(DIALOG_ID)
+                                ?: return@ChatDetailDialogComponent
                             findNavController().navigate(
                                 R.id.callFragment,
                                 Bundle().apply {
                                     putString(CallFragment.ARG_CONTACT_NAME, name)
                                     putString(CallFragment.ARG_AVATAR_URL, avatar)
+                                    putLong(CallFragment.ARG_DIALOG_ID, dialogId)
                                 }
                             )
                         },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
@@ -89,11 +89,14 @@ class ChatGroupDetailFragment : Fragment() {
                             findNavController().navigate(R.id.chatCreateMultiFragment)
                         },
                         onCallClick = { name, avatar ->
+                            val dialogId = (viewModel.uiState.value as? ChatGroupDetailUiState.Success)?.dialogId
+                                ?: return@ChatGroupDetailComponent
                             findNavController().navigate(
                                 R.id.callFragment,
                                 Bundle().apply {
                                     putString(CallFragment.ARG_CONTACT_NAME, name)
                                     putString(CallFragment.ARG_AVATAR_URL, avatar)
+                                    putLong(CallFragment.ARG_DIALOG_ID, dialogId)
                                 }
                             )
                         },

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -128,6 +128,10 @@
             android:name="call_title"
             app:argType="string"
             android:defaultValue="@null" />
+        <argument
+            android:name="dialog_id"
+            app:argType="long"
+            android:defaultValue="-1" />
     </fragment>
 
 </navigation>


### PR DESCRIPTION
## Summary
- connect to Flashphoner rooms using the dialog id and publish an audio-only stream so the backend receives onPublish events
- centralize room/stream lifecycle handling in the Flashphoner session manager
- pass the dialog id through navigation to call screens and overlays to align with room-based signaling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693045d0ba748329ac3792744b820c42)