### PR TITLE
Initialize Flashphoner with ContainerActivity

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/NaukotekaApplication.kt
+++ b/app/src/main/java/uddug/com/naukoteka/NaukotekaApplication.kt
@@ -7,24 +7,18 @@ import dagger.hilt.android.HiltAndroidApp
 import uddug.com.naukoteka.di.DI
 import uddug.com.naukoteka.di.modules.AppModule
 import uddug.com.naukoteka.ext.data.SUPPORTED_LOCALES
-import uddug.com.naukoteka.flashphoner.FlashphonerEnvironment
 import toothpick.Scope
 import toothpick.ktp.KTP
-import javax.inject.Inject
 
 @HiltAndroidApp
 class NaukotekaApplication : Application() {
 
     lateinit var scope: Scope
 
-    @Inject
-    lateinit var flashphonerEnvironment: FlashphonerEnvironment
-
     override fun onCreate() {
         super.onCreate()
         initializeToothpick()
         LocaleChanger.initialize(this, SUPPORTED_LOCALES)
-        flashphonerEnvironment.ensureInitialised()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
@@ -1,10 +1,10 @@
 package uddug.com.naukoteka.flashphoner
 
-import android.content.Context
+import android.app.Activity
+import java.lang.ref.WeakReference
 import com.flashphoner.fpwcsapi.Flashphoner
 import com.flashphoner.fpwcsapi.session.Session
 import com.flashphoner.fpwcsapi.session.SessionOptions
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,20 +14,24 @@ import javax.inject.Singleton
  * can be used by feature modules.
  */
 @Singleton
-class FlashphonerEnvironment @Inject constructor(
-    @ApplicationContext private val appContext: Context,
-) {
+class FlashphonerEnvironment @Inject constructor() {
 
     private var isInitialised: Boolean = false
+    private var containerActivityRef: WeakReference<Activity?> = WeakReference(null)
+
+    fun attachContainerActivity(activity: Activity) {
+        containerActivityRef = WeakReference(activity)
+    }
 
     /**
      * Initialise Flashphoner lazily on first usage. According to the SDK documentation
      * the call is idempotent, therefore we protect it with an [isInitialised] flag to
      * avoid extra work on subsequent injections.
      */
-    fun ensureInitialised() {
+    fun ensureInitialised(activity: Activity? = containerActivityRef.get()) {
         if (!isInitialised) {
-            Flashphoner.init(appContext.applicationContext)
+            val hostActivity = activity ?: error("Container Activity must be attached before initializing Flashphoner")
+            Flashphoner.init(hostActivity)
             isInitialised = true
         }
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/activities/main/ContainerActivity.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/activities/main/ContainerActivity.kt
@@ -13,10 +13,12 @@ import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.databinding.ActivityMainBinding
 import uddug.com.naukoteka.global.base.BaseActivity
+import uddug.com.naukoteka.flashphoner.FlashphonerEnvironment
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerPresenter
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerView
 import uddug.com.naukoteka.utils.viewBinding
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ContainerActivity : BaseActivity(), ContainerView, ContainerNavigationView {
@@ -26,6 +28,9 @@ class ContainerActivity : BaseActivity(), ContainerView, ContainerNavigationView
 
     @InjectPresenter
     lateinit var presenter: ContainerPresenter
+
+    @Inject
+    lateinit var flashphonerEnvironment: FlashphonerEnvironment
 
     private var pulseAnimation: Animation? = null
 
@@ -50,6 +55,9 @@ class ContainerActivity : BaseActivity(), ContainerView, ContainerNavigationView
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(contentView.root)
+
+        flashphonerEnvironment.attachContainerActivity(this)
+        flashphonerEnvironment.ensureInitialised(this)
 
         contentView.bottomNav.setOnNavigationItemSelectedListener {
             when (it.itemId) {


### PR DESCRIPTION
## Summary
- initialize the Flashphoner SDK using the ContainerActivity instead of the application context
- add lifecycle attachment for the container activity before Flashphoner usage
- remove unused application-level initialization code

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305a353c548329a62b1e4a883919d4)