### PR TITLE
Load user avatar in chat toolbar

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarComponent.kt
@@ -11,6 +11,8 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -74,12 +76,13 @@ fun ChatToolbarComponent(
             elevation = 0.dp
         )
     } else {
+        val currentUser by viewModel.currentUser.collectAsState()
         TopAppBar(
             title = {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.mock_avatar),
-                        contentDescription = "User Icon",
+                    Avatar(
+                        url = currentUser?.image?.path,
+                        name = currentUser?.fullName ?: currentUser?.nickname,
                         modifier = Modifier.size(36.dp)
                     )
                     Spacer(modifier = Modifier.width(8.dp))


### PR DESCRIPTION
## Summary
- fetch the current user profile when opening the chat list
- expose the avatar data to the chat toolbar and render it like NauSphere

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931ab11c67483298862e65aff6af312)