### PR TITLE
Fix chat theme colors and poll previews

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatListComponent.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import uddug.com.naukoteka.R
@@ -58,7 +59,7 @@ fun ChatListComponent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(color = Color.White)
+            .background(color = colorResource(id = R.color.main_background))
     ) {
         val focusManager = LocalFocusManager.current
         ChatToolbarComponent(
@@ -176,14 +177,14 @@ private fun SearchResultsContent(
     onResultClick: (Long) -> Unit,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(Color.White)
+            modifier = modifier
+                .fillMaxSize()
+                .background(colorResource(id = R.color.main_background))
     ) {
         TabRow(
             modifier = Modifier.fillMaxWidth(),
             selectedTabIndex = selectedTab.ordinal,
-            containerColor = Color.White,
+            containerColor = colorResource(id = R.color.main_background),
             indicator = { tabPositions ->
                 TabRowDefaults.Indicator(
                     modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTab.ordinal]),
@@ -199,7 +200,11 @@ private fun SearchResultsContent(
                     text = {
                         Text(
                             text = stringResource(id = tab.titleRes),
-                            color = if (tab == selectedTab) Color.Black else Color(0xFF8083A0)
+                            color = if (tab == selectedTab) {
+                                colorResource(id = R.color.main_text)
+                            } else {
+                                colorResource(id = R.color.secondary_text)
+                            }
                         )
                     }
                 )
@@ -208,13 +213,13 @@ private fun SearchResultsContent(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color.White)
+                .background(colorResource(id = R.color.main_background))
         ) {
             when {
                 query.isEmpty() -> {
                     Text(
                         text = stringResource(R.string.search_enter_query),
-                        color = Color(0xFF8083A0),
+                        color = colorResource(id = R.color.secondary_text),
                         modifier = Modifier
                             .align(Alignment.Center)
                             .padding(horizontal = 32.dp)
@@ -224,7 +229,7 @@ private fun SearchResultsContent(
                 query.length < SEARCH_MIN_QUERY_LENGTH -> {
                     Text(
                         text = stringResource(R.string.search_enter_query_min_length),
-                        color = Color(0xFF8083A0),
+                        color = colorResource(id = R.color.secondary_text),
                         modifier = Modifier
                             .align(Alignment.Center)
                             .padding(horizontal = 32.dp)
@@ -241,7 +246,7 @@ private fun SearchResultsContent(
                     if (currentResults.isEmpty()) {
                         Text(
                             text = stringResource(R.string.search_empty_result),
-                            color = Color(0xFF8083A0),
+                            color = colorResource(id = R.color.secondary_text),
                             modifier = Modifier
                                 .align(Alignment.Center)
                                 .padding(horizontal = 32.dp)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -28,6 +29,7 @@ import coil.compose.AsyncImage
 import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.core.deeplink.formatMessageTime
+import uddug.com.domain.entities.chat.MessageType
 import uddug.com.naukoteka.ui.chat.compose.components.Avatar
 
 enum class ChatAttachmentType {
@@ -60,6 +62,7 @@ fun ChatCard(
     isMuted: Boolean = false,
     selectionMode: Boolean = false,
     isSelected: Boolean = false,
+    messageType: MessageType = MessageType.TEXT,
     onSelectChange: (Boolean) -> Unit = {},
     onChatClick: (Long) -> Unit,
     onChatLongClick: (Long) -> Unit
@@ -86,8 +89,8 @@ fun ChatCard(
                         onChatLongClick(dialogId)
                     }
                 }
-            ),  
-        colors = CardDefaults.cardColors(containerColor = Color.White)  
+            ),
+        colors = CardDefaults.cardColors(containerColor = colorResource(id = R.color.main_background))
     ) {
         Column {
             Row(
@@ -130,7 +133,7 @@ fun ChatCard(
                                 stringResource(R.string.group_chat)
                             } else {
                                 name
-                            }, style = TextStyle(fontSize = 16.sp, color = Color.Black)
+                            }, style = TextStyle(fontSize = 16.sp, color = colorResource(id = R.color.main_text))
                         )
                         if (isMuted) {
                             Icon(
@@ -148,6 +151,14 @@ fun ChatCard(
                     
                     val messageText = when {
                         isRepost -> stringResource(R.string.chat_last_message_repost, message)
+                        messageType == MessageType.POLL -> {
+                            val question = message.ifBlank { "" }
+                            if (question.isNotBlank()) {
+                                stringResource(R.string.chat_last_message_poll, question)
+                            } else {
+                                stringResource(R.string.chat_poll_label)
+                            }
+                        }
                         attachmentPreview != null -> when (attachmentPreview.type) {
                             ChatAttachmentType.IMAGE -> stringResource(R.string.chat_last_message_image)
                             ChatAttachmentType.VIDEO -> stringResource(R.string.chat_last_message_video)
@@ -195,7 +206,11 @@ fun ChatCard(
                             text = messageText,
                             style = TextStyle(
                                 fontSize = 14.sp,
-                                color = if (!isGroupChat && isFromMe) Color(0xFF2E83D9) else Color(0xFF4E5068),
+                                color = if (!isGroupChat && isFromMe) {
+                                    Color(0xFF2E83D9)
+                                } else {
+                                    colorResource(id = R.color.secondary_text)
+                                },
                                 fontWeight = if (isRepost) FontWeight.Bold else FontWeight.Normal
                             ),
                             maxLines = 1,
@@ -220,7 +235,10 @@ fun ChatCard(
                         }
                         Text(
                             text = formattedTime,
-                            style = TextStyle(fontSize = 12.sp, color = Color.Gray),
+                            style = TextStyle(
+                                fontSize = 12.sp,
+                                color = colorResource(id = R.color.secondary_text)
+                            ),
                         )
                     }
 
@@ -252,7 +270,7 @@ fun ChatCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(1.dp)
-                    .background(Color(0xFFEAEAF2))
+                    .background(colorResource(id = R.color.main_background_input_stroke))
             )
         }
     }
@@ -268,7 +286,7 @@ private fun AttachmentPreview(
         modifier = modifier
             .size(size)
             .clip(CircleShape)
-            .background(Color(0xFFF2F5FA)),
+            .background(colorResource(id = R.color.main_background_input)),
         contentAlignment = Alignment.Center
     ) {
         when (preview.type) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -40,12 +40,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import uddug.com.domain.entities.chat.MessageType
 import uddug.com.domain.entities.chat.ChatFolder
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatListUiState
@@ -173,20 +175,20 @@ fun ChatTabBar(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(Color.White),
+                .background(colorResource(id = R.color.main_background)),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(Color.White),
+                    .background(colorResource(id = R.color.main_background)),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 if (folders.isNotEmpty()) {
                     TabRow(
                         modifier = Modifier
                             .weight(1f)
-                            .background(Color.White),
+                            .background(colorResource(id = R.color.main_background)),
                         selectedTabIndex = selectedTabIndex,
                         indicator = { tabPositions ->
                             if (tabPositions.isNotEmpty()) {
@@ -230,9 +232,11 @@ fun ChatTabBar(
                                                 style = TextStyle(
                                                     fontSize = 14.sp,
                                                     fontWeight = FontWeight.Bold,
-                                                    color = if (selectedTabIndex == index) Color.Black else Color(
-                                                        0xFF8083A0
-                                                    )
+                                                    color = if (selectedTabIndex == index) {
+                                                        colorResource(id = R.color.main_text)
+                                                    } else {
+                                                        colorResource(id = R.color.secondary_text)
+                                                    }
                                                 )
                                             )
                                             if (folder.unreadCount > 0) {
@@ -273,7 +277,7 @@ fun ChatTabBar(
                     Icon(
                         imageVector = Icons.Filled.MoreVert,
                         contentDescription = stringResource(R.string.chat_folder_menu_configure),
-                        tint = Color(0xFF8083A0)
+                        tint = colorResource(id = R.color.secondary_text)
                     )
                 }
             }
@@ -289,7 +293,10 @@ fun ChatTabBar(
 
                 is ChatListUiState.Success -> {
                     val chats = state.chats
-                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = 80.dp)
+                    ) {
                         items(chats) { chat ->
                             val displayName = when {
                                 chat.dialogType != 1 && chat.dialogName.isNotBlank() -> chat.dialogName
@@ -319,6 +326,7 @@ fun ChatTabBar(
                             }
                             val isGroupChat = chat.dialogType != 1
                             val isFromMe = viewModel.isMessageFromMe(chat.lastMessage.ownerId)
+                            val messageType = MessageType.fromInt(chat.lastMessage.type ?: 0)
                             val authorName = if (isGroupChat && !isFromMe) {
                                 val ownerId = chat.lastMessage.ownerId
                                 val author = chat.users.firstOrNull { it.userId == ownerId }
@@ -346,6 +354,7 @@ fun ChatTabBar(
                                 isMuted = chat.notificationsDisable,
                                 selectionMode = isSelectionMode,
                                 isSelected = selectedChats.contains(chat.dialogId),
+                                messageType = messageType,
                                 onSelectChange = { onChatSelect(chat.dialogId) },
                                 onChatClick = {
                                     viewModel.onChatClick(it)

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchResultItem.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchResultItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
@@ -102,13 +103,17 @@ private fun SearchMessageResultCard(
                     HighlightedText(
                         text = result.fullName,
                         query = query,
-                        style = TextStyle(fontSize = 16.sp, color = Color.Black, fontWeight = FontWeight.SemiBold),
+                        style = TextStyle(
+                            fontSize = 16.sp,
+                            color = colorResource(id = R.color.main_text),
+                            fontWeight = FontWeight.SemiBold
+                        ),
                         highlightColor = highlightColor,
                         modifier = Modifier.weight(1f)
                     )
                     Text(
                         text = formatMessageTime(createdAtIso),
-                        color = Color(0xFF8083A0),
+                        color = colorResource(id = R.color.secondary_text),
                         fontSize = 12.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -118,7 +123,7 @@ private fun SearchMessageResultCard(
                 if (messageText.isNotBlank()) {
                     Text(
                         text = buildHighlightedString(messageText, query, highlightColor),
-                        color = Color(0xFF4E5068),
+                        color = colorResource(id = R.color.secondary_text),
                         fontSize = 14.sp,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
@@ -131,7 +136,7 @@ private fun SearchMessageResultCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 68.dp),
-            color = Color(0xFFEAEAF2),
+            color = colorResource(id = R.color.main_background_input_stroke),
             thickness = 1.dp,
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,6 +233,7 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_last_message_video">Video</string>
     <string name="chat_last_message_file">File</string>
     <string name="chat_last_message_author_you">You</string>
+    <string name="chat_last_message_poll">Опрос: %1$s</string>
     <string name="chat_swipe_to_cancel">Swipe left to cancel</string>
     <string name="chat_message_placeholder">Write a message</string>
     <string name="chat_reply_default_author">Reply</string>


### PR DESCRIPTION
## Summary
- update chat compose components to use themed colors so dark mode matches the rest of the app
- show poll message labels in chat list items and add padding so lists can scroll past the bottom navigation
- refresh search result styling and strings for the new poll preview label

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931939b7a448329a5aee89a456c4961)