### PR TITLE
Connect Flashphoner room manager

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -5,6 +5,7 @@ import com.flashphoner.fpwcsapi.bean.Data
 import com.flashphoner.fpwcsapi.room.Room
 import com.flashphoner.fpwcsapi.room.RoomManager
 import com.flashphoner.fpwcsapi.room.RoomManagerOptions
+import com.flashphoner.fpwcsapi.room.RoomManagerEvent
 import com.flashphoner.fpwcsapi.room.RoomOptions
 import com.flashphoner.fpwcsapi.session.RestAppCommunicator
 import com.flashphoner.fpwcsapi.session.Session
@@ -68,6 +69,13 @@ class FlashphonerSessionManager @Inject constructor(
         roomManagerRef.set(manager)
 
         return manager
+    }
+
+    fun connectRoomManager(event: RoomManagerEvent) {
+        val manager = roomManagerRef.get()
+            ?: error("Flashphoner room manager must be prepared before connecting")
+
+        manager.connect(event)
     }
 
     fun joinRoom(

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
@@ -81,13 +81,15 @@ class CallViewModel @Inject constructor(
                 val username = resolveUsername()
                 val streamName = buildStreamName(config, dialogId, username)
 
-                val roomManager = flashphonerSessionManager.prepareRoomManager(
+                flashphonerSessionManager.prepareRoomManager(
                     activity = activity,
                     serverUrl = config.serverUrl,
                     username = username,
                 )
 
-                roomManager.on(createRoomManagerEvent(dialogId, streamName))
+                flashphonerSessionManager.connectRoomManager(
+                    createRoomManagerEvent(dialogId, streamName)
+                )
             }.onSuccess {
                 _uiState.value = _uiState.value.copy(status = CallStatus.CONNECTING)
             }.onFailure {


### PR DESCRIPTION
## Summary
- connect the Flashphoner room manager instead of only registering an event handler when starting calls
- centralize room manager connection logic inside the FlashphonerSessionManager helper

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69304cc599108329b17e9076e5a26269)