### PR TITLE
Fix tab backgrounds in chat detail screens

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogComponent.kt
@@ -441,8 +441,9 @@ fun ChatDetailDialogComponent(
                     TabRow(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(MaterialTheme.colorScheme.background),
+                            .background(Color.White),
                         selectedTabIndex = selectedTabIndex,
+                        containerColor = Color.White,
                         indicator = { tabPositions ->
                             TabRowDefaults.Indicator(
                                 Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),

--- a/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/chat/compose/ChatDetailDialogSearchComponent.kt
@@ -103,6 +103,7 @@ fun ChatDetailDialogSearchComponent(
         ) {
             TabRow(
                 selectedTabIndex = selectedTabIndex,
+                containerColor = Color.White,
                 indicator = { tabPositions ->
                     TabRowDefaults.Indicator(
                         Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),


### PR DESCRIPTION
## Summary
- ensure chat detail dialog tabs use a white background in light theme
- align chat search tabs with the same white container color

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932fc26daf0832983563d8b0f948b1b)