### PR TITLE
Enable keep-alive for Flashphoner sessions

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -35,7 +35,10 @@ class FlashphonerSessionManager @Inject constructor(
         configureOptions: SessionOptions.() -> Unit = {},
         onSessionReady: Session.() -> Unit = {}
     ): Session {
-        val session = environment.createSession(serverUrl, configureOptions)
+        val session = environment.createSession(serverUrl) {
+            keepAlive = true
+            configureOptions()
+        }
         session.onSessionReady()
         sessionRef.set(session)
         return session
@@ -60,7 +63,10 @@ class FlashphonerSessionManager @Inject constructor(
         onManagerReady: RoomManager.() -> Unit = {},
     ): RoomManager {
         environment.ensureInitialised()
-        val options = RoomManagerOptions(serverUrl, username).apply(configureOptions)
+        val options = RoomManagerOptions(serverUrl, username).apply {
+            keepAlive = true
+            configureOptions()
+        }
         val manager = RoomManager(options)
         onManagerReady(manager)
         roomManagerRef.set(manager)


### PR DESCRIPTION
## Summary
- ensure created Flashphoner sessions and room managers enable WebSocket keep-alives by default
- allow additional option customization while keeping persistent connections active

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930681981288329a3e1bcde2b63fad9)