### PR TITLE
Initialize socket connection from container activity

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/socket/SocketEnvironment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/socket/SocketEnvironment.kt
@@ -1,0 +1,36 @@
+package uddug.com.naukoteka.socket
+
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Singleton
+import uddug.com.naukoteka.ui.chat.di.SocketService
+
+@Singleton
+class SocketEnvironment @Inject constructor(
+    private val socketService: SocketService,
+) {
+
+    fun ensureConnected() {
+        try {
+            socketService.connect()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to establish socket connection", e)
+        }
+    }
+
+    fun disconnect() {
+        try {
+            socketService.disconnect()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to disconnect socket", e)
+        }
+    }
+
+    fun registerListener(event: String, callback: (data: String) -> Unit) {
+        socketService.setOnEvent(event, callback)
+    }
+
+    companion object {
+        private const val TAG = "SocketEnvironment"
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/activities/main/ContainerActivity.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/activities/main/ContainerActivity.kt
@@ -14,6 +14,7 @@ import uddug.com.naukoteka.R
 import uddug.com.naukoteka.databinding.ActivityMainBinding
 import uddug.com.naukoteka.global.base.BaseActivity
 import uddug.com.naukoteka.flashphoner.FlashphonerEnvironment
+import uddug.com.naukoteka.socket.SocketEnvironment
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerPresenter
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerView
@@ -31,6 +32,9 @@ class ContainerActivity : BaseActivity(), ContainerView, ContainerNavigationView
 
     @Inject
     lateinit var flashphonerEnvironment: FlashphonerEnvironment
+
+    @Inject
+    lateinit var socketEnvironment: SocketEnvironment
 
     private var pulseAnimation: Animation? = null
 
@@ -58,6 +62,8 @@ class ContainerActivity : BaseActivity(), ContainerView, ContainerNavigationView
 
         flashphonerEnvironment.attachContainerActivity(this)
         flashphonerEnvironment.ensureInitialised(this)
+
+        socketEnvironment.ensureConnected()
 
         contentView.bottomNav.setOnNavigationItemSelectedListener {
             when (it.itemId) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/di/ChatModule.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/di/ChatModule.kt
@@ -5,7 +5,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import retrofit2.Retrofit
-import uddug.com.data.cache.cookies.CookiesCache
 import uddug.com.data.services.chat.ChatApiService
 import uddug.com.data.repositories.chat.ChatRepositoryImpl
 import uddug.com.domain.repositories.chat.ChatRepository
@@ -29,11 +28,6 @@ object ChatModule {
     @Provides
     fun provideChatInteractor(repository: ChatRepository): ChatInteractor {
         return ChatInteractor(repository)
-    }
-
-    @Provides
-    fun provideSocketService(cookiesCache: CookiesCache): SocketService {
-        return SocketServiceImpl(cookiesCache)
     }
 
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/di/SocketModule.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/di/SocketModule.kt
@@ -1,0 +1,19 @@
+package uddug.com.naukoteka.ui.chat.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import uddug.com.data.cache.cookies.CookiesCache
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SocketModule {
+
+    @Provides
+    @Singleton
+    fun provideSocketService(cookiesCache: CookiesCache): SocketService {
+        return SocketServiceImpl(cookiesCache)
+    }
+}


### PR DESCRIPTION
## Summary
- add a SocketEnvironment wrapper to manage the chat socket lifecycle
- provide the socket service as a singleton through a new Hilt module
- start the socket connection from ContainerActivity alongside Flashphoner setup

## Testing
- ./gradlew test --no-daemon *(fails: SDK location not found in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305b8e1a8c8329b3da4bb27f701e87)