### PR TITLE
Initialize socket in chat list view model

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatListViewModel.kt
@@ -18,6 +18,7 @@ import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.domain.entities.chat.SearchDialog
 import uddug.com.domain.entities.chat.SearchMessage
 import uddug.com.domain.repositories.chat.ChatRepository
+import uddug.com.naukoteka.ui.chat.di.SocketService
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,6 +26,7 @@ class ChatListViewModel @Inject constructor(
     private val chatRepository: ChatRepository,
     userIdCache: UserIdCache,
     userUUIDCache: UserUUIDCache,
+    private val socketService: SocketService,
 ) : ViewModel() {
 
     private val currentUserIds: Set<String> = listOfNotNull(
@@ -66,6 +68,10 @@ class ChatListViewModel @Inject constructor(
 
     private var loadChatsJob: kotlinx.coroutines.Job? = null
     private var searchJob: Job? = null
+
+    init {
+        socketService.connect()
+    }
 
     fun isMessageFromMe(ownerId: String?): Boolean {
         return ownerId.isNullOrBlank() || currentUserIds.contains(ownerId)


### PR DESCRIPTION
## Summary
- inject the chat SocketService into ChatListViewModel
- initialize the socket connection when chat list is opened to keep NauChat connected

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693065ce616c8329940e7aec41f345af)