### PR TITLE
Split call screens and add call option sheet

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
@@ -49,6 +49,7 @@ class CallViewModel @Inject constructor(
         avatarUrl: String?,
         participants: List<CallParticipant>? = null,
         callTitle: String? = null,
+        isVideoCall: Boolean = true,
     ) {
         if (isCallStarted) return
 
@@ -80,7 +81,7 @@ class CallViewModel @Inject constructor(
             callTitle = callTitle ?: contactName,
             participants = resolvedParticipants,
             status = CallStatus.DIALING,
-            sessionState = CallSessionState(micOn = true, camOn = true),
+            sessionState = CallSessionState(micOn = true, camOn = isVideoCall),
         )
 
         viewModelScope.launch {

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/GroupCallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/GroupCallFragment.kt
@@ -1,0 +1,36 @@
+package uddug.com.naukoteka.ui.call
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+
+class GroupCallFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialTheme {
+                    Surface {
+                        Text(text = "Group call is not implemented yet")
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_CONTACT_NAME = "contact_name"
+        const val ARG_AVATAR_URL = "avatar_url"
+        const val ARG_DIALOG_ID = "dialog_id"
+    }
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
@@ -13,12 +13,12 @@ import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import uddug.com.naukoteka.mvvm.call.CallParticipant
 import uddug.com.naukoteka.mvvm.call.CallViewModel
+import uddug.com.naukoteka.ui.activities.main.ContainerActivity
 import uddug.com.naukoteka.ui.call.compose.CallScreen
 import uddug.com.naukoteka.ui.call.overlay.CallOverlayFragment
-import uddug.com.naukoteka.ui.activities.main.ContainerActivity
 
 @AndroidEntryPoint
-class CallFragment : Fragment() {
+class SingleCallFragment : Fragment() {
 
     private val viewModel: CallViewModel by activityViewModels()
 
@@ -32,6 +32,7 @@ class CallFragment : Fragment() {
         val callTitle = arguments?.getString(ARG_CALL_TITLE)
         val participants = arguments?.getParcelableArrayList<CallParticipant>(ARG_PARTICIPANTS)
         val dialogId = arguments?.getLong(ARG_DIALOG_ID)
+        val isVideoCall = arguments?.getBoolean(ARG_IS_VIDEO_CALL) ?: true
 
         viewModel.startCall(
             dialogId = dialogId ?: viewModel.uiState.value.dialogId ?: 0L,
@@ -39,6 +40,7 @@ class CallFragment : Fragment() {
             avatarUrl = avatarUrl,
             participants = participants,
             callTitle = callTitle,
+            isVideoCall = isVideoCall,
         )
 
         return ComposeView(requireContext()).apply {
@@ -91,5 +93,6 @@ class CallFragment : Fragment() {
         const val ARG_CALL_TITLE = "call_title"
         const val ARG_PARTICIPANTS = "participants"
         const val ARG_DIALOG_ID = "dialog_id"
+        const val ARG_IS_VIDEO_CALL = "is_video_call"
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
@@ -15,7 +15,7 @@ import androidx.navigation.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.call.CallViewModel
-import uddug.com.naukoteka.ui.call.CallFragment
+import uddug.com.naukoteka.ui.call.SingleCallFragment
 import kotlin.math.roundToInt
 
 @AndroidEntryPoint
@@ -59,14 +59,15 @@ class CallOverlayFragment : Fragment() {
     private fun openFullScreen() {
         val navController = requireActivity().findNavController(R.id.main_nav_host_fragment)
         val args = Bundle().apply {
-            putLong(CallFragment.ARG_DIALOG_ID, viewModel.uiState.value.dialogId ?: 0L)
-            putString(CallFragment.ARG_CALL_TITLE, viewModel.uiState.value.callTitle)
+            putLong(SingleCallFragment.ARG_DIALOG_ID, viewModel.uiState.value.dialogId ?: 0L)
+            putString(SingleCallFragment.ARG_CALL_TITLE, viewModel.uiState.value.callTitle)
             putParcelableArrayList(
-                CallFragment.ARG_PARTICIPANTS,
+                SingleCallFragment.ARG_PARTICIPANTS,
                 ArrayList(viewModel.uiState.value.participants),
             )
+            putBoolean(SingleCallFragment.ARG_IS_VIDEO_CALL, viewModel.uiState.value.sessionState.camOn)
         }
-        navController.navigate(R.id.callFragment, args)
+        navController.navigate(R.id.singleCallFragment, args)
     }
 
     private fun removeSelf() {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
@@ -25,7 +25,7 @@ import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationVi
 import uddug.com.naukoteka.ui.chat.compose.ChatDetailDialogComponent
 import uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment.Companion.ARG_AVATAR_PATH
 import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
-import uddug.com.naukoteka.ui.call.CallFragment
+import uddug.com.naukoteka.ui.call.SingleCallFragment
 @AndroidEntryPoint
 class ChatDetailDialogFragment : Fragment() {
 
@@ -119,16 +119,17 @@ class ChatDetailDialogFragment : Fragment() {
                                 Bundle().apply { putLong(DIALOG_ID, dialogId) }
                             )
                         },
-                        onCallClick = { name, avatar ->
+                        onCallClick = { name, avatar, isVideoCall ->
                             val dialogId = (viewModel.uiState.value as? ChatDetailUiState.Success)?.dialogId
                                 ?: arguments?.getLong(DIALOG_ID)
                                 ?: return@ChatDetailDialogComponent
                             findNavController().navigate(
-                                R.id.callFragment,
+                                R.id.singleCallFragment,
                                 Bundle().apply {
-                                    putString(CallFragment.ARG_CONTACT_NAME, name)
-                                    putString(CallFragment.ARG_AVATAR_URL, avatar)
-                                    putLong(CallFragment.ARG_DIALOG_ID, dialogId)
+                                    putString(SingleCallFragment.ARG_CONTACT_NAME, name)
+                                    putString(SingleCallFragment.ARG_AVATAR_URL, avatar)
+                                    putLong(SingleCallFragment.ARG_DIALOG_ID, dialogId)
+                                    putBoolean(SingleCallFragment.ARG_IS_VIDEO_CALL, isVideoCall)
                                 }
                             )
                         },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -31,7 +31,7 @@ import uddug.com.naukoteka.ui.chat.compose.ChatDialogComponent
 import uddug.com.naukoteka.ui.chat.compose.ChatListComponent
 import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
 import uddug.com.naukoteka.ui.chat.ChatPollResultsFragment
-import uddug.com.naukoteka.ui.call.CallFragment
+import uddug.com.naukoteka.ui.call.SingleCallFragment
 
 @AndroidEntryPoint
 class ChatDialogFragment : Fragment() {
@@ -97,16 +97,16 @@ class ChatDialogFragment : Fragment() {
                         )
                     }
                     is ChatDialogEvents.IncomingCall -> {
-                        findNavController().navigate(
-                            R.id.callFragment,
-                            Bundle().apply {
-                                putString(CallFragment.ARG_CONTACT_NAME, state.contactName)
-                                putString(CallFragment.ARG_AVATAR_URL, state.avatarUrl)
-                                putLong(CallFragment.ARG_DIALOG_ID, state.dialogId)
-                                putString(CallFragment.ARG_CALL_TITLE, state.callTitle)
-                            }
-                        )
-                    }
+                            findNavController().navigate(
+                                R.id.singleCallFragment,
+                                Bundle().apply {
+                                    putString(SingleCallFragment.ARG_CONTACT_NAME, state.contactName)
+                                    putString(SingleCallFragment.ARG_AVATAR_URL, state.avatarUrl)
+                                    putLong(SingleCallFragment.ARG_DIALOG_ID, state.dialogId)
+                                    putString(SingleCallFragment.ARG_CALL_TITLE, state.callTitle)
+                                }
+                            )
+                        }
                 }
             }
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
@@ -22,7 +22,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatGroupDetailUiState
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatGroupDetailComponent
 import uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment.Companion.ARG_AVATAR_PATH
-import uddug.com.naukoteka.ui.call.CallFragment
+import uddug.com.naukoteka.ui.call.GroupCallFragment
 
 @AndroidEntryPoint
 class ChatGroupDetailFragment : Fragment() {
@@ -92,11 +92,11 @@ class ChatGroupDetailFragment : Fragment() {
                             val dialogId = (viewModel.uiState.value as? ChatGroupDetailUiState.Success)?.dialogId
                                 ?: return@ChatGroupDetailComponent
                             findNavController().navigate(
-                                R.id.callFragment,
+                                R.id.groupCallFragment,
                                 Bundle().apply {
-                                    putString(CallFragment.ARG_CONTACT_NAME, name)
-                                    putString(CallFragment.ARG_AVATAR_URL, avatar)
-                                    putLong(CallFragment.ARG_DIALOG_ID, dialogId)
+                                    putString(GroupCallFragment.ARG_CONTACT_NAME, name)
+                                    putString(GroupCallFragment.ARG_AVATAR_URL, avatar)
+                                    putLong(GroupCallFragment.ARG_DIALOG_ID, dialogId)
                                 }
                             )
                         },

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -114,8 +114,8 @@
         android:name="uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment" />
 
     <fragment
-        android:id="@+id/callFragment"
-        android:name="uddug.com.naukoteka.ui.call.CallFragment">
+        android:id="@+id/singleCallFragment"
+        android:name="uddug.com.naukoteka.ui.call.SingleCallFragment">
         <argument
             android:name="contact_name"
             app:argType="string"
@@ -126,6 +126,27 @@
             android:defaultValue="@null" />
         <argument
             android:name="call_title"
+            app:argType="string"
+            android:defaultValue="@null" />
+        <argument
+            android:name="dialog_id"
+            app:argType="long"
+            android:defaultValue="-1L" />
+        <argument
+            android:name="is_video_call"
+            app:argType="boolean"
+            android:defaultValue="true" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/groupCallFragment"
+        android:name="uddug.com.naukoteka.ui.call.GroupCallFragment">
+        <argument
+            android:name="contact_name"
+            app:argType="string"
+            android:defaultValue="@null" />
+        <argument
+            android:name="avatar_url"
             app:argType="string"
             android:defaultValue="@null" />
         <argument

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -469,6 +469,9 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="call_status_finished">Звонок завершен</string>
     <string name="call_status_loading">Загрузка…</string>
     <string name="call_status_in_call">Звонок</string>
+    <string name="call_create_title">Создать звонок</string>
+    <string name="call_audio">Аудиозвонок</string>
+    <string name="call_video">Видеозвонок</string>
     <string name="call_primary_action">Позвонить</string>
     <string name="call_secondary_action">Сообщение</string>
     <string name="call_terminate_action">Завершить</string>


### PR DESCRIPTION
## Summary
- rename the existing call screen to SingleCallFragment and introduce a stub GroupCallFragment
- show a call creation bottom sheet in chat details with audio/video options and pass the selection into the call
- update navigation and call overlay logic to use the new destinations and video flag

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69319dea065c8329bf030f206f58dec0)