### PR TITLE
Fix room reference set before publishing

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -93,9 +93,9 @@ class FlashphonerSessionManager @Inject constructor(
             ?: error("Flashphoner room manager must be prepared before joining rooms")
         val options = RoomOptions().apply { name = roomName }
         val room = manager.join(options)
+        roomRef.set(room)
         roomEvent?.invoke(room)
         onRoomReady(room)
-        roomRef.set(room)
         return room
     }
 


### PR DESCRIPTION
## Summary
- set room reference immediately after joining to ensure publish uses active room

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c625e99c8329b8d02e56ebfef0ae)