### PR TITLE
Move hardcoded UI strings and colors into resources

### DIFF
--- a/app/src/main/res/layout/fragment_profile_edit.xml
+++ b/app/src/main/res/layout/fragment_profile_edit.xml
@@ -181,7 +181,7 @@
                                 android:layout_width="wrap_content"
                                 android:layout_height="match_parent"
                                 android:gravity="center_vertical"
-                                android:text="wqewqeqweqw"
+                                android:text="@string/profile_edit_nickname_placeholder"
                                 android:textColor="@color/text_link" />
 
                             <ImageView

--- a/app/src/main/res/layout/fragment_profile_edit_settings_personal.xml
+++ b/app/src/main/res/layout/fragment_profile_edit_settings_personal.xml
@@ -252,7 +252,7 @@
                         android:layout_height="1dp"
                         android:layout_marginTop="32dp"
                         android:layout_marginBottom="32dp"
-                        android:background="#2A2C41" />
+                        android:background="@color/profile_settings_divider" />
 
                     <TextView
                         style="@style/NauTextAppearance.AppCompat.Title"
@@ -335,7 +335,7 @@
                         android:layout_height="1dp"
                         android:layout_marginTop="32dp"
                         android:layout_marginBottom="32dp"
-                        android:background="#2A2C41" />
+                        android:background="@color/profile_settings_divider" />
 
                 </LinearLayout>
 
@@ -420,7 +420,7 @@
                     android:layout_height="1dp"
                     android:layout_marginTop="32dp"
                     android:layout_marginBottom="32dp"
-                    android:background="#2A2C41" />
+                    android:background="@color/profile_settings_divider" />
 
                 <TextView
                     style="@style/NauTextAppearance.AppCompat.Title"

--- a/app/src/main/res/layout/fragment_profile_full_info.xml
+++ b/app/src/main/res/layout/fragment_profile_full_info.xml
@@ -27,7 +27,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="0.5dp"
                 android:layout_marginTop="16dp"
-                android:background="#EAEAF2" />
+                android:background="@color/background_more_info" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -75,7 +75,7 @@
                             android:background="@drawable/background_interest_tag"
                             android:maxLines="6"
                             android:padding="10dp"
-                            android:text="IT-специалист" />
+                            android:text="@string/profile_interest_it_specialist" />
 
                         <TextView
                             style="@style/NauTextAppearance.AppCompat.SubTitleDark"
@@ -85,7 +85,7 @@
                             android:background="@drawable/background_interest_tag"
                             android:maxLines="6"
                             android:padding="10dp"
-                            android:text="Разработчик" />
+                            android:text="@string/profile_interest_developer" />
 
 
                     </com.google.android.flexbox.FlexboxLayout>
@@ -98,7 +98,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="0.5dp"
                 android:layout_marginTop="16dp"
-                android:background="#EAEAF2" />
+                android:background="@color/background_more_info" />
 
             <LinearLayout
                 android:id="@+id/profileLink"
@@ -126,7 +126,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="0.5dp"
-                android:background="#EAEAF2" />
+                android:background="@color/background_more_info" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -157,7 +157,7 @@
                             style="@style/NauTextAppearance.AppCompat.Title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="999"
+                            android:text="@string/profile_followers_placeholder"
                             android:textColor="@color/text_link"
                             android:textSize="18sp" />
 
@@ -183,7 +183,7 @@
                             style="@style/NauTextAppearance.AppCompat.Title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="999"
+                            android:text="@string/profile_followers_placeholder"
                             android:textColor="@color/text_link"
                             android:textSize="18sp" />
 
@@ -203,7 +203,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="0.5dp"
                     android:layout_marginTop="16dp"
-                    android:background="#EAEAF2" />
+                    android:background="@color/background_more_info" />
 
                 <LinearLayout
                     android:id="@+id/nauDataContainer"
@@ -237,7 +237,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="4dp"
-                            android:text="1234-1234" />
+                            android:text="@string/profile_spin_code_placeholder" />
 
                     </LinearLayout>
 
@@ -260,7 +260,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="4dp"
-                            android:text="0000 - 0001 - 2345 - 678X" />
+                            android:text="@string/profile_orcid_placeholder" />
 
                     </LinearLayout>
 
@@ -283,7 +283,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="4dp"
-                            android:text="0000 - 0001 - 2345 - 678X" />
+                            android:text="@string/profile_researcher_placeholder" />
 
                     </LinearLayout>
 
@@ -292,7 +292,7 @@
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="0.5dp"
-                    android:background="#EAEAF2" />
+                    android:background="@color/background_more_info" />
 
                 <LinearLayout
                     android:id="@+id/careerContainer"
@@ -323,7 +323,7 @@
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="0.5dp"
-                    android:background="#EAEAF2" />
+                    android:background="@color/background_more_info" />
 
                 <LinearLayout
                     android:id="@+id/educationContainer"
@@ -355,7 +355,7 @@
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="0.5dp"
-                    android:background="#EAEAF2" />
+                    android:background="@color/background_more_info" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -381,7 +381,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="15dp"
-                            android:text="14 сентября 1984" />
+                            android:text="@string/profile_birthday_placeholder" />
 
                     </LinearLayout>
 
@@ -413,7 +413,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="4dp"
-                            android:text="Мужской" />
+                            android:text="@string/profile_gender_placeholder" />
 
                     </LinearLayout>
 
@@ -445,7 +445,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="4dp"
-                            android:text="г. Самара, Самарская област" />
+                            android:text="@string/profile_birthplace_placeholder" />
 
                     </LinearLayout>
 
@@ -476,7 +476,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="4dp"
-                            android:text="г. Самара, Самарская област" />
+                            android:text="@string/profile_residence_placeholder" />
 
                     </LinearLayout>
 
@@ -485,7 +485,7 @@
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="0.5dp"
-                    android:background="#EAEAF2" />
+                    android:background="@color/background_more_info" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -519,7 +519,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="15dp"
-                            android:text="markovskaya.1977@yandex.ru"
+                            android:text="@string/profile_email_placeholder"
                             android:textColor="@color/text_link" />
 
                     </LinearLayout>
@@ -543,7 +543,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="15dp"
-                            android:text="+ 7 (915) 333-91-19"
+                            android:text="@string/profile_phone_placeholder"
                             android:textColor="@color/text_inactive" />
 
                     </LinearLayout>

--- a/app/src/main/res/layout/fragment_registration_first_step.xml
+++ b/app/src/main/res/layout/fragment_registration_first_step.xml
@@ -25,7 +25,7 @@
         android:layout_marginTop="41dp"
         android:layout_marginEnd="32dp"
         android:fontFamily="@font/golos_text_regular"
-        android:text="3"
+        android:text="@string/registration_step_three_label"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -37,7 +37,7 @@
         android:layout_marginTop="41dp"
         android:layout_marginEnd="8dp"
         android:fontFamily="@font/golos_text_regular"
-        android:text="2"
+        android:text="@string/registration_step_two_label"
         app:layout_constraintEnd_toStartOf="@id/tv_third_step"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -54,7 +54,7 @@
         android:paddingTop="2dp"
         android:paddingEnd="7dp"
         android:paddingBottom="2dp"
-        android:text="1"
+        android:text="@string/registration_step_one_label"
         android:textColor="@color/white"
         app:layout_constraintEnd_toStartOf="@id/tv_second_step"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/fragment_registration_second_step.xml
+++ b/app/src/main/res/layout/fragment_registration_second_step.xml
@@ -24,7 +24,7 @@
         android:layout_marginTop="41dp"
         android:layout_marginEnd="32dp"
         android:fontFamily="@font/golos_text_regular"
-        android:text="3"
+        android:text="@string/registration_step_three_label"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -41,7 +41,7 @@
         android:paddingTop="2dp"
         android:paddingEnd="7dp"
         android:paddingBottom="2dp"
-        android:text="2"
+        android:text="@string/registration_step_two_label"
         android:textColor="@color/white"
         app:layout_constraintEnd_toStartOf="@id/tv_third_step"
         app:layout_constraintTop_toTopOf="parent" />
@@ -54,7 +54,7 @@
         android:layout_marginTop="41dp"
         android:layout_marginEnd="8dp"
         android:fontFamily="@font/golos_text_regular"
-        android:text="1"
+        android:text="@string/registration_step_one_label"
         app:layout_constraintEnd_toStartOf="@id/tv_second_step"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/fragment_registration_third_step.xml
+++ b/app/src/main/res/layout/fragment_registration_third_step.xml
@@ -19,7 +19,7 @@
         android:paddingBottom="2dp"
         android:textColor="@color/white"
         android:fontFamily="@font/golos_text_regular"
-        android:text="3"
+        android:text="@string/registration_step_three_label"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -31,7 +31,7 @@
         android:layout_marginTop="41dp"
         android:layout_marginEnd="8dp"
         android:fontFamily="@font/golos_text_regular"
-        android:text="2"
+        android:text="@string/registration_step_two_label"
         app:layout_constraintEnd_toStartOf="@id/tv_third_step"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -43,7 +43,7 @@
         android:layout_marginTop="41dp"
         android:layout_marginEnd="8dp"
         android:fontFamily="@font/golos_text_regular"
-        android:text="1"
+        android:text="@string/registration_step_one_label"
         app:layout_constraintEnd_toStartOf="@id/tv_second_step"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/fragment_settings_system.xml
+++ b/app/src/main/res/layout/fragment_settings_system.xml
@@ -108,7 +108,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="2dp"
-                        android:text="Правила посылки"
+                        android:text="@string/settings_system_reply_user_message_placeholder"
                         android:textColor="@color/main_text"
                         android:textSize="14sp"
                         app:layout_constraintStart_toStartOf="@id/replyUserName"
@@ -120,7 +120,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="6dp"
-                        android:text="Национальной театральной "
+                        android:text="@string/settings_system_main_message_placeholder"
                         android:textColor="@color/main_text"
                         android:textSize="14sp"
                         app:layout_constraintStart_toStartOf="parent"
@@ -135,7 +135,7 @@
                     android:layout_gravity="end"
                     android:layout_marginTop="12dp"
                     android:background="@drawable/bg_rounded_corners_12dp_enabled"
-                    android:backgroundTint="#2E83D9"
+                    android:backgroundTint="@color/object_main"
                     android:paddingHorizontal="12dp"
                     android:paddingVertical="8dp">
 

--- a/app/src/main/res/layout/view_interest_tag.xml
+++ b/app/src/main/res/layout/view_interest_tag.xml
@@ -12,6 +12,6 @@
         android:maxLines="6"
         android:padding="10dp"
         android:background="@drawable/background_interest_tag"
-        android:text="Бла-бла, будет очень ин" />
+        android:text="@string/profile_interest_placeholder" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/view_profile_career_info.xml
+++ b/app/src/main/res/layout/view_profile_career_info.xml
@@ -11,7 +11,7 @@
         style="@style/NauTextAppearance.AppCompat.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Ответственный работник"
+        android:text="@string/profile_career_position_placeholder"
         android:visibility="gone"
         android:textSize="16sp" />
 
@@ -29,7 +29,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
-        android:textColor="#8083A0"
+        android:textColor="@color/secondary_text"
         android:textSize="16sp" />
 
     <TextView
@@ -38,7 +38,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
-        android:textColor="#8083A0"
+        android:textColor="@color/secondary_text"
         android:textSize="16sp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/view_profile_study_info.xml
+++ b/app/src/main/res/layout/view_profile_study_info.xml
@@ -11,7 +11,7 @@
         style="@style/NauTextAppearance.AppCompat.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Самарский государственный архитектурно-строительный университет"
+        android:text="@string/profile_education_name_placeholder"
         android:textSize="16sp" />
 
 
@@ -21,8 +21,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
-        android:text="Россия, Самара • В настоящее время"
-        android:textColor="#8083A0"
+        android:text="@string/profile_education_location_placeholder"
+        android:textColor="@color/secondary_text"
         android:textSize="16sp" />
 
 
@@ -32,8 +32,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
-        android:text="Высшее образование • Бакалавр"
-        android:textColor="#8083A0"
+        android:text="@string/profile_education_speciality_placeholder"
+        android:textColor="@color/secondary_text"
         android:textSize="16sp" />
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -45,6 +45,7 @@
     <color name="delete_education_gray">#8083A0</color>
     <color name="red_color_exit">#EB5757</color>
     <color name="password_button_disabled_color">#8083A0</color>
+    <color name="profile_settings_divider">#2A2C41</color>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -631,4 +631,28 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="chat_file_download_started">Downloading file…</string>
     <string name="chat_voice_message_playback_error">Не удалось воспроизвести голосовое сообщение</string>
 
+    <string name="profile_edit_nickname_placeholder">wqewqeqweqw</string>
+    <string name="profile_career_position_placeholder">Ответственный работник</string>
+    <string name="settings_system_reply_user_message_placeholder">Правила посылки</string>
+    <string name="settings_system_main_message_placeholder">Национальной театральной </string>
+    <string name="profile_interest_it_specialist">IT-специалист</string>
+    <string name="profile_interest_developer">Разработчик</string>
+    <string name="profile_followers_placeholder">999</string>
+    <string name="profile_spin_code_placeholder">1234-1234</string>
+    <string name="profile_orcid_placeholder">0000 - 0001 - 2345 - 678X</string>
+    <string name="profile_researcher_placeholder">0000 - 0001 - 2345 - 678X</string>
+    <string name="profile_birthday_placeholder">14 сентября 1984</string>
+    <string name="profile_gender_placeholder">Мужской</string>
+    <string name="profile_birthplace_placeholder">г. Самара, Самарская област</string>
+    <string name="profile_residence_placeholder">г. Самара, Самарская област</string>
+    <string name="profile_email_placeholder">markovskaya.1977@yandex.ru</string>
+    <string name="profile_phone_placeholder">+ 7 (915) 333-91-19</string>
+    <string name="profile_interest_placeholder">Бла-бла, будет очень ин</string>
+    <string name="profile_education_name_placeholder">Самарский государственный архитектурно-строительный университет</string>
+    <string name="profile_education_location_placeholder">Россия, Самара • В настоящее время</string>
+    <string name="profile_education_speciality_placeholder">Высшее образование • Бакалавр</string>
+    <string name="registration_step_three_label">3</string>
+    <string name="registration_step_two_label">2</string>
+    <string name="registration_step_one_label">1</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- replace hardcoded placeholder texts in profile, settings, and registration layouts with string resources
- swap inline hex colors for shared resources and add a divider color for profile settings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693195820b888329a104d75241af6a98)