### PR TITLE
Handle incoming call notifications

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -31,6 +31,7 @@ import uddug.com.naukoteka.ui.chat.compose.ChatDialogComponent
 import uddug.com.naukoteka.ui.chat.compose.ChatListComponent
 import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
 import uddug.com.naukoteka.ui.chat.ChatPollResultsFragment
+import uddug.com.naukoteka.ui.call.CallFragment
 
 @AndroidEntryPoint
 class ChatDialogFragment : Fragment() {
@@ -92,6 +93,17 @@ class ChatDialogFragment : Fragment() {
                             args = Bundle().apply {
                                 putLong(DIALOG_ID, state.dialogId)
                                 putParcelable(DIALOG_DETAIL, state.dialogInfo)
+                            }
+                        )
+                    }
+                    is ChatDialogEvents.IncomingCall -> {
+                        findNavController().navigate(
+                            R.id.callFragment,
+                            Bundle().apply {
+                                putString(CallFragment.ARG_CONTACT_NAME, state.contactName)
+                                putString(CallFragment.ARG_AVATAR_URL, state.avatarUrl)
+                                putLong(CallFragment.ARG_DIALOG_ID, state.dialogId)
+                                putString(CallFragment.ARG_CALL_TITLE, state.callTitle)
                             }
                         )
                     }


### PR DESCRIPTION
## Summary
- detect incoming call socket messages and emit navigation events
- navigate to the call screen with dialog details for automatic connection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693055d2dbd88329b0bf0939056530b7)