### PR TITLE
Fix Toothpick scope to reuse application scope

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/global/base/BaseActivity.kt
+++ b/app/src/main/java/uddug/com/naukoteka/global/base/BaseActivity.kt
@@ -4,6 +4,7 @@ import android.app.ActionBar
 import android.os.Bundle
 import android.view.View
 import androidx.viewbinding.ViewBinding
+import uddug.com.naukoteka.NaukotekaApplication
 import uddug.com.naukoteka.di.DI
 import uddug.com.naukoteka.di.modules.ActivityModule
 import moxy.MvpAppCompatActivity
@@ -24,8 +25,10 @@ abstract class BaseActivity : MvpAppCompatActivity() {
     }
 
     open fun getScope(): Scope {
+        val appScope = (application as NaukotekaApplication).scope
+
         return KTP.openRootScope()
-            .openSubScope(DI.APP_SCOPE)
+            .openSubScope(appScope.name)
             .openSubScope(DI.MAIN_ACTIVITY_SCOPE)
     }
 


### PR DESCRIPTION
## Summary
- reuse the application Toothpick scope when creating the main activity scope
- ensure dependencies bound in the application scope (including SocketService) are available during activity injection

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930604fb8048329bff7dd251c1cbfb2)