### PR TITLE
Ensure Toothpick binding for socket service uses provider

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/di/modules/AppModule.kt
+++ b/app/src/main/java/uddug/com/naukoteka/di/modules/AppModule.kt
@@ -25,6 +25,7 @@ import uddug.com.naukoteka.di.utils.Logger
 import uddug.com.naukoteka.navigation.AppRouter
 import uddug.com.naukoteka.ui.chat.di.SocketService
 import uddug.com.naukoteka.ui.chat.di.SocketServiceImpl
+import uddug.com.naukoteka.ui.chat.di.SocketServiceProvider
 import okhttp3.CookieJar
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -63,7 +64,7 @@ class AppModule(application: Application) : Module() {
         bind(UserProfileRepository::class.java).to(UserProfileRepositoryImpl::class.java)
         bind(LocationApiService::class.java).toProvider(LocationApiProvider::class.java).singleton()
         bind(LocationRepository::class.java).to(LocationRepositoryImpl::class.java)
-        bind(SocketService::class.java).to(SocketServiceImpl::class.java).singleton()
+        bind(SocketService::class.java).toProvider(SocketServiceProvider::class.java).singleton()
 
     }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/di/SocketServiceProvider.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/di/SocketServiceProvider.kt
@@ -1,0 +1,11 @@
+package uddug.com.naukoteka.ui.chat.di
+
+import javax.inject.Inject
+import javax.inject.Provider
+import uddug.com.data.cache.cookies.CookiesCache
+
+class SocketServiceProvider @Inject constructor(
+    private val cookiesCache: CookiesCache,
+) : Provider<SocketService> {
+    override fun get(): SocketService = SocketServiceImpl(cookiesCache)
+}


### PR DESCRIPTION
## Summary
- bind SocketService through a Provider so Toothpick can supply the dependency without needing a generated factory for the interface
- add SocketServiceProvider to construct SocketServiceImpl with the cached authentication cookies

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693061aa9760832981e339a224698c68)