### PR TITLE
Add permission prompts before starting calls

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -494,6 +494,10 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="call_participant_action_copy">Скопировать контакт</string>
     <string name="call_participant_action_profile">Посмотреть профиль</string>
     <string name="call_sheet_close">Закрыть</string>
+    <string name="call_permission_microphone_title">Нет доступа к микрофону</string>
+    <string name="call_permission_microphone_message">Без доступа к микрофону не получится совершить звонок.</string>
+    <string name="call_permission_camera_title">Нет доступа к камере</string>
+    <string name="call_permission_camera_message">Для видеозвонка нужен доступ к камере.</string>
     <string name="profile_shasre">Поделиться</string>
     <string name="profile_more">Еще</string>
     <string name="find_chat_message">Поиск чатов и сообщений</string>


### PR DESCRIPTION
## Summary
- check microphone and camera permissions before starting a call and request any that are missing
- prevent call navigation when permissions are denied and show alerts explaining the requirement
- add strings for the new permission alert titles and messages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a4bde7648329bece7fdd18aa9aeb)