### PR TITLE
Hide poll attachment option in non-group chats

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDialogComponent.kt
@@ -113,6 +113,11 @@ fun ChatDialogComponent(
     val isCurrentUserAdmin by viewModel.isCurrentUserAdmin.collectAsState()
     val notificationsDisabled by viewModel.notificationsDisabled.collectAsState()
     val pollRevoteTriggers = remember { mutableStateMapOf<String, Int>() }
+    val isGroupChat = when (val state = uiState) {
+        is ChatDialogUiState.Success -> state.isGroup
+        is ChatDialogUiState.Loading -> state.isGroup
+        else -> false
+    }
 
     val audioRecorder = remember { AudioRecorder(context) }
     val mediaPlayer = remember { MediaPlayer() }
@@ -673,7 +678,8 @@ fun ChatDialogComponent(
                 onContactClick = {
                     showAttachmentSheet = false
                     onContactClick()
-                }
+                },
+                isGroupChat = isGroupChat
             )
         }
         selectedMessage?.let { message ->

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -25,9 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.res.painterResource
-
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -50,6 +46,7 @@ fun AttachOptionsBottomSheetDialog(
     onPollClick: () -> Unit,
     onContactClick: () -> Unit,
     selected: AttachOption? = null,
+    isGroupChat: Boolean = true,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
@@ -74,12 +71,14 @@ fun AttachOptionsBottomSheetDialog(
                 isSelected = selected == AttachOption.FILE,
                 onClick = onFileClick
             )
-            BottomSheetItem(
-                icon = painterResource(R.drawable.ic_bottom_poll),
-                text = stringResource(R.string.chat_attach_poll),
-                isSelected = selected == AttachOption.POLL,
-                onClick = onPollClick
-            )
+            if (isGroupChat) {
+                BottomSheetItem(
+                    icon = painterResource(R.drawable.ic_bottom_poll),
+                    text = stringResource(R.string.chat_attach_poll),
+                    isSelected = selected == AttachOption.POLL,
+                    onClick = onPollClick
+                )
+            }
             BottomSheetItem(
                 icon = painterResource(R.drawable.ic_bottom_contacts),
                 text = stringResource(R.string.chat_attach_contact),


### PR DESCRIPTION
## Summary
- hide the poll attachment button when the chat is not a group
- pass chat type to the attachment sheet to control poll visibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a234b77883299b89774957cc067b)