### PR TITLE
Remove English method comments

### DIFF
--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerEnvironment.kt
@@ -10,11 +10,6 @@ import com.flashphoner.fpwcsapi.room.RoomManagerOptions
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/**
- * Central entry point to the Flashphoner Android SDK. The environment is responsible
- * for initialising the SDK once and creating pre-configured [Session] instances that
- * can be used by feature modules.
- */
 @Singleton
 class FlashphonerEnvironment @Inject constructor() {
 
@@ -25,11 +20,6 @@ class FlashphonerEnvironment @Inject constructor() {
         containerActivityRef = WeakReference(activity)
     }
 
-    /**
-     * Initialise Flashphoner lazily on first usage. According to the SDK documentation
-     * the call is idempotent, therefore we protect it with an [isInitialised] flag to
-     * avoid extra work on subsequent injections.
-     */
     fun ensureInitialised(activity: Activity? = containerActivityRef.get()) {
         if (!isInitialised) {
             val hostActivity = activity ?: error("Container Activity must be attached before initializing Flashphoner")
@@ -38,11 +28,6 @@ class FlashphonerEnvironment @Inject constructor() {
         }
     }
 
-    /**
-     * Creates a new [Session] with provided [serverUrl] and optional configuration block.
-     * The caller is still responsible for connecting the session and listening for state
-     * callbacks according to the Flashphoner SDK documentation.
-     */
     fun createSession(
         serverUrl: String,
         configure: SessionOptions.() -> Unit = {},
@@ -52,10 +37,6 @@ class FlashphonerEnvironment @Inject constructor() {
         return Flashphoner.createSession(options)
     }
 
-    /**
-     * Creates a new [RoomManager] instance with provided [serverUrl] and [username].
-     * Ensures the SDK is initialised before delegating to [Flashphoner].
-     */
     fun createRoomManager(
         serverUrl: String,
         username: String,

--- a/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
+++ b/app/src/main/java/uddug/com/naukoteka/flashphoner/FlashphonerSessionManager.kt
@@ -17,11 +17,6 @@ import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/**
- * Helper responsible for holding references to the current Flashphoner [Session] and
- * [Stream]. The class centralises session lifecycle handling so that future features can
- * focus on business logic instead of repetitive boilerplate.
- */
 @Singleton
 class FlashphonerSessionManager @Inject constructor(
     private val environment: FlashphonerEnvironment
@@ -118,11 +113,6 @@ class FlashphonerSessionManager @Inject constructor(
         streamRef.getAndSet(null)?.stop()
     }
 
-    /**
-     * Acceptable way to leave a call: stop publishing media for the current room.
-     * If the room is still attached, request unpublish so the backend cleans up
-     * the media session; otherwise, fall back to stopping the stream directly.
-     */
     fun unpublishCurrentStream() {
         val stream = streamRef.getAndSet(null) ?: return
         val room = roomRef.get()
@@ -139,10 +129,6 @@ class FlashphonerSessionManager @Inject constructor(
         session.disconnect()
     }
 
-    /**
-     * Proper way to leave a call: unpublish active media and leave the room so
-     * the backend receives the appropriate callbacks before the session closes.
-     */
     fun disconnectRoom() {
         logLifecycleCall("disconnectRoom")
         unpublishCurrentStream()
@@ -151,11 +137,6 @@ class FlashphonerSessionManager @Inject constructor(
         disconnectSession()
     }
 
-    /**
-     * Fully clears any existing session, stream or room manager state to ensure a fresh
-     * connection can be established. This is intentionally idempotent and safe to call
-     * before creating new Flashphoner objects.
-     */
     fun reset() {
         logLifecycleCall("reset")
         stopStream()

--- a/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
+++ b/app/src/main/java/uddug/com/naukoteka/mvvm/call/CallViewModel.kt
@@ -249,7 +249,6 @@ class CallViewModel @Inject constructor(
             }
 
             override fun onMessage(message: Message) {
-                // No-op. Signalling is handled by the backend, clients only need to join the room.
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove English-language documentation comments from Flashphoner session/environment classes
- drop the remaining inline English comment from CallViewModel

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330de1131483298528165f422c5828)