### PR TITLE
Include chat nav graph in main bottom navigation

### DIFF
--- a/app/src/main/res/navigation/nav_graph_main_bottom_nav.xml
+++ b/app/src/main/res/navigation/nav_graph_main_bottom_nav.xml
@@ -6,5 +6,6 @@
 
     <include app:graph="@navigation/nav_graph_profile" />
     <include app:graph="@navigation/nav_graph_sphere" />
+    <include app:graph="@navigation/nav_graph_chat" />
 
 </navigation>


### PR DESCRIPTION
## Summary
- add the chat navigation graph to the main bottom navigation host graph so the back stack can be restored when returning from PiP

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69319d3889548329a43ab8e786610934)