### PR TITLE
Restore picture-in-picture support when minimizing calls

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,6 +95,7 @@
             android:configChanges="keyboardHidden|screenSize|orientation|layoutDirection"
             android:exported="true"
             android:launchMode="singleInstance"
+            android:supportsPictureInPicture="true"
             android:screenOrientation="portrait"
             android:theme="@style/ContainerAppTheme"
             android:windowSoftInputMode="adjustPan" />

--- a/app/src/main/java/uddug/com/naukoteka/ui/activities/main/ContainerActivity.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/activities/main/ContainerActivity.kt
@@ -1,7 +1,11 @@
 package uddug.com.naukoteka.ui.activities.main
 
+import android.app.PictureInPictureParams
 import android.content.Intent
+import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
+import android.util.Rational
 import android.view.animation.Animation
 import androidx.core.view.isVisible
 import androidx.navigation.findNavController
@@ -12,8 +16,8 @@ import moxy.presenter.ProvidePresenter
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.databinding.ActivityMainBinding
-import uddug.com.naukoteka.global.base.BaseActivity
 import uddug.com.naukoteka.flashphoner.FlashphonerEnvironment
+import uddug.com.naukoteka.global.base.BaseActivity
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerPresenter
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerView
@@ -33,6 +37,15 @@ class ContainerActivity : BaseActivity(), ContainerView, ContainerNavigationView
     lateinit var flashphonerEnvironment: FlashphonerEnvironment
 
     private var pulseAnimation: Animation? = null
+
+    private val pictureInPictureParams: PictureInPictureParams?
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            PictureInPictureParams.Builder()
+                .setAspectRatio(Rational(9, 16))
+                .build()
+        } else {
+            null
+        }
 
     companion object {
         const val PROFILE_ARGS = "profileFullInfo"
@@ -81,6 +94,20 @@ class ContainerActivity : BaseActivity(), ContainerView, ContainerNavigationView
                 else -> true
             }
         }
+    }
+
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration?) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        contentView.bottomNav.isVisible = !isInPictureInPictureMode
+    }
+
+    fun enterCallPictureInPictureMode(): Boolean {
+        val params = pictureInPictureParams ?: return false
+        val entered = enterPictureInPictureMode(params)
+        if (entered) {
+            contentView.bottomNav.isVisible = false
+        }
+        return entered
     }
 
     override fun selectShowEditFragment(profileInfo: UserProfileFullInfo) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/CallFragment.kt
@@ -15,6 +15,7 @@ import uddug.com.naukoteka.mvvm.call.CallParticipant
 import uddug.com.naukoteka.mvvm.call.CallViewModel
 import uddug.com.naukoteka.ui.call.compose.CallScreen
 import uddug.com.naukoteka.ui.call.overlay.CallOverlayFragment
+import uddug.com.naukoteka.ui.activities.main.ContainerActivity
 
 @AndroidEntryPoint
 class CallFragment : Fragment() {
@@ -55,8 +56,10 @@ class CallFragment : Fragment() {
                         onToggleMicrophone = viewModel::toggleMicrophone,
                         onToggleCamera = viewModel::toggleCamera,
                         onMinimize = {
-                            showFloatingCall()
-                            findNavController().popBackStack()
+                            if (!((requireActivity() as? ContainerActivity)?.enterCallPictureInPictureMode() ?: false)) {
+                                showFloatingCall()
+                                findNavController().popBackStack()
+                            }
                         },
                     )
                 }


### PR DESCRIPTION
## Summary
- enable picture-in-picture mode for the main activity and hide navigation while in PIP
- trigger PIP when minimizing a call, falling back to the existing floating overlay if unavailable
- configure PIP with a portrait aspect ratio for call sessions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693199924a908329b2f6b2dd16680790)