### PR TITLE
Add call state toggles and wire call API

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
@@ -52,6 +52,8 @@ class CallFragment : Fragment() {
                             findNavController().popBackStack()
                             removeFloatingCall()
                         },
+                        onToggleMicrophone = viewModel::toggleMicrophone,
+                        onToggleCamera = viewModel::toggleCamera,
                         onMinimize = {
                             showFloatingCall()
                             findNavController().popBackStack()

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/compose/CallScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/compose/CallScreen.kt
@@ -58,6 +58,7 @@ import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.call.CallParticipant
 import uddug.com.naukoteka.mvvm.call.CallStatus
 import uddug.com.naukoteka.mvvm.call.CallUiState
+import uddug.com.domain.entities.call.CallSessionState
 import uddug.com.naukoteka.ui.chat.compose.components.Avatar
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -66,6 +67,8 @@ fun CallScreen(
     state: CallUiState,
     onBackPressed: () -> Unit,
     onEndCall: () -> Unit,
+    onToggleMicrophone: () -> Unit,
+    onToggleCamera: () -> Unit,
     onMinimize: () -> Unit,
 ) {
     val backgroundColor = Color(0xFF0B1020)
@@ -143,7 +146,12 @@ fun CallScreen(
                 )
             }
 
-            CallControls(onEndCall = onEndCall)
+            CallControls(
+                sessionState = state.sessionState,
+                onToggleMicrophone = onToggleMicrophone,
+                onToggleCamera = onToggleCamera,
+                onEndCall = onEndCall,
+            )
         }
     }
 
@@ -369,6 +377,9 @@ private fun ParticipantCard(
 
 @Composable
 private fun CallControls(
+    sessionState: CallSessionState,
+    onToggleMicrophone: () -> Unit,
+    onToggleCamera: () -> Unit,
     onEndCall: () -> Unit,
 ) {
     Surface(
@@ -384,17 +395,23 @@ private fun CallControls(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             CallActionButton(
-                iconRes = R.drawable.ic_rec_mic_inactive,
+                iconRes = if (sessionState.micOn) {
+                    R.drawable.ic_rec_mic_active
+                } else {
+                    R.drawable.ic_rec_mic_inactive
+                },
                 label = stringResource(R.string.call_microphone),
                 containerColor = Color.Transparent,
-                contentColor = Color.White,
-            ) {}
+                contentColor = if (sessionState.micOn) Color.White else Color(0xFF8083A0),
+                onClick = onToggleMicrophone,
+            )
             CallActionButton(
-                iconRes = R.drawable.ic_mute_sound_folder,
-                label = stringResource(R.string.call_speaker),
+                iconRes = R.drawable.ic_camera,
+                label = stringResource(R.string.call_camera),
                 containerColor = Color.Transparent,
-                contentColor = Color.White,
-            ) {}
+                contentColor = if (sessionState.camOn) Color.White else Color(0xFF8083A0),
+                onClick = onToggleCamera,
+            )
             CallActionButton(
                 iconRes = R.drawable.ic_close,
                 label = stringResource(R.string.call_terminate_action),

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/di/CallModule.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/di/CallModule.kt
@@ -1,0 +1,25 @@
+package uddug.com.naukoteka.ui.call.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import retrofit2.Retrofit
+import uddug.com.data.repositories.call.CallRepositoryImpl
+import uddug.com.data.services.CallApiService
+import uddug.com.domain.repositories.call.CallRepository
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object CallModule {
+
+    @Provides
+    fun provideCallApiService(retrofit: Retrofit): CallApiService {
+        return retrofit.create(CallApiService::class.java)
+    }
+
+    @Provides
+    fun provideCallRepository(apiService: CallApiService): CallRepository {
+        return CallRepositoryImpl(apiService)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -472,6 +472,7 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="call_secondary_action">Сообщение</string>
     <string name="call_terminate_action">Завершить</string>
     <string name="call_microphone">Микрофон</string>
+    <string name="call_camera">Камера</string>
     <string name="call_chat">Чат</string>
     <string name="call_record">Запись</string>
     <string name="call_minimize">Свернуть</string>


### PR DESCRIPTION
## Summary
- add a Hilt module to provide CallApiService and CallRepository
- expose microphone and camera toggles in CallViewModel and CallScreen that call the update state API
- show toggle state in the call UI and add a camera label string

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693194c6edd4832989e0713c597f4874)