### PR TITLE
Fix dark theme backgrounds in chat screens

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -80,6 +79,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -172,7 +172,7 @@ fun ChatDetailDialogComponent(
                     Text(
                         text = stringResource(R.string.chat_group_info_title),
                         fontSize = 20.sp,
-                        color = Color.Black
+                        color = colorResource(id = R.color.main_text)
                     )
                 },
                 actions = {
@@ -196,7 +196,7 @@ fun ChatDetailDialogComponent(
                         )
                     }
                 },
-                backgroundColor = Color.White,
+                backgroundColor = colorResource(id = R.color.main_background),
                 elevation = 0.dp
             )
         }
@@ -278,7 +278,7 @@ fun ChatDetailDialogComponent(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(Color.White)
+                        .background(colorResource(id = R.color.main_background))
                         .padding(paddingValues)
                 ) {
 
@@ -330,12 +330,13 @@ fun ChatDetailDialogComponent(
                         Text(
                             text = state.profile.fullName.orEmpty(),
                             fontSize = 20.sp,
-                            fontWeight = FontWeight.Bold
+                            fontWeight = FontWeight.Bold,
+                            color = colorResource(id = R.color.main_text)
                         )
                         Text(
                             text = state.profile.nickname.orEmpty(),
                             fontSize = 14.sp,
-                            color = Color.Gray
+                            color = colorResource(id = R.color.secondary_text)
                         )
                         Spacer(modifier = Modifier.height(16.dp))
                         Row {
@@ -438,7 +439,7 @@ fun ChatDetailDialogComponent(
                     TabRow(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(Color.White),
+                            .background(colorResource(id = R.color.main_background)),
                         selectedTabIndex = selectedTabIndex,
                         indicator = { tabPositions ->
                             TabRowDefaults.Indicator(
@@ -460,9 +461,11 @@ fun ChatDetailDialogComponent(
                                             style = TextStyle(
                                                 fontSize = 14.sp,
                                                 fontWeight = if (selectedTabIndex == index) FontWeight.Bold else FontWeight.Bold,
-                                                color = if (selectedTabIndex == index) Color.Black else Color(
-                                                    0xFF8083A0
-                                                )
+                                                color = if (selectedTabIndex == index) {
+                                                    colorResource(id = R.color.main_text)
+                                                } else {
+                                                    colorResource(id = R.color.secondary_text)
+                                                }
                                             )
                                         )
                                     }
@@ -637,7 +640,7 @@ private fun FileItem(
                 onLongClick = { onShowOptions(item) }
             ),
         elevation = 0.dp,
-        backgroundColor = Color.White,
+        backgroundColor = MaterialTheme.colorScheme.surface,
         shape = RoundedCornerShape(16.dp),
         border = BorderStroke(width = 1.dp, color = Color(0xFFE7E9EC))
     ) {
@@ -781,7 +784,7 @@ private fun CallOptionItem(
         Text(
             text = text,
             fontSize = 16.sp,
-            color = Color.Black,
+            color = colorResource(id = R.color.main_text),
             fontWeight = FontWeight.Light,
         )
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -82,7 +83,9 @@ fun ChatDetailDialogSearchComponent(
                         )
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White)
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = colorResource(id = R.color.main_background)
+                )
             )
         }
     ) { paddingValues ->
@@ -96,7 +99,7 @@ fun ChatDetailDialogSearchComponent(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .background(Color.White)
+                .background(colorResource(id = R.color.main_background))
         ) {
             TabRow(
                 selectedTabIndex = selectedTabIndex,
@@ -114,15 +117,19 @@ fun ChatDetailDialogSearchComponent(
                         onClick = { selectedTabIndex = index },
                         text = {
                             Text(
-                                text = title,
-                                maxLines = 1,
-                                style = TextStyle(
-                                    fontSize = 14.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    color = if (selectedTabIndex == index) Color.Black else Color(0xFF8083A0)
-                                )
+                            text = title,
+                            maxLines = 1,
+                            style = TextStyle(
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = if (selectedTabIndex == index) {
+                                    colorResource(id = R.color.main_text)
+                                } else {
+                                    colorResource(id = R.color.secondary_text)
+                                }
                             )
-                        }
+                        )
+                    }
                     )
                 }
             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -117,7 +118,11 @@ fun ChatGroupDetailComponent(
         topBar = {
             androidx.compose.material.TopAppBar(
                 title = {
-                    Text(text = stringResource(R.string.chat_group_info_title), fontSize = 20.sp, color = Color.Black)
+                    Text(
+                        text = stringResource(R.string.chat_group_info_title),
+                        fontSize = 20.sp,
+                        color = colorResource(id = R.color.main_text)
+                    )
                 },
                 actions = {
                     androidx.compose.material.IconButton(onClick = { onSearchClick() }) {
@@ -137,7 +142,7 @@ fun ChatGroupDetailComponent(
                         )
                     }
                 },
-                backgroundColor = Color.White,
+                backgroundColor = colorResource(id = R.color.main_background),
                 elevation = 0.dp
             )
         }
@@ -292,7 +297,7 @@ private fun ParticipantsTabContent(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.White)
+            .background(colorResource(id = R.color.main_background))
             .padding(paddingValues),
         state = listState,
         contentPadding = PaddingValues(bottom = 16.dp)
@@ -339,7 +344,7 @@ private fun OtherTabsContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.White)
+            .background(colorResource(id = R.color.main_background))
             .padding(paddingValues)
     ) {
         GroupHeaderSection(
@@ -416,12 +421,13 @@ private fun GroupHeaderSection(
         Text(
             text = state.name,
             fontSize = 20.sp,
-            fontWeight = FontWeight.Bold
+            fontWeight = FontWeight.Bold,
+            color = colorResource(id = R.color.main_text)
         )
         Text(
             text = state.participants.joinToString(", ") { it.user.fullName.orEmpty() },
             fontSize = 14.sp,
-            color = Color.Gray,
+            color = colorResource(id = R.color.secondary_text),
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center
         )
@@ -490,11 +496,11 @@ private fun GroupTabRow(
     selectedTabIndex: Int,
     onTabSelected: (Int) -> Unit,
 ) {
-    Column(modifier = Modifier.background(Color.White)) {
+    Column(modifier = Modifier.background(colorResource(id = R.color.main_background))) {
         TabRow(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(Color.White),
+                .background(colorResource(id = R.color.main_background)),
             selectedTabIndex = selectedTabIndex,
             indicator = { tabPositions ->
                 val safeIndex = selectedTabIndex.coerceIn(tabTitles.indices)
@@ -516,7 +522,11 @@ private fun GroupTabRow(
                             style = TextStyle(
                                 fontSize = 14.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = if (selectedTabIndex == index) Color.Black else Color(0xFF8083A0)
+                                color = if (selectedTabIndex == index) {
+                                    colorResource(id = R.color.main_text)
+                                } else {
+                                    colorResource(id = R.color.secondary_text)
+                                }
                             )
                         )
                     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTabBar.kt
@@ -208,7 +208,7 @@ fun ChatTabBar(
                             }
                             Box(
                                 modifier = Modifier
-                                    .background(Color.White)
+                                    .background(colorResource(id = R.color.main_background))
                                     .pointerInput(mainFolderId, folder.id) {
                                         detectTapGestures(
                                             onTap = { onTabClick() },

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarComponent.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -37,13 +38,19 @@ fun ChatToolbarComponent(
 ) {
     if (isSelectionMode) {
         TopAppBar(
-            title = { Text(text = selectedCount.toString(), fontSize = 20.sp, color = Color.Black) },
+            title = {
+                Text(
+                    text = selectedCount.toString(),
+                    fontSize = 20.sp,
+                    color = colorResource(id = R.color.main_text)
+                )
+            },
             navigationIcon = {
                 IconButton(onClick = onCloseSelection) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_close),
                         contentDescription = "Close",
-                        tint = Color.Black
+                        tint = colorResource(id = R.color.main_text)
                     )
                 }
             },
@@ -52,18 +59,18 @@ fun ChatToolbarComponent(
                     Icon(
                         painter = painterResource(id = R.drawable.ic_trash),
                         contentDescription = "Delete",
-                        tint = Color.Black
+                        tint = colorResource(id = R.color.main_text)
                     )
                 }
                 IconButton(onClick = onMoreClick) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_more_chat),
                         contentDescription = "More",
-                        tint = Color.Black
+                        tint = colorResource(id = R.color.main_text)
                     )
                 }
             },
-            backgroundColor = Color.White,
+            backgroundColor = colorResource(id = R.color.main_background),
             elevation = 0.dp
         )
     } else {
@@ -76,7 +83,11 @@ fun ChatToolbarComponent(
                         modifier = Modifier.size(36.dp)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = stringResource(R.string.nau_chat), fontSize = 20.sp, color = Color.Black)
+                    Text(
+                        text = stringResource(R.string.nau_chat),
+                        fontSize = 20.sp,
+                        color = colorResource(id = R.color.main_text)
+                    )
                 }
             },
             actions = {
@@ -86,19 +97,19 @@ fun ChatToolbarComponent(
                     Icon(
                         painter = painterResource(id = R.drawable.ic_create_chat),
                         contentDescription = "Edit Icon",
-                        tint = Color.Black
+                        tint = colorResource(id = R.color.main_text)
                     )
                 }
                 IconButton(onClick = { }) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_more_chat),
                         contentDescription = "Edit Icon",
-                        tint = Color.Black
+                        tint = colorResource(id = R.color.main_text)
                     )
                 }
             },
             navigationIcon = null,
-            backgroundColor = Color.White,
+            backgroundColor = colorResource(id = R.color.main_background),
             elevation = 0.dp
         )
     }


### PR DESCRIPTION
## Summary
- adjust chat detail and search dialogs to use themed backgrounds and text colors in dark mode
- update chat list toolbar and folder tabs to avoid white backgrounds
- align group detail header and tabs with dark theme colors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a7105ab883298c6bb7b093bc61c9)