### PR TITLE
Ensure Flashphoner state reset before starting calls

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
@@ -48,6 +48,11 @@ class CallViewModel @Inject constructor(
     ) {
         if (isCallStarted) return
 
+        // Ensure any previous Flashphoner session artifacts are fully released before
+        // attempting to start a new call. Residual state may keep the WebSocket client in
+        // a disconnecting state and cause subsequent calls to close immediately.
+        flashphonerSessionManager.disconnectRoom()
+
         if (dialogId <= 0) {
             _uiState.value = _uiState.value.copy(status = CallStatus.FINISHED)
             return


### PR DESCRIPTION
## Summary
- clear any previous Flashphoner room and session state before starting a new call

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69307139f4f8832983ba7cb01a47976f)