### PR TITLE
Initialize Flashphoner globally

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/NaukotekaApplication.kt
+++ b/app/src/main/java/uddug/com/naukoteka/NaukotekaApplication.kt
@@ -7,17 +7,24 @@ import dagger.hilt.android.HiltAndroidApp
 import uddug.com.naukoteka.di.DI
 import uddug.com.naukoteka.di.modules.AppModule
 import uddug.com.naukoteka.ext.data.SUPPORTED_LOCALES
+import uddug.com.naukoteka.flashphoner.FlashphonerEnvironment
 import toothpick.Scope
 import toothpick.ktp.KTP
+import javax.inject.Inject
 
 @HiltAndroidApp
 class NaukotekaApplication : Application() {
 
     lateinit var scope: Scope
+
+    @Inject
+    lateinit var flashphonerEnvironment: FlashphonerEnvironment
+
     override fun onCreate() {
         super.onCreate()
         initializeToothpick()
         LocaleChanger.initialize(this, SUPPORTED_LOCALES)
+        flashphonerEnvironment.ensureInitialised()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
@@ -1,9 +1,10 @@
 package uddug.com.naukoteka.flashphoner
 
-import android.app.Activity
+import android.content.Context
 import com.flashphoner.fpwcsapi.Flashphoner
 import com.flashphoner.fpwcsapi.session.Session
 import com.flashphoner.fpwcsapi.session.SessionOptions
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -13,7 +14,9 @@ import javax.inject.Singleton
  * can be used by feature modules.
  */
 @Singleton
-class FlashphonerEnvironment @Inject constructor() {
+class FlashphonerEnvironment @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+) {
 
     private var isInitialised: Boolean = false
 
@@ -22,9 +25,9 @@ class FlashphonerEnvironment @Inject constructor() {
      * the call is idempotent, therefore we protect it with an [isInitialised] flag to
      * avoid extra work on subsequent injections.
      */
-    fun ensureInitialised(activity: Activity) {
+    fun ensureInitialised() {
         if (!isInitialised) {
-            Flashphoner.init(activity)
+            Flashphoner.init(appContext.applicationContext)
             isInitialised = true
         }
     }
@@ -35,11 +38,10 @@ class FlashphonerEnvironment @Inject constructor() {
      * callbacks according to the Flashphoner SDK documentation.
      */
     fun createSession(
-        activity: Activity,
         serverUrl: String,
-        configure: SessionOptions.() -> Unit = {}
+        configure: SessionOptions.() -> Unit = {},
     ): Session {
-        ensureInitialised(activity)
+        ensureInitialised()
         val options = SessionOptions(serverUrl).apply(configure)
         return Flashphoner.createSession(options)
     }

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -1,6 +1,5 @@
 package uddug.com.naukoteka.flashphoner
 
-import android.app.Activity
 import com.flashphoner.fpwcsapi.bean.Data
 import com.flashphoner.fpwcsapi.room.Room
 import com.flashphoner.fpwcsapi.room.RoomManager
@@ -32,12 +31,11 @@ class FlashphonerSessionManager @Inject constructor(
     private val roomRef = AtomicReference<Room?>()
 
     fun prepareSession(
-        activity: Activity,
         serverUrl: String,
         configureOptions: SessionOptions.() -> Unit = {},
         onSessionReady: Session.() -> Unit = {}
     ): Session {
-        val session = environment.createSession(activity, serverUrl, configureOptions)
+        val session = environment.createSession(serverUrl, configureOptions)
         session.onSessionReady()
         sessionRef.set(session)
         return session
@@ -45,7 +43,7 @@ class FlashphonerSessionManager @Inject constructor(
 
     fun createStream(
         streamName: String,
-        configure: StreamOptions.() -> Unit = {}
+        configure: StreamOptions.() -> Unit = {},
     ): Stream {
         val session = sessionRef.get()
             ?: error("Flashphoner session must be prepared before creating streams")
@@ -56,13 +54,12 @@ class FlashphonerSessionManager @Inject constructor(
     }
 
     fun prepareRoomManager(
-        activity: Activity,
         serverUrl: String,
         username: String,
         configureOptions: SessionOptions.() -> Unit = {},
         onManagerReady: RoomManager.() -> Unit = {},
     ): RoomManager {
-        environment.ensureInitialised(activity)
+        environment.ensureInitialised()
         val options = RoomManagerOptions(serverUrl, username).apply(configureOptions)
         val manager = RoomManager(options)
         onManagerReady(manager)

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
@@ -1,6 +1,5 @@
 package uddug.com.naukoteka.mvvm.call
 
-import android.app.Activity
 import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -41,7 +40,6 @@ class CallViewModel @Inject constructor(
     private var callDurationJob: Job? = null
 
     fun startCall(
-        activity: Activity,
         dialogId: Long,
         contactName: String?,
         avatarUrl: String?,
@@ -82,7 +80,6 @@ class CallViewModel @Inject constructor(
                 val streamName = buildStreamName(config, dialogId, username)
 
                 flashphonerSessionManager.prepareRoomManager(
-                    activity = activity,
                     serverUrl = config.serverUrl,
                     username = username,
                 )

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
@@ -33,7 +33,6 @@ class CallFragment : Fragment() {
         val dialogId = arguments?.getLong(ARG_DIALOG_ID)
 
         viewModel.startCall(
-            activity = requireActivity(),
             dialogId = dialogId ?: viewModel.uiState.value.dialogId ?: 0L,
             contactName = contactName,
             avatarUrl = avatarUrl,


### PR DESCRIPTION
## Summary
- initialize the Flashphoner SDK with the application context during app startup
- remove activity-scoped initialization from Flashphoner managers to allow global background operation
- update call flow to use the global Flashphoner setup without passing activities around

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930589d8450832986166a23bdf97ebd)