### PR TITLE
Fix dark theme colors in chat screens

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -236,6 +236,7 @@ fun ChatDetailDialogComponent(
                     ModalBottomSheet(
                         onDismissRequest = { showCallOptions = false },
                         sheetState = callSheetState,
+                        containerColor = colorResource(id = R.color.main_background),
                     ) {
                         Column(
                             modifier = Modifier
@@ -346,7 +347,7 @@ fun ChatDetailDialogComponent(
                                     .padding(end = 4.dp)
                                     .background(
                                         shape = RoundedCornerShape(8.dp),
-                                        color = Color(0xFFF5F5F9)
+                                        color = colorResource(id = R.color.background_more_info)
                                     )
                                     .clickable(
                                         interactionSource = remember { MutableInteractionSource() },
@@ -370,7 +371,7 @@ fun ChatDetailDialogComponent(
                                 Text(
                                     text = stringResource(R.string.call_user),
                                     fontSize = 12.sp,
-                                    color = Color(0xFF8083A0)
+                                    color = colorResource(id = R.color.secondary_text)
                                 )
                             }
                             Column(
@@ -379,7 +380,7 @@ fun ChatDetailDialogComponent(
                                     .padding(start = 4.dp, end = 4.dp)
                                     .background(
                                         shape = RoundedCornerShape(8.dp),
-                                        color = Color(0xFFF5F5F9)
+                                        color = colorResource(id = R.color.background_more_info)
                                     )
                                     .clickable(
                                         interactionSource = remember { MutableInteractionSource() },
@@ -401,7 +402,7 @@ fun ChatDetailDialogComponent(
                                 Text(
                                     text = stringResource(R.string.profile_shasre),
                                     fontSize = 12.sp,
-                                    color = Color(0xFF8083A0)
+                                    color = colorResource(id = R.color.secondary_text)
                                 )
                             }
                             Column(
@@ -410,7 +411,7 @@ fun ChatDetailDialogComponent(
                                     .padding(start = 4.dp)
                                     .background(
                                         shape = RoundedCornerShape(8.dp),
-                                        color = Color(0xFFF5F5F9)
+                                        color = colorResource(id = R.color.background_more_info)
                                     )
                                     .clickable(
                                         interactionSource = remember { MutableInteractionSource() },
@@ -430,7 +431,7 @@ fun ChatDetailDialogComponent(
                                 Text(
                                     text = stringResource(R.string.profile_more),
                                     fontSize = 12.sp,
-                                    color = Color(0xFF8083A0)
+                                    color = colorResource(id = R.color.secondary_text)
                                 )
                             }
                         }
@@ -473,7 +474,7 @@ fun ChatDetailDialogComponent(
                             )
                         }
                     }
-                    Divider()
+                    Divider(color = colorResource(id = R.color.main_background_input_stroke))
 
 
                     when (selectedTabIndex) {

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -51,7 +52,8 @@ fun AttachOptionsBottomSheetDialog(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        sheetState = sheetState
+        sheetState = sheetState,
+        containerColor = colorResource(id = R.color.main_background)
     ) {
         Row(
             modifier = Modifier
@@ -107,9 +109,9 @@ private fun BottomSheetItem(
                 .size(56.dp)
                 .background(
                     color = if (isSelected) {
-                        Color(0xFF2E83D9)
+                        colorResource(id = R.color.object_main)
                     } else {
-                        Color(0xFFEAEAF2)
+                        colorResource(id = R.color.background_more_info)
                     },
                     shape = CircleShape
                 ),
@@ -118,11 +120,7 @@ private fun BottomSheetItem(
             Image(
                 painter = icon,
                 contentDescription = text,
-//                tint = if (isSelected) {
-//                    MaterialTheme.colorScheme.onPrimary
-//                } else {
-//                    Color(0xFF8083A0)
-//                },
+                colorFilter = null,
                 modifier = Modifier.size(24.dp)
             )
         }
@@ -130,7 +128,7 @@ private fun BottomSheetItem(
         Text(
             text = text,
             style = MaterialTheme.typography.bodySmall,
-            color = Color.Black,
+            color = colorResource(id = R.color.main_text),
             textAlign = TextAlign.Center,
             maxLines = 2
         )

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -56,7 +57,8 @@ fun ChatFunctionsBottomSheetDialog(
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        sheetState = sheetState
+        sheetState = sheetState,
+        containerColor = colorResource(id = R.color.main_background)
     ) {
         Column(
             modifier = Modifier
@@ -66,7 +68,8 @@ fun ChatFunctionsBottomSheetDialog(
             Text(
                 text = stringResource(R.string.chat_functions_title),
                 style = MaterialTheme.typography.titleMedium.copy(
-                    fontSize = MaterialTheme.typography.titleMedium.fontSize * 1.3f
+                    fontSize = MaterialTheme.typography.titleMedium.fontSize * 1.3f,
+                    color = colorResource(id = R.color.main_text)
                 )
             )
             Spacer(modifier = Modifier.height(10.dp))
@@ -125,7 +128,9 @@ fun ChatFunctionsBottomSheetDialog(
                 ) {
                     Text(
                         text = stringResource(id = textRes),
-                        style = MaterialTheme.typography.bodyLarge,
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            color = colorResource(id = R.color.main_text)
+                        ),
                     )
                 }
             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ShimmerComponents.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ShimmerComponents.kt
@@ -5,10 +5,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
@@ -16,12 +16,14 @@ import com.valentinilk.shimmer.Shimmer
 import com.valentinilk.shimmer.ShimmerBounds
 import com.valentinilk.shimmer.rememberShimmer
 import com.valentinilk.shimmer.shimmer
+import uddug.com.naukoteka.R
 
 @Composable
 fun ChatListShimmer() {
     val shimmer: Shimmer = rememberShimmer(
         shimmerBounds = ShimmerBounds.View
     )
+    val placeholderColor = colorResource(id = R.color.main_background_input_stroke)
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         items((1..10).toList()) { _ ->
             Row(
@@ -35,7 +37,7 @@ fun ChatListShimmer() {
                     modifier = Modifier
                         .size(48.dp)
                         .clip(CircleShape)
-                        .background(Color(0xFFE0E0E0))
+                        .background(placeholderColor)
                 )
                 Spacer(modifier = Modifier.width(16.dp))
                 Column(modifier = Modifier.fillMaxWidth()) {
@@ -44,7 +46,7 @@ fun ChatListShimmer() {
                             .fillMaxWidth(0.6f)
                             .height(14.dp)
                             .clip(RoundedCornerShape(4.dp))
-                            .background(Color(0xFFE0E0E0))
+                            .background(placeholderColor)
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     Box(
@@ -52,7 +54,7 @@ fun ChatListShimmer() {
                             .fillMaxWidth(0.4f)
                             .height(12.dp)
                             .clip(RoundedCornerShape(4.dp))
-                            .background(Color(0xFFE0E0E0))
+                            .background(placeholderColor)
                     )
                 }
             }
@@ -65,6 +67,7 @@ fun MessageListShimmer() {
     val shimmer: Shimmer = rememberShimmer(
         shimmerBounds = ShimmerBounds.View
     )
+    val placeholderColor = colorResource(id = R.color.main_background_input_stroke)
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -83,7 +86,7 @@ fun MessageListShimmer() {
                         .width(100.dp)
                         .height(30.dp)
                         .clip(RoundedCornerShape(12.dp))
-                        .background(Color(0xFFE0E0E0))
+                        .background(placeholderColor)
                         .shimmer(shimmer)
                 )
             }
@@ -96,6 +99,7 @@ fun ChatDetailShimmer() {
     val shimmer: Shimmer = rememberShimmer(
         shimmerBounds = ShimmerBounds.View
     )
+    val placeholderColor = colorResource(id = R.color.main_background_input_stroke)
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -108,7 +112,7 @@ fun ChatDetailShimmer() {
                     .height(80.dp)
                     .padding(vertical = 8.dp)
                     .clip(RoundedCornerShape(8.dp))
-                    .background(Color(0xFFE0E0E0))
+                    .background(placeholderColor)
                     .shimmer(shimmer)
             )
         }


### PR DESCRIPTION
## Summary
- adjust chat detail action buttons to use theme-aware backgrounds and text colors
- apply dark-theme colors to attachment picker sheet and chat function bottom sheet
- update shimmer placeholders to follow themed background colors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a9590e448329b7c51917146fe413)