### PR TITLE
Add call recording API integration

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/ui/call/GroupCallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/GroupCallFragment.kt
@@ -56,6 +56,7 @@ class GroupCallFragment : Fragment() {
                         onDeclineCall = viewModel::endCall,
                         onToggleMicrophone = viewModel::toggleMicrophone,
                         onToggleCamera = viewModel::toggleCamera,
+                        onToggleRecording = viewModel::toggleRecording,
                         onMinimize = {
                             if (!((requireActivity() as? ContainerActivity)?.enterCallPictureInPictureMode() ?: false)) {
                                 showFloatingCall()

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/SingleCallFragment.kt
@@ -85,6 +85,7 @@ class SingleCallFragment : Fragment() {
                         onDeclineCall = viewModel::endCall,
                         onToggleMicrophone = viewModel::toggleMicrophone,
                         onToggleCamera = viewModel::toggleCamera,
+                        onToggleRecording = viewModel::toggleRecording,
                         onMinimize = {
                             showFloatingCall()
                             navigateBackToChatList()

--- a/app/src/main/java/uddug/com/naukoteka/ui/call/compose/CallScreen.kt
+++ b/app/src/main/java/uddug/com/naukoteka/ui/call/compose/CallScreen.kt
@@ -1,5 +1,11 @@
 package uddug.com.naukoteka.ui.call.compose
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -47,6 +53,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
@@ -72,6 +79,7 @@ fun CallScreen(
     onDeclineCall: () -> Unit,
     onToggleMicrophone: () -> Unit,
     onToggleCamera: () -> Unit,
+    onToggleRecording: () -> Unit,
     onMinimize: () -> Unit,
 ) {
     val backgroundColor = Color(0xFF0B1020)
@@ -108,7 +116,8 @@ fun CallScreen(
                 callDurationSeconds = state.callDurationSeconds,
                 onOpenChat = {},
                 onShowParticipants = { isParticipantsSheetVisible = true },
-                onStartRecording = {},
+                isRecording = state.isRecording,
+                onToggleRecording = onToggleRecording,
                 onMinimize = onMinimize,
             )
         }
@@ -354,9 +363,25 @@ private fun CallTopBar(
     callDurationSeconds: Int,
     onOpenChat: () -> Unit,
     onShowParticipants: () -> Unit,
-    onStartRecording: () -> Unit,
+    isRecording: Boolean,
+    onToggleRecording: () -> Unit,
     onMinimize: () -> Unit,
 ) {
+    val recordingScale = if (isRecording) {
+        val infiniteTransition = rememberInfiniteTransition(label = "record_scale_transition")
+        infiniteTransition.animateFloat(
+            initialValue = 1f,
+            targetValue = 1.15f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 800, easing = FastOutSlowInEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "record_scale",
+        ).value
+    } else {
+        1f
+    }
+
     Surface(color = containerColor) {
         Row(
             modifier = Modifier
@@ -400,7 +425,10 @@ private fun CallTopBar(
                     )
                 }
 
-                IconButton(onClick = onStartRecording) {
+                IconButton(
+                    onClick = onToggleRecording,
+                    modifier = Modifier.scale(recordingScale),
+                ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_call_record),
                         contentDescription = stringResource(R.string.call_record),

--- a/data/src/main/java/uddug/com/data/repositories/call/CallRepositoryImpl.kt
+++ b/data/src/main/java/uddug/com/data/repositories/call/CallRepositoryImpl.kt
@@ -66,4 +66,12 @@ class CallRepositoryImpl @Inject constructor(
     override suspend fun stopCall(callId: Long) {
         callApiService.stopCall(callId)
     }
+
+    override suspend fun startRecording(dialogId: Long) {
+        callApiService.startRecording(dialogId)
+    }
+
+    override suspend fun stopRecording(dialogId: Long) {
+        callApiService.stopRecording(dialogId)
+    }
 }

--- a/data/src/main/java/uddug/com/data/services/CallApiService.kt
+++ b/data/src/main/java/uddug/com/data/services/CallApiService.kt
@@ -4,6 +4,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import uddug.com.data.services.models.request.call.UpdateCallPermitsRequestDto
 import uddug.com.data.services.models.request.call.UpdateCallStateRequestDto
@@ -38,5 +39,15 @@ interface CallApiService {
     @POST("calls/{callId}/stop")
     suspend fun stopCall(
         @Path("callId") callId: Long,
+    )
+
+    @PUT("calls/record/start/dialog/{dialogId}")
+    suspend fun startRecording(
+        @Path("dialogId") dialogId: Long,
+    )
+
+    @PUT("calls/record/stop/dialog/{dialogId}")
+    suspend fun stopRecording(
+        @Path("dialogId") dialogId: Long,
     )
 }

--- a/domain/src/main/java/uddug/com/domain/repositories/call/CallRepository.kt
+++ b/domain/src/main/java/uddug/com/domain/repositories/call/CallRepository.kt
@@ -25,4 +25,8 @@ interface CallRepository {
     )
 
     suspend fun stopCall(callId: Long)
+
+    suspend fun startRecording(dialogId: Long)
+
+    suspend fun stopRecording(dialogId: Long)
 }


### PR DESCRIPTION
## Summary
- add REST endpoints and repository methods to start and stop call recordings
- expose recording toggle in the call view model and wire it through call screens
- animate the record icon while recording and reset the state when calls finish

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932fe6a9fac832980097d470c3af3f5)