### PR TITLE
Ensure minimizing calls returns to chats

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/call/GroupCallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/GroupCallFragment.kt
@@ -59,7 +59,7 @@ class GroupCallFragment : Fragment() {
                         onMinimize = {
                             if (!((requireActivity() as? ContainerActivity)?.enterCallPictureInPictureMode() ?: false)) {
                                 showFloatingCall()
-                                findNavController().popBackStack()
+                                navigateBackToChatList()
                             }
                         },
                     )
@@ -111,6 +111,14 @@ class GroupCallFragment : Fragment() {
             requireActivity().supportFragmentManager.beginTransaction()
                 .remove(it)
                 .commitAllowingStateLoss()
+        }
+    }
+
+    private fun navigateBackToChatList() {
+        val navController = requireActivity().findNavController(R.id.main_nav_host_fragment)
+        val popped = navController.popBackStack(R.id.chatListFragment, false)
+        if (!popped) {
+            navController.navigate(R.id.chatListFragment)
         }
     }
 

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
@@ -87,7 +87,7 @@ class SingleCallFragment : Fragment() {
                         onToggleCamera = viewModel::toggleCamera,
                         onMinimize = {
                             showFloatingCall()
-                            findNavController().popBackStack()
+                            navigateBackToChatList()
                         },
                     )
                 }
@@ -131,6 +131,14 @@ class SingleCallFragment : Fragment() {
         viewModel.endCall()
         removeFloatingCall()
         findNavController().popBackStack()
+    }
+
+    private fun navigateBackToChatList() {
+        val navController = requireActivity().findNavController(R.id.main_nav_host_fragment)
+        val popped = navController.popBackStack(R.id.chatListFragment, false)
+        if (!popped) {
+            navController.navigate(R.id.chatListFragment)
+        }
     }
 
     private fun removeFloatingCall() {


### PR DESCRIPTION
## Summary
- ensure minimizing calls shows the draggable floating view and returns to the chat list
- add navigation fallback to open the chat list when back stack popping is not possible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932fb8b2c7c83299a87782dfe4613b6)