### PR TITLE
Make chat toolbars and sheets white

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatAvatarPreviewFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/ChatAvatarPreviewFragment.kt
@@ -70,19 +70,19 @@ private fun ChatAvatarPreviewScreen(
             TopAppBar(
                 title = { Text(text = stringResource(R.string.chat_avatar_preview_title)) },
                 navigationIcon = {
-                    IconButton(onClick = onBackPressed) {
-                        Icon(
-                            imageVector = Icons.Default.ArrowBack,
-                            contentDescription = null,
-                            tint = MaterialTheme.colors.primary,
-                        )
-                    }
-                },
-                backgroundColor = MaterialTheme.colors.surface,
-                elevation = 0.dp
-            )
-        },
-        backgroundColor = MaterialTheme.colors.background
+                IconButton(onClick = onBackPressed) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = null,
+                        tint = MaterialTheme.colors.primary,
+                    )
+                }
+            },
+            backgroundColor = Color.White,
+            elevation = 0.dp
+        )
+    },
+        backgroundColor = Color.White
     ) { padding ->
         Box(
             modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateGroupScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatCreateGroupScreen.kt
@@ -473,7 +473,8 @@ private fun GroupMemberActionsBottomSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        sheetState = sheetState
+        sheetState = sheetState,
+        containerColor = Color.White
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -172,7 +172,7 @@ fun ChatDetailDialogComponent(
                     Text(
                         text = stringResource(R.string.chat_group_info_title),
                         fontSize = 20.sp,
-                        color = MaterialTheme.colorScheme.onBackground
+                        color = Color(0xFF10101C)
                     )
                 },
                 actions = {
@@ -196,7 +196,7 @@ fun ChatDetailDialogComponent(
                         )
                     }
                 },
-                backgroundColor = MaterialTheme.colorScheme.background,
+                backgroundColor = Color.White,
                 elevation = 0.dp
             )
         }
@@ -236,7 +236,7 @@ fun ChatDetailDialogComponent(
                     ModalBottomSheet(
                         onDismissRequest = { showCallOptions = false },
                         sheetState = callSheetState,
-                        containerColor = MaterialTheme.colorScheme.background,
+                        containerColor = Color.White,
                     ) {
                         Column(
                             modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -83,7 +84,7 @@ fun ChatDetailDialogSearchComponent(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background
+                    containerColor = Color.White
                 )
             )
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditGroupScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatEditGroupScreen.kt
@@ -424,7 +424,8 @@ private fun GroupMemberActionsBottomSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        sheetState = sheetState
+        sheetState = sheetState,
+        containerColor = Color.White
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatFolderSettingsComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatFolderSettingsComponent.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -54,7 +55,7 @@ fun ChatFolderSettingsComponent(
                 title = {
                     Text(
                         text = stringResource(R.string.chat_folder_settings_title),
-                        color = MaterialTheme.colors.onBackground
+                        color = Color(0xFF10101C)
                     )
                 },
                 navigationIcon = {
@@ -78,7 +79,7 @@ fun ChatFolderSettingsComponent(
                         )
                     }
                 },
-                backgroundColor = MaterialTheme.colors.background,
+                backgroundColor = Color.White,
                 elevation = 0.dp
             )
         }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatGroupDetailComponent.kt
@@ -121,7 +121,7 @@ fun ChatGroupDetailComponent(
                     Text(
                         text = stringResource(R.string.chat_group_info_title),
                         fontSize = 20.sp,
-                        color = colorResource(id = R.color.main_text)
+                        color = Color(0xFF10101C)
                     )
                 },
                 actions = {
@@ -142,7 +142,7 @@ fun ChatGroupDetailComponent(
                         )
                     }
                 },
-                backgroundColor = colorResource(id = R.color.main_background),
+                backgroundColor = Color.White,
                 elevation = 0.dp
             )
         }
@@ -687,7 +687,8 @@ private fun ParticipantActionsBottomSheet(
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        sheetState = sheetState
+        sheetState = sheetState,
+        containerColor = Color.White
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatPollResultsScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatPollResultsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -88,12 +89,12 @@ fun ChatPollResultsScreen(
                 elevation = 0.dp
             )
         },
-        backgroundColor = MaterialTheme.colors.background
+        backgroundColor = Color.White
     ) { paddingValues ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colors.background)
+                .background(Color.White)
                 .padding(paddingValues)
         ) {
             when {
@@ -327,16 +328,16 @@ private fun PollResultsError(
 }
 
 @Composable
-private fun primaryTextColor() = MaterialTheme.colors.onSurface
+private fun primaryTextColor() = Color(0xFF1F1F1F)
 
 @Composable
-private fun secondaryTextColor() = MaterialTheme.colors.onSurface.copy(alpha = 0.7f)
+private fun secondaryTextColor() = Color(0xFF8083A0)
 
 @Composable
-private fun accentColor() = MaterialTheme.colors.primary
+private fun accentColor() = Color(0xFF2E83D9)
 
 @Composable
-private fun surfaceColor() = MaterialTheme.colors.surface
+private fun surfaceColor() = Color.White
 
 @Composable
 private fun questionBackgroundColor() = NauTheme.extendedColors.backgroundMoreInfo

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/AttachOptionsBottomSheetDialog.kt
@@ -53,7 +53,7 @@ fun AttachOptionsBottomSheetDialog(
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        containerColor = colorResource(id = R.color.main_background)
+        containerColor = Color.White
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatDetailMoreSheetDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -56,7 +57,8 @@ fun ChatDetailMoreSheetDialog(
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        sheetState = sheetState
+        sheetState = sheetState,
+        containerColor = Color.White
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatFunctionsBottomSheetDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -58,7 +59,7 @@ fun ChatFunctionsBottomSheetDialog(
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        containerColor = colorResource(id = R.color.main_background)
+        containerColor = Color.White
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarComponent.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -44,7 +43,7 @@ fun ChatToolbarComponent(
                 Text(
                     text = selectedCount.toString(),
                     fontSize = 20.sp,
-                    color = colorResource(id = R.color.main_text)
+                    color = Color(0xFF10101C)
                 )
             },
             navigationIcon = {
@@ -52,7 +51,7 @@ fun ChatToolbarComponent(
                     Icon(
                         painter = painterResource(id = R.drawable.ic_close),
                         contentDescription = "Close",
-                        tint = colorResource(id = R.color.main_text)
+                        tint = Color(0xFF10101C)
                     )
                 }
             },
@@ -61,18 +60,18 @@ fun ChatToolbarComponent(
                     Icon(
                         painter = painterResource(id = R.drawable.ic_trash),
                         contentDescription = "Delete",
-                        tint = colorResource(id = R.color.main_text)
+                        tint = Color(0xFF10101C)
                     )
                 }
                 IconButton(onClick = onMoreClick) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_more_chat),
                         contentDescription = "More",
-                        tint = colorResource(id = R.color.main_text)
+                        tint = Color(0xFF10101C)
                     )
                 }
             },
-            backgroundColor = colorResource(id = R.color.main_background),
+            backgroundColor = Color.White,
             elevation = 0.dp
         )
     } else {
@@ -89,7 +88,7 @@ fun ChatToolbarComponent(
                     Text(
                         text = stringResource(R.string.nau_chat),
                         fontSize = 20.sp,
-                        color = colorResource(id = R.color.main_text)
+                        color = Color(0xFF10101C)
                     )
                 }
             },
@@ -100,19 +99,19 @@ fun ChatToolbarComponent(
                     Icon(
                         painter = painterResource(id = R.drawable.ic_create_chat),
                         contentDescription = "Edit Icon",
-                        tint = colorResource(id = R.color.main_text)
+                        tint = Color(0xFF10101C)
                     )
                 }
                 IconButton(onClick = { }) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_more_chat),
                         contentDescription = "Edit Icon",
-                        tint = colorResource(id = R.color.main_text)
+                        tint = Color(0xFF10101C)
                     )
                 }
             },
             navigationIcon = null,
-            backgroundColor = colorResource(id = R.color.main_background),
+            backgroundColor = Color.White,
             elevation = 0.dp
         )
     }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatToolbarCreateSingleComponent.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -32,7 +33,7 @@ fun ChatToolbarCreateSingleComponent(
                 Text(
                     text = stringResource(R.string.chat_create_single_title),
                     fontSize = 20.sp,
-                    color = MaterialTheme.colors.onBackground
+                    color = Color(0xFF10101C)
                 )
             }
         },
@@ -56,7 +57,7 @@ fun ChatToolbarCreateSingleComponent(
                 )
             }
         },
-        backgroundColor = MaterialTheme.colors.background,
+        backgroundColor = Color.White,
         elevation = 0.dp
     )
 }

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/ChatTopBar.kt
@@ -44,7 +44,7 @@ fun ChatTopBar(
     onBackPressed: () -> Unit,
     onMoreClick: () -> Unit,
 ) {
-    Surface(elevation = 4.dp) {
+    Surface(elevation = 4.dp, color = Color.White) {
         Column {
             Row(
                 modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/FileFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/FileFunctionsBottomSheetDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import uddug.com.naukoteka.R
@@ -42,6 +43,7 @@ fun FileFunctionsBottomSheetDialog(
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
+        containerColor = Color.White,
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/components/MessageFunctionsBottomSheetDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -47,7 +48,8 @@ fun MessageFunctionsBottomSheetDialog(
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        sheetState = sheetState
+        sheetState = sheetState,
+        containerColor = Color.White
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
## Summary
- set chat toolbars to always use a white background and dark content across chat screens
- force bottom sheet container colors in chat components to white to match the light toolbar design
- align chat poll results layout with white surfaces and fixed text colors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d6c852908329bddfa16112b8adbe)