### PR TITLE
Improve Flashphoner session cleanup

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -35,6 +35,7 @@ class FlashphonerSessionManager @Inject constructor(
         configureOptions: SessionOptions.() -> Unit = {},
         onSessionReady: Session.() -> Unit = {}
     ): Session {
+        reset()
         val session = environment.createSession(serverUrl) {
 
             configureOptions()
@@ -62,6 +63,7 @@ class FlashphonerSessionManager @Inject constructor(
         configureOptions: SessionOptions.() -> Unit = {},
         onManagerReady: RoomManager.() -> Unit = {},
     ): RoomManager {
+        reset()
         environment.ensureInitialised()
         val options = RoomManagerOptions(serverUrl, username).apply {
             configureOptions()
@@ -126,6 +128,18 @@ class FlashphonerSessionManager @Inject constructor(
         leaveRoom()
         roomManagerRef.getAndSet(null)?.disconnect()
         disconnectSession()
+    }
+
+    /**
+     * Fully clears any existing session, stream or room manager state to ensure a fresh
+     * connection can be established. This is intentionally idempotent and safe to call
+     * before creating new Flashphoner objects.
+     */
+    fun reset() {
+        stopStream()
+        leaveRoom()
+        roomManagerRef.getAndSet(null)?.disconnect()
+        sessionRef.getAndSet(null)?.disconnect()
     }
 
     private val defaultHandler = object : RestAppCommunicator.Handler {

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
@@ -212,6 +212,11 @@ class CallViewModel @Inject constructor(
         return listOf(config.streamName, dialogId, username)
             .joinToString(separator = "-")
     }
+
+    override fun onCleared() {
+        flashphonerSessionManager.reset()
+        super.onCleared()
+    }
 }
 
 data class CallUiState(


### PR DESCRIPTION
## Summary
- add a reusable reset helper to clear Flashphoner sessions, rooms, and streams
- reset existing connections before preparing new sessions or room managers
- ensure CallViewModel clears Flashphoner resources when destroyed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693195fd968883298bb6bccd4452ef03)