### PR TITLE
Fix dark theme for chat creation and folder settings

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateMultiScreen.kt
@@ -8,12 +8,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -37,7 +37,7 @@ fun ChatCreateMultiScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(color = Color.White)
+            .background(color = MaterialTheme.colors.background)
     ) {
         ChatToolbarCreateSingleComponent(
             onBackPressed = onBackPressed,
@@ -67,7 +67,7 @@ fun ChatCreateMultiScreen(
                             Text(
                                 text = stringResource(R.string.search_country),
                                 fontSize = 18.sp,
-                                color = Color.Black,
+                                color = MaterialTheme.colors.onBackground,
                             )
                         }
                         items(state.searchResults) { user ->
@@ -88,7 +88,7 @@ fun ChatCreateMultiScreen(
                         Text(
                             text = stringResource(R.string.subs),
                             fontSize = 18.sp,
-                            color = Color.Black,
+                            color = MaterialTheme.colors.onBackground,
                             modifier = Modifier.padding(vertical = 10.dp)
                         )
                     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateSingleScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -20,10 +21,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -46,7 +45,7 @@ fun ChatCreateSingleScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(color = Color.White)
+            .background(color = MaterialTheme.colors.background)
     ) {
         ChatToolbarCreateSingleComponent(
             onBackPressed = onBackPressed
@@ -74,7 +73,7 @@ fun ChatCreateSingleScreen(
                             Text(
                                 text = stringResource(R.string.search_country),
                                 fontSize = 18.sp,
-                                color = Color.Black,
+                                color = MaterialTheme.colors.onBackground,
                             )
                         }
                         items(state.searchResults) { user ->
@@ -103,13 +102,13 @@ fun ChatCreateSingleScreen(
                             Icon(
                                 painter = painterResource(id = R.drawable.ic_add_users_chat),
                                 contentDescription = "Edit Icon",
-                                tint = Color(0xFF2E83D9)
+                                tint = MaterialTheme.colors.primary
                             )
                             Text(
                                 modifier = Modifier.padding(start = 8.dp),
                                 text = stringResource(R.string.create_group_chat),
                                 fontSize = 18.sp,
-                                color = Color.Black,
+                                color = MaterialTheme.colors.onBackground,
                             )
                         }
                     }
@@ -118,7 +117,7 @@ fun ChatCreateSingleScreen(
                         Text(
                             text = stringResource(R.string.subs),
                             fontSize = 18.sp,
-                            color = Color.Black,
+                            color = MaterialTheme.colors.onBackground,
                             fontWeight = FontWeight.Bold,
                             modifier = Modifier.padding(vertical = 10.dp)
                         )

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatFolderSettingsComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatFolderSettingsComponent.kt
@@ -9,20 +9,18 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Done
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -35,6 +33,7 @@ import org.burnoutcrew.reorderable.rememberReorderableLazyListState
 import org.burnoutcrew.reorderable.reorderable
 import uddug.com.naukoteka.R
 import uddug.com.naukoteka.mvvm.chat.ChatListViewModel
+import uddug.com.naukoteka.ui.theme.NauTheme
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -55,7 +54,7 @@ fun ChatFolderSettingsComponent(
                 title = {
                     Text(
                         text = stringResource(R.string.chat_folder_settings_title),
-                        color = Color.Black
+                        color = MaterialTheme.colors.onBackground
                     )
                 },
                 navigationIcon = {
@@ -63,7 +62,7 @@ fun ChatFolderSettingsComponent(
                         Icon(
                             Icons.Filled.ArrowBack,
                             contentDescription = null,
-                            tint = Color(0xFF2E83D9)
+                            tint = MaterialTheme.colors.primary
                         )
                     }
                 },
@@ -75,11 +74,11 @@ fun ChatFolderSettingsComponent(
                         Icon(
                             imageVector = Icons.Filled.Done,
                             contentDescription = null,
-                            tint = if (isFolderOrderChanged) Color(0xFF2E83D9) else Color(0xFFBFC4D5)
+                            tint = if (isFolderOrderChanged) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface.copy(alpha = 0.3f)
                         )
                     }
                 },
-                backgroundColor = Color.White,
+                backgroundColor = MaterialTheme.colors.background,
                 elevation = 0.dp
             )
         }
@@ -87,28 +86,28 @@ fun ChatFolderSettingsComponent(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color.White)
+                .background(MaterialTheme.colors.background)
                 .padding(padding)
         ) {
             Text(
                 text = stringResource(R.string.chat_folder_settings_description),
                 modifier = Modifier.padding(16.dp),
                 fontSize = 14.sp,
-                color = Color(0xFF8083A0)
+                color = NauTheme.extendedColors.inactive
             )
             Text(
                 text = stringResource(R.string.chat_folder_settings_selected_chats),
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Medium,
-                color = Color.Black
+                color = MaterialTheme.colors.onBackground
             )
             androidx.compose.material.TextButton(
                 onClick = onCreateFolderClick,
             ) {
                 Text(
                     text = stringResource(R.string.chat_folder_settings_add_folder),
-                    color = Color(0xFF2E83D9),
+                    color = MaterialTheme.colors.primary,
                     style = TextStyle.Default
                 )
             }
@@ -118,7 +117,7 @@ fun ChatFolderSettingsComponent(
                     .fillMaxWidth()
                     .padding(start = 20.dp, end = 20.dp)
                     .wrapContentHeight()
-                    .background(Color(0xFFf6f5f9), shape = RoundedCornerShape(16.dp))
+                    .background(NauTheme.extendedColors.backgroundMoreInfo, shape = RoundedCornerShape(16.dp))
             ) {
 
                 LazyColumn(
@@ -147,7 +146,7 @@ fun ChatFolderSettingsComponent(
                                         .weight(1f)
                                         .padding(horizontal = 16.dp),
                                     fontSize = 16.sp,
-                                    color = Color.Black
+                                    color = MaterialTheme.colors.onBackground
                                 )
                                 Image(
                                     painter = painterResource(id = R.drawable.ic_move_folders),

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
@@ -4,13 +4,13 @@ package uddug.com.naukoteka.ui.chat.compose.components
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -29,7 +29,11 @@ fun ChatToolbarCreateSingleComponent(
     TopAppBar(
         title = {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(text = stringResource(R.string.chat_create_single_title), fontSize = 20.sp, color = Color.Black)
+                Text(
+                    text = stringResource(R.string.chat_create_single_title),
+                    fontSize = 20.sp,
+                    color = MaterialTheme.colors.onBackground
+                )
             }
         },
         actions = {
@@ -38,7 +42,7 @@ fun ChatToolbarCreateSingleComponent(
                     Icon(
                         painter = painterResource(id = R.drawable.ic_chat_create_apply),
                         contentDescription = "Edit Icon",
-                        tint = if (isActionEnabled) Color(0xFF2E83D9) else Color(0x4D2E83D9)
+                        tint = if (isActionEnabled) MaterialTheme.colors.primary else MaterialTheme.colors.primary.copy(alpha = 0.3f)
                     )
                 }
             }
@@ -48,11 +52,11 @@ fun ChatToolbarCreateSingleComponent(
                 Icon(
                     painter = painterResource(id = R.drawable.ic_chat_back),
                     contentDescription = "Edit Icon",
-                    tint = Color(0xFF2E83D9)
+                    tint = MaterialTheme.colors.primary
                 )
             }
         },
-        backgroundColor = Color.White,
+        backgroundColor = MaterialTheme.colors.background,
         elevation = 0.dp
     )
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/CreateChatMemberCard.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/CreateChatMemberCard.kt
@@ -6,10 +6,10 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -44,7 +44,7 @@ fun CreateChatMemberCard(
                 }
                 onMemberClick()
             },
-        colors = CardDefaults.cardColors(containerColor = Color.White)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colors.surface)
     ) {
         Column {
             Row(
@@ -61,7 +61,11 @@ fun CreateChatMemberCard(
                             onMemberClick()
                         },
                         modifier = Modifier.size(24.dp),
-                        colors = CheckboxDefaults.colors(checkedColor = Color(0xFF2E83D9))
+                        colors = CheckboxDefaults.colors(
+                            checkedColor = MaterialTheme.colors.primary,
+                            uncheckedColor = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                            checkmarkColor = MaterialTheme.colors.onPrimary,
+                        )
                     )
                     Spacer(modifier = Modifier.width(16.dp))
                 }
@@ -77,7 +81,7 @@ fun CreateChatMemberCard(
                                 stringResource(R.string.group_chat)
                             } else {
                                 name
-                            }, style = TextStyle(fontSize = 16.sp, color = Color.Black)
+                            }, style = TextStyle(fontSize = 16.sp, color = MaterialTheme.colors.onSurface)
                         )
                     }
 
@@ -91,7 +95,11 @@ fun CreateChatMemberCard(
                             onMemberClick()
                         },
                         modifier = Modifier.size(24.dp),
-                        colors = CheckboxDefaults.colors(checkedColor = Color(0xFF2E83D9))
+                        colors = CheckboxDefaults.colors(
+                            checkedColor = MaterialTheme.colors.primary,
+                            uncheckedColor = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                            checkmarkColor = MaterialTheme.colors.onPrimary,
+                        )
                     )
                 }
             }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/SearchField.kt
@@ -12,16 +12,17 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import uddug.com.naukoteka.R
+import uddug.com.naukoteka.ui.theme.NauTheme
 
 @Composable
 fun SearchField(
@@ -39,7 +40,7 @@ fun SearchField(
             .padding(horizontal = 16.dp, vertical = 8.dp)
             .background(
                 shape = RoundedCornerShape(16.dp),
-                color = Color(0xFFEAEAF2)
+                color = NauTheme.extendedColors.inputBackground
             )
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -47,14 +48,14 @@ fun SearchField(
         Icon(
             painter = painterResource(id = R.drawable.ic_search),
             contentDescription = "Search",
-            tint = Color.Gray,
+            tint = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
             modifier = Modifier.size(18.dp)
         )
 
         BasicTextField(
             value = query,
             onValueChange = { onSearchChanged(it) },
-            textStyle = LocalTextStyle.current.copy(color = Color.Black),
+            textStyle = LocalTextStyle.current.copy(color = MaterialTheme.colors.onBackground),
             modifier = Modifier
                 .weight(1f)
                 .onFocusChanged { onFocusChanged(it.isFocused) }
@@ -67,7 +68,7 @@ fun SearchField(
                     if (query.isEmpty()) {
                         Text(
                             text = title,
-                            color = Color(0xFF8083A0),
+                            color = NauTheme.extendedColors.inactive,
                             textAlign = if (placeholderCentered) TextAlign.Center else TextAlign.Start,
                             modifier = Modifier.fillMaxWidth()
                         )
@@ -90,7 +91,7 @@ fun SearchField(
                 Icon(
                     painter = painterResource(id = R.drawable.ic_close),
                     contentDescription = "Clear search",
-                    tint = Color.Gray,
+                    tint = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
                     modifier = Modifier.size(18.dp)
                 )
             }


### PR DESCRIPTION
## Summary
- apply themed colors to chat creation screens so dark mode is respected
- align chat folder settings UI with Material theme colors for dark mode
- update shared chat UI components (toolbar, search, member cards) to use theme palettes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931aa0c6184832987b6a6f75a3f5da0)