### PR TITLE
Add compose design system theme

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/chat/ChatDetailDialogFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -27,6 +26,7 @@ import uddug.com.naukoteka.ui.chat.ChatDialogFragment.Companion
 import uddug.com.naukoteka.ui.chat.ForwardMessageFragment.Companion.ARG_MESSAGE_ID
 import uddug.com.naukoteka.ui.chat.compose.ChatDialogComponent
 import uddug.com.naukoteka.ui.chat.compose.ChatListComponent
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatDetailDialogFragment : Fragment() {
@@ -89,7 +89,7 @@ class ChatDetailDialogFragment : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatDialogComponent(
                         viewModel = viewModel,
                         onBackPressed = {

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/GroupCallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/GroupCallFragment.kt
@@ -4,11 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 class GroupCallFragment : Fragment() {
 
@@ -19,7 +19,7 @@ class GroupCallFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     Surface {
                         Text(text = "Group call is not implemented yet")
                     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
@@ -16,6 +15,7 @@ import uddug.com.naukoteka.mvvm.call.CallViewModel
 import uddug.com.naukoteka.ui.activities.main.ContainerActivity
 import uddug.com.naukoteka.ui.call.compose.CallScreen
 import uddug.com.naukoteka.ui.call.overlay.CallOverlayFragment
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class SingleCallFragment : Fragment() {
@@ -46,7 +46,7 @@ class SingleCallFragment : Fragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 val state = viewModel.uiState.collectAsState().value
-                MaterialTheme {
+                NaukotekaTheme {
                     CallScreen(
                         state = state,
                         onBackPressed = { findNavController().popBackStack() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/overlay/CallOverlayFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
@@ -16,6 +15,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.call.CallViewModel
 import uddug.com.naukoteka.ui.call.SingleCallFragment
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 import kotlin.math.roundToInt
 
 @AndroidEntryPoint
@@ -37,7 +37,7 @@ class CallOverlayFragment : Fragment() {
             setContent {
                 val state = viewModel.uiState.collectAsState().value
 
-                MaterialTheme {
+                NaukotekaTheme {
                     CallOverlay(
                         state = state,
                         onExpand = {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatAvatarPreviewFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatAvatarPreviewFragment.kt
@@ -32,6 +32,8 @@ import androidx.fragment.app.Fragment
 import coil.compose.AsyncImage
 import uddug.com.naukoteka.BuildConfig
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.ui.theme.NauTheme
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 class ChatAvatarPreviewFragment : Fragment() {
 
@@ -43,7 +45,7 @@ class ChatAvatarPreviewFragment : Fragment() {
         val avatarPath = arguments?.getString(ARG_AVATAR_PATH)
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatAvatarPreviewScreen(
                         avatarPath = avatarPath,
                         onBackPressed = { requireActivity().onBackPressed() }
@@ -69,14 +71,18 @@ private fun ChatAvatarPreviewScreen(
                 title = { Text(text = stringResource(R.string.chat_avatar_preview_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBackPressed) {
-                        Icon(imageVector = Icons.Default.ArrowBack, contentDescription = null, tint = Color(0xFF2E83D9))
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = null,
+                            tint = MaterialTheme.colors.primary,
+                        )
                     }
                 },
-                backgroundColor = Color.White,
+                backgroundColor = MaterialTheme.colors.surface,
                 elevation = 0.dp
             )
         },
-        backgroundColor = Color(0xFFF5F5F9)
+        backgroundColor = MaterialTheme.colors.background
     ) { padding ->
         Box(
             modifier = Modifier
@@ -90,7 +96,7 @@ private fun ChatAvatarPreviewScreen(
                         .padding(horizontal = 24.dp, vertical = 32.dp)
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(24.dp))
-                        .background(Color.White),
+                        .background(MaterialTheme.colors.surface),
                     contentAlignment = Alignment.Center
                 ) {
                     AsyncImage(
@@ -107,7 +113,7 @@ private fun ChatAvatarPreviewScreen(
                 Text(
                     text = stringResource(R.string.chat_avatar_preview_empty),
                     modifier = Modifier.padding(32.dp),
-                    color = Color(0xFF8083A0)
+                    color = NauTheme.extendedColors.inactive,
                 )
             }
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateFolderFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateFolderFragment.kt
@@ -20,6 +20,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatCreateFolderEvent
 import uddug.com.naukoteka.mvvm.chat.ChatCreateFolderViewModel
 import uddug.com.naukoteka.mvvm.chat.ChatFolderSelectionItem
 import uddug.com.naukoteka.ui.chat.compose.ChatCreateFolderScreen
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatCreateFolderFragment : Fragment() {
@@ -33,7 +34,7 @@ class ChatCreateFolderFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatCreateFolderScreen(
                         viewModel = viewModel,
                         onBackPressed = { findNavController().popBackStack() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateGroupFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateGroupFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -20,6 +19,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatCreateGroupEvent
 import uddug.com.naukoteka.mvvm.chat.ChatCreateGroupViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatCreateGroupScreen
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatCreateGroupFragment : Fragment() {
@@ -85,7 +85,7 @@ class ChatCreateGroupFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatCreateGroupScreen(
                         viewModel = viewModel,
                         onBackPressed = { findNavController().popBackStack() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateMultiFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -22,6 +21,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatCreateMultiViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatCreateMultiScreen
 import uddug.com.naukoteka.ui.chat.ChatCreateGroupFragment
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatCreateMultiFragment : Fragment() {
@@ -85,7 +85,7 @@ class ChatCreateMultiFragment : Fragment() {
     ): View? {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatCreateMultiScreen(
                         viewModel = viewModel,
                         onBackPressed = { findNavController().popBackStack() }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreatePollFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreatePollFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -19,6 +18,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatCreatePollEvent
 import uddug.com.naukoteka.mvvm.chat.ChatCreatePollViewModel
 import uddug.com.naukoteka.ui.chat.compose.ChatCreatePollScreen
 import uddug.com.naukoteka.ui.chat.ChatDialogFragment.Companion.CREATED_POLL_ID_KEY
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatCreatePollFragment : Fragment() {
@@ -60,7 +60,7 @@ class ChatCreatePollFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatCreatePollScreen(
                         viewModel = viewModel,
                         onBack = { requireActivity().onBackPressed() }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatCreateSingleFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -23,6 +22,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatCreateSingleViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.ChatDialogFragment.Companion.INTERLOCUTOR_ID
 import uddug.com.naukoteka.ui.chat.compose.ChatCreateSingleScreen
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatCreateSingleFragment : Fragment() {
@@ -79,7 +79,7 @@ class ChatCreateSingleFragment : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatCreateSingleScreen(
                         viewModel = viewModel,
                         onGroupCreateClick = {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -26,6 +25,7 @@ import uddug.com.naukoteka.ui.chat.compose.ChatDetailDialogComponent
 import uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment.Companion.ARG_AVATAR_PATH
 import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
 import uddug.com.naukoteka.ui.call.SingleCallFragment
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 @AndroidEntryPoint
 class ChatDetailDialogFragment : Fragment() {
 
@@ -101,7 +101,7 @@ class ChatDetailDialogFragment : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatDetailDialogComponent(
                         viewModel = viewModel,
                         onBackPressed = {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogSearchFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDetailDialogSearchFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -15,6 +14,7 @@ import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatDialogDetailViewModel
 import uddug.com.naukoteka.ui.chat.ForwardMessageFragment.Companion.ARG_MESSAGE_ID
 import uddug.com.naukoteka.ui.chat.compose.ChatDetailDialogSearchComponent
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatDetailDialogSearchFragment : Fragment() {
@@ -32,7 +32,7 @@ class ChatDetailDialogSearchFragment : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatDetailDialogSearchComponent(
                         viewModel = viewModel,
                         onBackPressed = { requireActivity().onBackPressed() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -28,6 +27,7 @@ import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationVi
 import uddug.com.naukoteka.ui.chat.ChatDetailDialogFragment.Companion.DIALOG_DETAIL
 import uddug.com.naukoteka.ui.chat.ForwardMessageFragment.Companion.ARG_MESSAGE_ID
 import uddug.com.naukoteka.ui.chat.compose.ChatDialogComponent
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 import uddug.com.naukoteka.ui.chat.compose.ChatListComponent
 import uddug.com.naukoteka.ui.chat.ChatEditGroupFragment
 import uddug.com.naukoteka.ui.chat.ChatPollResultsFragment
@@ -146,7 +146,7 @@ class ChatDialogFragment : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatDialogComponent(
                         viewModel = viewModel,
                         onBackPressed = {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditFolderFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditFolderFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -20,6 +19,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatEditFolderEvent
 import uddug.com.naukoteka.mvvm.chat.ChatEditFolderViewModel
 import uddug.com.naukoteka.mvvm.chat.ChatFolderSelectionItem
 import uddug.com.naukoteka.ui.chat.compose.ChatEditFolderScreen
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatEditFolderFragment : Fragment() {
@@ -33,7 +33,7 @@ class ChatEditFolderFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatEditFolderScreen(
                         viewModel = viewModel,
                         onBackPressed = { findNavController().popBackStack() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditGroupFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatEditGroupFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -21,6 +20,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatEditGroupViewModel
 import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationView
 import uddug.com.naukoteka.ui.chat.compose.ChatEditGroupScreen
 import uddug.com.naukoteka.ui.chat.ChatCreateMultiFragment
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatEditGroupFragment : Fragment() {
@@ -84,7 +84,7 @@ class ChatEditGroupFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatEditGroupScreen(
                         viewModel = viewModel,
                         onBackPressed = { findNavController().popBackStack() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatFolderAddChatsFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatFolderAddChatsFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -16,6 +15,7 @@ import kotlinx.coroutines.launch
 import uddug.com.naukoteka.mvvm.chat.ChatFolderAddChatsEvent
 import uddug.com.naukoteka.mvvm.chat.ChatFolderAddChatsViewModel
 import uddug.com.naukoteka.ui.chat.compose.ChatFolderAddChatsScreen
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 import java.util.ArrayList
 
 @AndroidEntryPoint
@@ -30,7 +30,7 @@ class ChatFolderAddChatsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatFolderAddChatsScreen(
                         viewModel = viewModel,
                         onBackPressed = { viewModel.onBackPressed() }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatFolderSettingsFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatFolderSettingsFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -13,6 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
 import uddug.com.naukoteka.ui.chat.compose.ChatFolderSettingsComponent
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatFolderSettingsFragment : Fragment() {
@@ -26,7 +26,7 @@ class ChatFolderSettingsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatFolderSettingsComponent(
                         viewModel = viewModel,
                         onBackPressed = { findNavController().popBackStack() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatGroupDetailFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -23,6 +22,7 @@ import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationVi
 import uddug.com.naukoteka.ui.chat.compose.ChatGroupDetailComponent
 import uddug.com.naukoteka.ui.chat.ChatAvatarPreviewFragment.Companion.ARG_AVATAR_PATH
 import uddug.com.naukoteka.ui.call.GroupCallFragment
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatGroupDetailFragment : Fragment() {
@@ -74,7 +74,7 @@ class ChatGroupDetailFragment : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatGroupDetailComponent(
                         viewModel = viewModel,
                         onBackPressed = { requireActivity().onBackPressed() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatListFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -27,6 +26,7 @@ import uddug.com.naukoteka.presentation.profile.navigation.ContainerNavigationVi
 import uddug.com.naukoteka.ui.chat.ChatDialogFragment.Companion.DIALOG_ID
 import uddug.com.naukoteka.ui.chat.ChatDetailDialogFragment
 import uddug.com.naukoteka.ui.chat.compose.ChatListComponent
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatListFragment : Fragment() {
@@ -132,7 +132,7 @@ class ChatListFragment : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatListComponent(
                         viewModel = viewModel,
                         onCreateChatClick = {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatPollResultsFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatPollResultsFragment.kt
@@ -4,13 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import uddug.com.naukoteka.mvvm.chat.ChatPollResultsViewModel
 import uddug.com.naukoteka.ui.chat.compose.ChatPollResultsScreen
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ChatPollResultsFragment : Fragment() {
@@ -24,7 +24,7 @@ class ChatPollResultsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ChatPollResultsScreen(
                         viewModel = viewModel,
                         onBack = { requireActivity().onBackPressed() }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ForwardMessageFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ForwardMessageFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -22,6 +21,7 @@ import uddug.com.naukoteka.mvvm.chat.ForwardMessageEvent
 import uddug.com.naukoteka.mvvm.chat.ForwardMessageItem
 import uddug.com.naukoteka.mvvm.chat.ForwardMessageViewModel
 import uddug.com.naukoteka.ui.chat.compose.ForwardMessageComponent
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class ForwardMessageFragment : Fragment() {
@@ -42,7 +42,7 @@ class ForwardMessageFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     ForwardMessageComponent(
                         viewModel = viewModel,
                         onBack = { requireActivity().onBackPressed() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/SendContactFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/SendContactFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -13,6 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import uddug.com.domain.entities.profile.UserProfileFullInfo
 import uddug.com.naukoteka.mvvm.chat.SendContactViewModel
 import uddug.com.naukoteka.ui.chat.compose.SendContactComponent
+import uddug.com.naukoteka.ui.theme.NaukotekaTheme
 
 @AndroidEntryPoint
 class SendContactFragment : Fragment() {
@@ -26,7 +26,7 @@ class SendContactFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MaterialTheme {
+                NaukotekaTheme {
                     SendContactComponent(
                         viewModel = viewModel,
                         onBack = { requireActivity().onBackPressed() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatPollResultsScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatPollResultsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -30,7 +31,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -43,13 +43,7 @@ import uddug.com.naukoteka.mvvm.chat.ChatPollResultsUiState
 import uddug.com.naukoteka.mvvm.chat.ChatPollResultsViewModel
 import uddug.com.naukoteka.mvvm.chat.PollResultOptionUi
 import uddug.com.naukoteka.mvvm.chat.PollResultsUiModel
-
-private val PrimaryTextColor = Color(0xFF111827)
-private val SecondaryTextColor = Color(0xFF6F7A90)
-private val AccentColor = Color(0xFF2E83D9)
-private val SurfaceColor = Color.White
-private val QuestionBackgroundColor = Color(0xFFF6F8FC)
-private val QuestionBorderColor = Color(0xFFE4E8F1)
+import uddug.com.naukoteka.ui.theme.NauTheme
 
 @Composable
 fun ChatPollResultsScreen(
@@ -76,7 +70,7 @@ fun ChatPollResultsScreen(
                 title = {
                     Text(
                         text = stringResource(id = R.string.chat_poll_results_title),
-                        color = PrimaryTextColor,
+                        color = primaryTextColor(),
                         fontSize = 20.sp,
                         fontWeight = FontWeight.SemiBold
                     )
@@ -86,27 +80,27 @@ fun ChatPollResultsScreen(
                         Icon(
                             imageVector = Icons.Filled.Close,
                             contentDescription = null,
-                            tint = PrimaryTextColor
+                            tint = primaryTextColor()
                         )
                     }
                 },
-                backgroundColor = SurfaceColor,
+                backgroundColor = surfaceColor(),
                 elevation = 0.dp
             )
         },
-        backgroundColor = SurfaceColor
+        backgroundColor = MaterialTheme.colors.background
     ) { paddingValues ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(SurfaceColor)
+                .background(MaterialTheme.colors.background)
                 .padding(paddingValues)
         ) {
             when {
                 state.isLoading -> {
                     CircularProgressIndicator(
                         modifier = Modifier.align(Alignment.Center),
-                        color = AccentColor
+                        color = accentColor()
                     )
                 }
                 state.poll != null -> {
@@ -130,7 +124,7 @@ private fun PollResultsContent(model: PollResultsUiModel) {
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .background(SurfaceColor)
+            .background(surfaceColor())
             .padding(vertical = 4.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
@@ -138,7 +132,7 @@ private fun PollResultsContent(model: PollResultsUiModel) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
                     text = stringResource(id = R.string.chat_poll_results_question_label),
-                    color = SecondaryTextColor,
+                    color = secondaryTextColor(),
                     fontSize = 12.sp,
                     fontWeight = FontWeight.SemiBold,
                     lineHeight = 16.sp
@@ -147,19 +141,19 @@ private fun PollResultsContent(model: PollResultsUiModel) {
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
-                            color = QuestionBackgroundColor,
+                            color = questionBackgroundColor(),
                             shape = RoundedCornerShape(16.dp)
                         )
                         .border(
                             width = 1.dp,
-                            color = QuestionBorderColor,
+                            color = questionBorderColor(),
                             shape = RoundedCornerShape(16.dp)
                         )
                         .padding(horizontal = 16.dp, vertical = 14.dp)
                 ) {
                     Text(
                         text = model.question,
-                        color = PrimaryTextColor,
+                        color = primaryTextColor(),
                         fontSize = 16.sp,
                         fontWeight = FontWeight.SemiBold,
                         lineHeight = 22.sp,
@@ -184,28 +178,28 @@ private fun PollResultsContent(model: PollResultsUiModel) {
                     pollTypeText,
                     votesText
                 ),
-                color = SecondaryTextColor,
+                color = secondaryTextColor(),
                 fontSize = 14.sp,
                 lineHeight = 20.sp
             )
             if (model.allowsMultipleAnswers) {
                 Text(
                     text = stringResource(id = R.string.chat_poll_results_multiple_allowed),
-                    color = SecondaryTextColor,
+                    color = secondaryTextColor(),
                     fontSize = 12.sp
                 )
             }
             if (model.isQuiz) {
                 Text(
                     text = stringResource(id = R.string.chat_poll_results_quiz_mode),
-                    color = SecondaryTextColor,
+                    color = secondaryTextColor(),
                     fontSize = 12.sp
                 )
             }
             if (model.isStopped) {
                 Text(
                     text = stringResource(id = R.string.chat_poll_results_stopped),
-                    color = SecondaryTextColor,
+                    color = secondaryTextColor(),
                     fontSize = 12.sp
                 )
             }
@@ -213,7 +207,7 @@ private fun PollResultsContent(model: PollResultsUiModel) {
 
         Text(
             text = stringResource(id = R.string.chat_poll_results_options_section),
-            color = PrimaryTextColor,
+            color = primaryTextColor(),
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold
         )
@@ -229,9 +223,9 @@ private fun PollResultsContent(model: PollResultsUiModel) {
 @Composable
 private fun PollResultOptionItem(option: PollResultOptionUi) {
     val background = when {
-        option.isRightAnswer -> AccentColor.copy(alpha = 0.08f)
-        option.isSelected -> AccentColor.copy(alpha = 0.05f)
-        else -> Color(0xFFF5F5F9)
+        option.isRightAnswer -> accentColor().copy(alpha = 0.08f)
+        option.isSelected -> accentColor().copy(alpha = 0.05f)
+        else -> surfaceColor()
     }
     Column(
         modifier = Modifier
@@ -245,14 +239,14 @@ private fun PollResultOptionItem(option: PollResultOptionUi) {
         ) {
             Text(
                 text = "${option.percent}%",
-                color = Color.Black,
+                color = primaryTextColor(),
                 fontWeight = FontWeight.SemiBold,
                 fontSize = 16.sp
             )
             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 Text(
                     text = option.text,
-                    color = PrimaryTextColor,
+                    color = primaryTextColor(),
                     fontSize = 15.sp,
                     fontWeight = if (option.isSelected || option.isRightAnswer) FontWeight.SemiBold else FontWeight.Normal,
                     lineHeight = 20.sp
@@ -260,7 +254,7 @@ private fun PollResultOptionItem(option: PollResultOptionUi) {
                 option.description?.takeIf { it.isNotBlank() }?.let { description ->
                     Text(
                         text = description,
-                        color = SecondaryTextColor,
+                        color = secondaryTextColor(),
                         fontSize = 13.sp,
                         lineHeight = 18.sp
                     )
@@ -268,14 +262,14 @@ private fun PollResultOptionItem(option: PollResultOptionUi) {
                 if (option.isRightAnswer) {
                     Text(
                         text = stringResource(id = R.string.chat_poll_results_correct_answer),
-                        color = AccentColor,
+                        color = accentColor(),
                         fontSize = 12.sp,
                         fontWeight = FontWeight.SemiBold
                     )
                 } else if (option.isSelected) {
                     Text(
                         text = stringResource(id = R.string.chat_poll_results_your_choice),
-                        color = AccentColor,
+                        color = accentColor(),
                         fontSize = 12.sp,
                         fontWeight = FontWeight.SemiBold
                     )
@@ -288,8 +282,8 @@ private fun PollResultOptionItem(option: PollResultOptionUi) {
                 .fillMaxWidth()
                 .height(2.dp)
                 .clip(RoundedCornerShape(3.dp)),
-            backgroundColor = Color(0xFFE4E8F1),
-            color = AccentColor
+            backgroundColor = questionBorderColor(),
+            color = accentColor()
         )
     }
 }
@@ -307,21 +301,21 @@ private fun PollResultsError(
     ) {
         Text(
             text = stringResource(id = R.string.chat_poll_results_error),
-            color = SecondaryTextColor,
+            color = secondaryTextColor(),
             fontSize = 16.sp,
             textAlign = TextAlign.Center
         )
         message?.takeIf { it.isNotBlank() }?.let { details ->
             Text(
                 text = details,
-                color = SecondaryTextColor,
+                color = secondaryTextColor(),
                 fontSize = 13.sp,
                 textAlign = TextAlign.Center
             )
         }
         TextButton(
             onClick = onRetry,
-            colors = ButtonDefaults.textButtonColors(contentColor = AccentColor)
+            colors = ButtonDefaults.textButtonColors(contentColor = accentColor())
         ) {
             Text(
                 text = stringResource(id = R.string.chat_poll_results_retry),
@@ -331,3 +325,21 @@ private fun PollResultsError(
         }
     }
 }
+
+@Composable
+private fun primaryTextColor() = MaterialTheme.colors.onSurface
+
+@Composable
+private fun secondaryTextColor() = MaterialTheme.colors.onSurface.copy(alpha = 0.7f)
+
+@Composable
+private fun accentColor() = MaterialTheme.colors.primary
+
+@Composable
+private fun surfaceColor() = MaterialTheme.colors.surface
+
+@Composable
+private fun questionBackgroundColor() = NauTheme.extendedColors.backgroundMoreInfo
+
+@Composable
+private fun questionBorderColor() = NauTheme.extendedColors.inputStroke

--- a/app/src/main/java/uddug/com/naukoteka/ui/theme/Color.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/theme/Color.kt
@@ -1,0 +1,22 @@
+package uddug.com.naukoteka.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Primary = Color(0xFF2E83D9)
+val PrimaryVariant = Color(0xFF0C1F5D)
+val BackgroundLight = Color(0xFFFFFFFF)
+val BackgroundDark = Color(0xFF242535)
+val SurfaceLight = Color(0xFFEAEAF2)
+val SurfaceDark = Color(0xFF1A1B2B)
+val TextPrimaryLight = Color(0xFF10101C)
+val TextPrimaryDark = Color(0xFFFFFFFF)
+val TextSecondary = Color(0xFF8083A0)
+val ErrorColor = Color(0xFFD92E4D)
+val BackgroundMoreInfoLight = Color(0xFFEAEAF2)
+val BackgroundMoreInfoDark = Color(0xFF363850)
+val InputStrokeLight = Color(0xFFDBDEE9)
+val InputStrokeDark = Color(0xFF4D4D67)
+val InputBackgroundLight = Color(0xFFEAEAF2)
+val InputBackgroundDark = Color(0xFF242535)
+val IconAccent = Color(0xFF2E83D9)
+val Inactive = Color(0xFF8083A0)

--- a/app/src/main/java/uddug/com/naukoteka/ui/theme/Theme.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/theme/Theme.kt
@@ -1,0 +1,140 @@
+package uddug.com.naukoteka.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.MaterialTheme as Material2Theme
+import androidx.compose.material.darkColors as materialDarkColors
+import androidx.compose.material.lightColors as materialLightColors
+import androidx.compose.material3.MaterialTheme as Material3Theme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+private val LightColorScheme = lightColorScheme(
+    primary = Primary,
+    onPrimary = Color.White,
+    secondary = PrimaryVariant,
+    onSecondary = Color.White,
+    background = BackgroundLight,
+    onBackground = TextPrimaryLight,
+    surface = SurfaceLight,
+    onSurface = TextPrimaryLight,
+    error = ErrorColor,
+    onError = Color.White,
+    surfaceVariant = BackgroundMoreInfoLight,
+    onSurfaceVariant = TextSecondary,
+    outline = InputStrokeLight,
+)
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Primary,
+    onPrimary = Color.White,
+    secondary = PrimaryVariant,
+    onSecondary = Color.White,
+    background = BackgroundDark,
+    onBackground = TextPrimaryDark,
+    surface = SurfaceDark,
+    onSurface = TextPrimaryDark,
+    error = ErrorColor,
+    onError = Color.White,
+    surfaceVariant = BackgroundMoreInfoDark,
+    onSurfaceVariant = TextSecondary,
+    outline = InputStrokeDark,
+)
+
+private val LightMaterialColors = materialLightColors(
+    primary = Primary,
+    primaryVariant = PrimaryVariant,
+    secondary = PrimaryVariant,
+    background = BackgroundLight,
+    surface = SurfaceLight,
+    error = ErrorColor,
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onBackground = TextPrimaryLight,
+    onSurface = TextPrimaryLight,
+)
+
+private val DarkMaterialColors = materialDarkColors(
+    primary = Primary,
+    primaryVariant = PrimaryVariant,
+    secondary = PrimaryVariant,
+    background = BackgroundDark,
+    surface = SurfaceDark,
+    error = ErrorColor,
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onBackground = TextPrimaryDark,
+    onSurface = TextPrimaryDark,
+)
+
+data class NaukotekaExtendedColors(
+    val backgroundMoreInfo: Color,
+    val inputBackground: Color,
+    val inputStroke: Color,
+    val accent: Color,
+    val inactive: Color,
+    val iconAccent: Color,
+)
+
+private val LocalNaukotekaExtendedColors = staticCompositionLocalOf {
+    NaukotekaExtendedColors(
+        backgroundMoreInfo = BackgroundMoreInfoLight,
+        inputBackground = InputBackgroundLight,
+        inputStroke = InputStrokeLight,
+        accent = Primary,
+        inactive = Inactive,
+        iconAccent = IconAccent,
+    )
+}
+
+private val LightExtendedColors = NaukotekaExtendedColors(
+    backgroundMoreInfo = BackgroundMoreInfoLight,
+    inputBackground = InputBackgroundLight,
+    inputStroke = InputStrokeLight,
+    accent = Primary,
+    inactive = Inactive,
+    iconAccent = IconAccent,
+)
+
+private val DarkExtendedColors = NaukotekaExtendedColors(
+    backgroundMoreInfo = BackgroundMoreInfoDark,
+    inputBackground = InputBackgroundDark,
+    inputStroke = InputStrokeDark,
+    accent = Primary,
+    inactive = Inactive,
+    iconAccent = IconAccent,
+)
+
+@Composable
+fun NaukotekaTheme(
+    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    val colorScheme = if (useDarkTheme) DarkColorScheme else LightColorScheme
+    val materialColors = if (useDarkTheme) DarkMaterialColors else LightMaterialColors
+    val extendedColors = if (useDarkTheme) DarkExtendedColors else LightExtendedColors
+
+    CompositionLocalProvider(LocalNaukotekaExtendedColors provides extendedColors) {
+        Material3Theme(
+            colorScheme = colorScheme,
+            typography = NaukotekaTypography,
+        ) {
+            Material2Theme(
+                colors = materialColors,
+                typography = NaukotekaMaterialTypography,
+                content = content,
+            )
+        }
+    }
+}
+
+object NauTheme {
+    val extendedColors: NaukotekaExtendedColors
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalNaukotekaExtendedColors.current
+}

--- a/app/src/main/java/uddug/com/naukoteka/ui/theme/Typography.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/theme/Typography.kt
@@ -1,0 +1,41 @@
+package uddug.com.naukoteka.ui.theme
+
+import androidx.compose.material.Typography
+import androidx.compose.material3.Typography as Typography3
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import uddug.com.naukoteka.R
+
+private val GolosFontFamily = FontFamily(
+    Font(resId = R.font.golos_text_regular, weight = FontWeight.Normal),
+    Font(resId = R.font.golos_text_medium, weight = FontWeight.Medium),
+    Font(resId = R.font.golos_text_demi_bold, weight = FontWeight.SemiBold),
+    Font(resId = R.font.golos_text_bold, weight = FontWeight.Bold),
+    Font(resId = R.font.golos_black, weight = FontWeight.Black),
+)
+
+val NaukotekaMaterialTypography = Typography(defaultFontFamily = GolosFontFamily)
+
+private val defaultM3Typography = Typography3()
+
+private fun TextStyle.withFontFamily(): TextStyle = copy(fontFamily = GolosFontFamily)
+
+val NaukotekaTypography = Typography3(
+    displayLarge = defaultM3Typography.displayLarge.withFontFamily(),
+    displayMedium = defaultM3Typography.displayMedium.withFontFamily(),
+    displaySmall = defaultM3Typography.displaySmall.withFontFamily(),
+    headlineLarge = defaultM3Typography.headlineLarge.withFontFamily(),
+    headlineMedium = defaultM3Typography.headlineMedium.withFontFamily(),
+    headlineSmall = defaultM3Typography.headlineSmall.withFontFamily(),
+    titleLarge = defaultM3Typography.titleLarge.withFontFamily(),
+    titleMedium = defaultM3Typography.titleMedium.withFontFamily(),
+    titleSmall = defaultM3Typography.titleSmall.withFontFamily(),
+    bodyLarge = defaultM3Typography.bodyLarge.withFontFamily(),
+    bodyMedium = defaultM3Typography.bodyMedium.withFontFamily(),
+    bodySmall = defaultM3Typography.bodySmall.withFontFamily(),
+    labelLarge = defaultM3Typography.labelLarge.withFontFamily(),
+    labelMedium = defaultM3Typography.labelMedium.withFontFamily(),
+    labelSmall = defaultM3Typography.labelSmall.withFontFamily(),
+)


### PR DESCRIPTION
## Summary
- add a Compose design system mirroring the existing light and dark palettes with shared typography
- wrap Compose entry points with the new theme so material components pick up app colors and fonts
- align chat Compose screens (avatar preview and poll results) with the themed colors

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not configured in CI container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a38411d08329974cc1b027f089fe)