### PR TITLE
Add incoming call waiting screen

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
@@ -39,15 +39,28 @@ class SingleCallFragment : Fragment() {
         val participants = arguments?.getParcelableArrayList<CallParticipant>(ARG_PARTICIPANTS)
         val dialogId = arguments?.getLong(ARG_DIALOG_ID)
         val isVideoCall = arguments?.getBoolean(ARG_IS_VIDEO_CALL) ?: true
+        val isIncomingCall = arguments?.getBoolean(ARG_IS_INCOMING_CALL) ?: false
+        val resolvedDialogId = dialogId ?: viewModel.uiState.value.dialogId ?: 0L
 
-        viewModel.startCall(
-            dialogId = dialogId ?: viewModel.uiState.value.dialogId ?: 0L,
-            contactName = contactName,
-            avatarUrl = avatarUrl,
-            participants = participants,
-            callTitle = callTitle,
-            isVideoCall = isVideoCall,
-        )
+        if (isIncomingCall) {
+            viewModel.showIncomingCall(
+                dialogId = resolvedDialogId,
+                contactName = contactName,
+                avatarUrl = avatarUrl,
+                participants = participants,
+                callTitle = callTitle,
+                isVideoCall = isVideoCall,
+            )
+        } else {
+            viewModel.startCall(
+                dialogId = resolvedDialogId,
+                contactName = contactName,
+                avatarUrl = avatarUrl,
+                participants = participants,
+                callTitle = callTitle,
+                isVideoCall = isVideoCall,
+            )
+        }
 
         return ComposeView(requireContext()).apply {
             setContent {
@@ -59,6 +72,18 @@ class SingleCallFragment : Fragment() {
                         onEndCall = {
                             viewModel.endCall()
                         },
+                        onAcceptCall = {
+                            viewModel.startCall(
+                                dialogId = resolvedDialogId,
+                                contactName = contactName,
+                                avatarUrl = avatarUrl,
+                                participants = participants,
+                                callTitle = callTitle,
+                                isVideoCall = isVideoCall,
+                                isAcceptingIncomingCall = isIncomingCall,
+                            )
+                        },
+                        onDeclineCall = viewModel::endCall,
                         onToggleMicrophone = viewModel::toggleMicrophone,
                         onToggleCamera = viewModel::toggleCamera,
                         onMinimize = {
@@ -126,5 +151,6 @@ class SingleCallFragment : Fragment() {
         const val ARG_PARTICIPANTS = "participants"
         const val ARG_DIALOG_ID = "dialog_id"
         const val ARG_IS_VIDEO_CALL = "is_video_call"
+        const val ARG_IS_INCOMING_CALL = "is_incoming_call"
     }
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatDialogFragment.kt
@@ -104,6 +104,7 @@ class ChatDialogFragment : Fragment() {
                                     putString(SingleCallFragment.ARG_AVATAR_URL, state.avatarUrl)
                                     putLong(SingleCallFragment.ARG_DIALOG_ID, state.dialogId)
                                     putString(SingleCallFragment.ARG_CALL_TITLE, state.callTitle)
+                                    putBoolean(SingleCallFragment.ARG_IS_INCOMING_CALL, true)
                                 }
                             )
                         }

--- a/app/src/main/res/navigation/nav_graph_chat.xml
+++ b/app/src/main/res/navigation/nav_graph_chat.xml
@@ -136,6 +136,10 @@
             android:name="is_video_call"
             app:argType="boolean"
             android:defaultValue="true" />
+        <argument
+            android:name="is_incoming_call"
+            app:argType="boolean"
+            android:defaultValue="false" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -466,9 +466,15 @@ To delete a folder or change the sorting order, tap the “Edit” button.</stri
     <string name="call_user">Позвонить</string>
     <string name="call_status_connecting">Подключаемся…</string>
     <string name="call_status_dialing">Идет звонок</string>
+    <string name="call_status_incoming">Входящий звонок</string>
     <string name="call_status_finished">Звонок завершен</string>
     <string name="call_status_loading">Загрузка…</string>
     <string name="call_status_in_call">Звонок</string>
+    <string name="call_incoming_audio">Аудио …</string>
+    <string name="call_incoming_accept">Принять</string>
+    <string name="call_incoming_decline">Отклонить</string>
+    <string name="call_incoming_remind">Напомнить</string>
+    <string name="call_incoming_message">Сообщение</string>
     <string name="call_create_title">Создать звонок</string>
     <string name="call_audio">Аудиозвонок</string>
     <string name="call_video">Видеозвонок</string>


### PR DESCRIPTION
## Summary
- add a dedicated incoming call state with accept/decline controls
- update navigation and view model flow so incoming calls wait for user action before connecting
- refresh the call compose UI to match the new incoming call design

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932cc780af88329b0d09ac583c36417)