### PR TITLE
Adjust Flashphoner room manager lifecycle handling

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
@@ -5,6 +5,8 @@ import java.lang.ref.WeakReference
 import com.flashphoner.fpwcsapi.Flashphoner
 import com.flashphoner.fpwcsapi.session.Session
 import com.flashphoner.fpwcsapi.session.SessionOptions
+import com.flashphoner.fpwcsapi.room.RoomManager
+import com.flashphoner.fpwcsapi.room.RoomManagerOptions
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -48,5 +50,19 @@ class FlashphonerEnvironment @Inject constructor() {
         ensureInitialised()
         val options = SessionOptions(serverUrl).apply(configure)
         return Flashphoner.createSession(options)
+    }
+
+    /**
+     * Creates a new [RoomManager] instance with provided [serverUrl] and [username].
+     * Ensures the SDK is initialised before delegating to [Flashphoner].
+     */
+    fun createRoomManager(
+        serverUrl: String,
+        username: String,
+        configure: RoomManagerOptions.() -> Unit = {},
+    ): RoomManager {
+        ensureInitialised()
+        val options = RoomManagerOptions(serverUrl, username).apply(configure)
+        return Flashphoner.createRoomManager(options)
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -1,6 +1,5 @@
 package uddug.com.naukoteka.flashphoner
 
-import com.flashphoner.fpwcsapi.Flashphoner
 import com.flashphoner.fpwcsapi.bean.Data
 import com.flashphoner.fpwcsapi.room.Room
 import com.flashphoner.fpwcsapi.room.RoomManager
@@ -65,12 +64,7 @@ class FlashphonerSessionManager @Inject constructor(
         onManagerReady: RoomManager.() -> Unit = {},
     ): RoomManager {
         reset()
-        environment.ensureInitialised()
-
-        val options = RoomManagerOptions(serverUrl, username).apply(configureOptions)
-
-
-        val manager = Flashphoner.createRoomManager(options)
+        val manager = environment.createRoomManager(serverUrl, username, configureOptions)
 
         onManagerReady(manager)
         roomManagerRef.set(manager)

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
@@ -53,11 +53,6 @@ class CallViewModel @Inject constructor(
     ) {
         if (isCallStarted) return
 
-        // Ensure any previous Flashphoner session artifacts are fully released before
-        // attempting to start a new call. Residual state may keep the WebSocket client in
-        // a disconnecting state and cause subsequent calls to close immediately.
-        flashphonerSessionManager.disconnectRoom()
-
         if (dialogId <= 0) {
             _uiState.value = _uiState.value.copy(status = CallStatus.FINISHED)
             return


### PR DESCRIPTION
## Summary
- add a FlashphonerEnvironment helper to create room managers through the SDK
- have the session manager use the new helper instead of constructing RoomManager directly
- avoid disconnecting Flashphoner sessions when starting a call to prevent immediate teardown

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a5ad1304832989ddf79df1951a75)