### PR TITLE
Ensure bottom navigation icons above labels

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,6 +30,7 @@
             app:elevation="4dp"
             android:theme="@style/NauWidget.BottomNavigationView"
             app:itemIconTint="@color/bnv_tab_item_foreground"
+            app:itemIconGravity="top"
             app:itemTextColor="@color/bnv_tab_item_foreground"
             app:labelVisibilityMode="labeled"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -28,6 +28,7 @@
             android:layout_marginBottom="22dp"
             android:showAsAction="always|withText"
             app:elevation="4dp"
+            app:itemIconGravity="top"
             app:layout_constraintBottom_toBottomOf="parent"
             app:menu="@menu/menu_bottom" />
 


### PR DESCRIPTION
## Summary
- force bottom navigation icons to appear above their labels in both activity and fragment layouts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931aa5753d48329abf3703344b3ab68)