### PR TITLE
Fix read status payload for message read API

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDialogModel.kt
@@ -1032,7 +1032,7 @@ private fun ChatPollOption.toDomain(): PollOption = PollOption(
     answeredUsers = emptyList()
 )
 
-private const val READ_STATUS = 2
+private const val READ_STATUS = 3
 
 private fun computeIsCurrentUserAdmin(info: DialogInfo, currentUserId: String?): Boolean {
     if (currentUserId.isNullOrEmpty()) return false

--- a/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/chat/ChatRepositoryImpl.kt
@@ -348,8 +348,8 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, status: Int) {
-        val request = ReadMessagesRequestDto(dialogId, messages, status)
+    override suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, readStatus: Int) {
+        val request = ReadMessagesRequestDto(dialogId, messages, readStatus)
         apiService.markMessagesRead(request)
     }
 

--- a/data/src/main/java/uddug/com/data/services/models/request/chat/ReadMessagesRequestDto.kt
+++ b/data/src/main/java/uddug/com/data/services/models/request/chat/ReadMessagesRequestDto.kt
@@ -3,5 +3,5 @@ package uddug.com.data.services.models.request.chat
 data class ReadMessagesRequestDto(
     val dialogId: Long,
     val messages: List<Long>,
-    val messageStatus: Int,
+    val readStatus: Int,
 )

--- a/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
+++ b/domain/src/main/java/uddug/com/domain/interactors/chat/ChatInteractor.kt
@@ -125,8 +125,8 @@ class ChatInteractor @Inject constructor(
     suspend fun searchUsers(query: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo> =
         chatRepository.searchUsers(query, limit, page)
 
-    suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, status: Int) =
-        chatRepository.markMessagesRead(dialogId, messages, status)
+    suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, readStatus: Int) =
+        chatRepository.markMessagesRead(dialogId, messages, readStatus)
 
     suspend fun pinDialog(dialogId: Long) = chatRepository.pinDialog(dialogId)
 

--- a/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/chat/ChatRepository.kt
@@ -117,7 +117,7 @@ interface ChatRepository {
 
     suspend fun searchUsers(searchField: String, limit: Int = 10, page: Int = 1): List<UserProfileFullInfo>
 
-    suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, status: Int)
+    suspend fun markMessagesRead(dialogId: Long, messages: List<Long>, readStatus: Int)
 
     suspend fun pinDialog(dialogId: Long)
 


### PR DESCRIPTION
## Summary
- update read messages request to send readStatus instead of messageStatus
- use server expected read status value when marking messages read
- keep repository and interactor naming consistent with the API

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931992564908329aa6c77c501a9439f)